### PR TITLE
simple multiprocessing for scoring

### DIFF
--- a/prototype/scoring.py
+++ b/prototype/scoring.py
@@ -1,4 +1,6 @@
 import multiprocessing, time
+
+import psutil
 import numpy as np
 
 def compute_all_scores_multi(spectra_list, gcf_list, strain_list, scoring_function, do_random=True, cpus=8):
@@ -11,7 +13,7 @@ def compute_all_scores_multi(spectra_list, gcf_list, strain_list, scoring_functi
         if len(spectra_part_list[i]) == 0:
             continue
 
-        p = multiprocessing.Process(target=compute_all_scores, args=(spectra_part_list[i], gcf_list, strain_list, scoring_function, do_random, q))
+        p = multiprocessing.Process(target=compute_all_scores, args=(spectra_part_list[i], gcf_list, strain_list, scoring_function, do_random, q, i))
         procs.append(p)
 
     for p in procs:
@@ -32,10 +34,13 @@ def compute_all_scores_multi(spectra_list, gcf_list, strain_list, scoring_functi
 
     return m_scores
 
-def compute_all_scores(spectra_list,gcf_list,strain_list,scoring_function,do_random = True, q=None):
+def compute_all_scores(spectra_list,gcf_list,strain_list,scoring_function,do_random = True, q=None, cpu_aff=None):
     m_scores = {}
     best = 0
     best_random = 0
+
+    if cpu_aff is not None:
+        psutil.Process().cpu_affinity([cpu_aff])
 
     for i,spectrum in enumerate(spectra_list):
         m_scores[spectrum] = {}

--- a/prototype/scoring.py
+++ b/prototype/scoring.py
@@ -1,8 +1,8 @@
 import multiprocessing, time
 import numpy as np
 
-def compute_all_scores_multi(spectra_list, gcf_list, strain_list, scoring_function, do_random=True):
-    cpus = 10 # TODO get num available from psutil
+def compute_all_scores_multi(spectra_list, gcf_list, strain_list, scoring_function, do_random=True, cpus=8):
+    # TODO get num CPUs available from psutil
     spectra_part_list = np.array_split(spectra_list, cpus)
 
     q = multiprocessing.Queue()


### PR DESCRIPTION
This should do simple parallelisation of the compute_all_scores method:
- pip install psutil
- replace call to **compute_all_scores** with **compute_all_scores_multi**, optionally setting number of cores to use with cpus= parameter

(it doesn't yet check for actual number of cores and handle that properly, e.g. if cpus=[more than the number of cores available])