### PR TITLE
Updating metcalf_scoring to use a faster numpy-based method.

### DIFF
--- a/prototype/genomics.py
+++ b/prototype/genomics.py
@@ -1,17 +1,11 @@
-import csv, glob, os
+import csv, glob, os, json
 import numpy as np
 
 import aa_pred
-
-
-class Strain(object):
-    def __init__(self,name):
-        self.name = name
-    def __str__(self):
-        return self.name
+from genomics_utilities import get_known_cluster_blast
 
 class BGC(object):
-    def __init__(self,strain,name,bigscape_class,product_prediction):
+    def __init__(self, strain, name, bigscape_class, product_prediction):
         self.strain = strain
         self.name = name
         self.bigscape_class = bigscape_class
@@ -37,18 +31,18 @@ class BGC(object):
     @property
     def known_cluster_blast(self):
         if self._known_cluster_blast is None:
-            from genomics_utilities import get_known_cluster_blast
             self._known_cluster_blast = get_known_cluster_blast(self)
         return self._known_cluster_blast
 
 
 class GCF(object):
-    def __init__(self,gcf_id):
+    def __init__(self, gcf_id):
         self.gcf_id = gcf_id
         self.bgc_list = []
         self.random_gcf = None
 
         self._aa_predictions = None
+        self.strains_lookup = None
 
     def __str__(self):
         return str(self.gcf_id.split(os.sep)[-1])
@@ -56,14 +50,18 @@ class GCF(object):
     def add_bgc(self, bgc):
         self.bgc_list.append(bgc)
 
-    def has_strain(self,strain):
+    @property
+    def strains(self):
+        return [bgc.strain for bgc in self.bgc_list]
+
+    def has_strain(self, strain):
         for bgc in self.bgc_list:
             if bgc.strain == strain:
                 return True
         return False
 
-    def add_random(self,bgc_list):
-        self.random_gcf = RandomGCF(self,bgc_list)
+    def add_random(self, bgc_list):
+        self.random_gcf = RandomGCF(self, bgc_list)
 
     def get_mibig_bgcs(self):
         mibig = []
@@ -107,44 +105,52 @@ class GCF(object):
 
 
 class RandomGCF(object):
-    def __init__(self,real_gcf,bgc_list):
+
+    def __init__(self, real_gcf, bgc_list):
         self.real_gcf = real_gcf
         n_bgc = self.real_gcf.n_non_mibig_bgc()
         # select n_bgc bgcs from the bgc_list
-        self.bgc_list = set(np.random.choice(bgc_list,n_bgc,replace = False))
-    def has_strain(self,strain):
+        # (convert back to list for consistency with GCF)
+        self.bgc_list = list(np.random.choice(bgc_list, n_bgc, replace=False))
+
+    @property
+    def strains(self):
+        return [bgc.strain for bgc in self.bgc_list]
+
+    def has_strain(self, strain):
         for bgc in self.bgc_list:
             if bgc.strain == strain:
                 return True
         return False
 
 class MiBIGBGC(BGC):
-    def __init__(self,name,product_prediction):
-        super(MiBIGBGC,self).__init__(None,name,None,product_prediction)
 
+    def __init__(self, name, product_prediction):
+        super(MiBIGBGC, self).__init__(None, name, None, product_prediction)
 
-def loadBGC_from_cluster_files(network_file_list,ann_file_list,antismash_dir = None,antismash_format = 'flat',mibig_bgc_dict = None):
+def loadBGC_from_cluster_files(network_file_list, ann_file_list, antismash_dir=None, antismash_format='flat', mibig_bgc_dict=None):
     strain_id_dict = {}
     strain_dict = {}
     gcf_dict = {}
     gcf_list = []
     strain_list = []
     bgc_list = []
-    with open('strain_ids.csv','r') as f:
+
+    with open('strain_ids.csv', 'r') as f:
         reader = csv.reader(f)
         for line in reader:
             strain_id_dict[line[0]] = line[1]
     metadata = {}
     for a in ann_file_list:
-        with open(a,'rU') as f:
-            reader =  csv.reader(f,delimiter = '\t')
+        with open(a, 'rU') as f:
+            reader = csv.reader(f, delimiter='\t')
             heads = next(reader)
             for line in reader:
                 metadata[line[0]] = line
 
     for filename in network_file_list:
-        with open(filename,'rU') as f:
-            reader = csv.reader(f,delimiter = '\t')
+        with open(filename, 'rU') as f:
+            reader = csv.reader(f, delimiter='\t')
             heads = next(reader)
             for line in reader:
                 name = line[0]
@@ -159,8 +165,9 @@ def loadBGC_from_cluster_files(network_file_list,ann_file_list,antismash_dir = N
                             strain_name = strain_id_dict[name.split('.')[0]]
                     except:
                         print("NO STRAIN")
-                if not strain_name in strain_dict:
-                    new_strain = Strain(strain_name)
+
+                if strain_name not in strain_dict:
+                    new_strain = strain_name
                     strain_dict[strain_name] = new_strain
                     strain_list.append(new_strain)
                 strain = strain_dict[strain_name]
@@ -177,7 +184,7 @@ def loadBGC_from_cluster_files(network_file_list,ann_file_list,antismash_dir = N
                 # the same BGC objects might be made more than once
                 # because they appear in multiple clusterings
                 if not strain_name == 'MiBIG':
-                    new_bgc = BGC(strain,name,bigscape_class,product_prediction)
+                    new_bgc = BGC(strain, name, bigscape_class, product_prediction)
                     if antismash_dir:
                         if antismash_format == 'flat':
                             antismash_filename = os.path.join(antismash_dir, new_bgc.name + '.gbk')
@@ -186,7 +193,7 @@ def loadBGC_from_cluster_files(network_file_list,ann_file_list,antismash_dir = N
                                 return None, None, None
                             new_bgc.antismash_file = antismash_filename
                         else:
-                            new_bgc.antismash_file = find_antismash_file(antismash_dir,new_bgc.name)
+                            new_bgc.antismash_file = find_antismash_file(antismash_dir, new_bgc.name)
                     bgc_list.append(new_bgc)
                 else:
                     if mibig_bgc_dict:
@@ -194,7 +201,7 @@ def loadBGC_from_cluster_files(network_file_list,ann_file_list,antismash_dir = N
                             new_bgc = mibig_bgc_dict[name.split('.')[0]]
                         except:
                             print(name)
-                            new_bgc = MiBIGBGC(name,product_prediction)
+                            new_bgc = MiBIGBGC(name, product_prediction)
                 
 
                 if not family in gcf_dict:
@@ -203,11 +210,10 @@ def loadBGC_from_cluster_files(network_file_list,ann_file_list,antismash_dir = N
                     gcf_list.append(new_gcf)
                 gcf_dict[family].add_bgc(new_bgc)
 
-    return gcf_list,bgc_list,strain_list
+    return gcf_list, bgc_list, strain_list
 
 # this is really slow. But hey, it works. Finally.
-def find_antismash_file_flat(antismash_dir,bgc_name):
-    import glob,os
+def find_antismash_file_flat(antismash_dir, bgc_name):
     all_gbk_files = glob.glob(antismash_dir + os.sep + '*.gbk')
     last_bit = [o.split(os.sep)[-1] for o in all_gbk_files]
     bgc_file_name = bgc_name + '.gbk'
@@ -219,8 +225,7 @@ def find_antismash_file_flat(antismash_dir,bgc_name):
         return None
 
 
-def find_antismash_file(antismash_dir,bgc_name):
-    import glob,os
+def find_antismash_file(antismash_dir, bgc_name):
     subdirs = [s.split(os.sep)[-1] for s in glob.glob(antismash_dir + os.sep+'*')]
     if bgc_name.startswith('BGC'):
         print("No file for MiBIG BGC")
@@ -241,7 +246,7 @@ def find_antismash_file(antismash_dir,bgc_name):
                 found = True
                 found_name = sub_name
     if not found:
-        print("Can't find antiSMASH info for ",bgc_name)
+        print("Can't find antiSMASH info for ", bgc_name)
         return None
 #     print found_name
     dir_contents = glob.glob(antismash_dir + os.sep + found_name + os.sep + '*.gbk')
@@ -259,7 +264,7 @@ def find_antismash_file(antismash_dir,bgc_name):
 
 def loadBGC_from_node_files(file_list):
     strain_id_dict = {}
-    with open('strain_ids.csv','r') as f:
+    with open('strain_ids.csv', 'r') as f:
         reader = csv.reader(f)
         for line in reader:
             strain_id_dict[line[0]] = line[1]
@@ -270,7 +275,7 @@ def loadBGC_from_node_files(file_list):
     gcf_list = []
     strain_list = []
     for filename in file_list:
-        with open(filename,'rU') as f:
+        with open(filename, 'rU') as f:
             reader = csv.reader(f)
             heads = next(reader)
             name_pos = heads.index("shared name")
@@ -288,8 +293,8 @@ def loadBGC_from_node_files(file_list):
                 except:
                     # it's a MiBIG one
                     strain_name = 'MiBIG'
-                if not strain_name in strain_dict:
-                    new_strain = Strain(strain_name)
+                if strain_name not in strain_dict:
+                    new_strain = strain_name
                     strain_dict[strain_name] = new_strain
                     strain_list.append(new_strain)
                 strain = strain_dict[strain_name]
@@ -306,28 +311,25 @@ def loadBGC_from_node_files(file_list):
 
                 # make a BGC object
                 if not strain_name == 'MiBIG':
-                    new_bgc = BGC(strain,name,bigscape_class,product_prediction)
+                    new_bgc = BGC(strain, name, bigscape_class, product_prediction)
                 else:
-                    new_bgc = MiBIGBGC(name,product_prediction)
+                    new_bgc = MiBIGBGC(name, product_prediction)
                 bgc_list.append(new_bgc)
 
-                if not family in gcf_dict:
+                if family not in gcf_dict:
                     new_gcf = GCF(family)
                     gcf_dict[family] = new_gcf
                     gcf_list.append(new_gcf)
                 gcf_dict[family].add_bgc(new_bgc)
 
+    return gcf_list, bgc_list, strain_list
 
-                
-    return gcf_list,bgc_list,strain_list
-    
-
-def load_mibig_map(filename = 'mibig_gnps_links_q3_loose.csv'):
+def load_mibig_map(filename='mibig_gnps_links_q3_loose.csv'):
     mibig_map = {}
-    with open(filename,'rU') as f:
+    with open(filename, 'rU') as f:
         reader = csv.reader(f)
         heads = next(reader)
-        
+
         for line in reader:
             bgc = line[0]
             if bgc in mibig_map:
@@ -338,12 +340,11 @@ def load_mibig_map(filename = 'mibig_gnps_links_q3_loose.csv'):
 
 
 def load_mibig_library_json(mibig_json_directory):
-    import glob,os,json
     mibig = {}
     files = glob.glob(mibig_json_directory + os.sep + '*.json')
     print("Found {} MiBIG json files".format(len(files)))
     for file in files:
-        with open(file,'r') as f:
+        with open(file, 'r') as f:
             bgc_id = file.split(os.sep)[-1].split('.')[0]
             mibig[bgc_id] = json.load(f)
     return mibig
@@ -351,11 +352,7 @@ def load_mibig_library_json(mibig_json_directory):
 def make_mibig_bgc_dict(mibig_json_directory):
     mibig_dict = load_mibig_library_json(mibig_json_directory)
     mibig_bgc_dict = {}
-    for name,data in list(mibig_dict.items()):
-        new_bgc = MiBIGBGC(data['general_params']['mibig_accession'],data['general_params']['biosyn_class'])
+    for name, data in list(mibig_dict.items()):
+        new_bgc = MiBIGBGC(data['general_params']['mibig_accession'], data['general_params']['biosyn_class'])
         mibig_bgc_dict[data['general_params']['mibig_accession']] = new_bgc
     return mibig_bgc_dict
-    
-    
-
-

--- a/prototype/metabolomics.py
+++ b/prototype/metabolomics.py
@@ -1,14 +1,18 @@
 import csv
 import numpy as np
 
-from nplinker_constants import LDA_PATH
+from ms2lda_feature_extraction import LoadMGF
 
 class Spectrum(object):
-    def __init__(self,peaks,spectrum_id,precursor_mz,parent_mz = None,rt = None):
-        self.peaks = sorted(peaks,key = lambda x: x[0]) # ensure sorted by mz
+    
+    METADATA_BLACKLIST = set(['AllOrganisms', 'AllFiles', 'LibraryID', 'RTStdErr', 'RTMean', 'AllGroups', 'DefaultGroups',
+                            'precursor mass', 'parent mass', 'ProteoSAFeClusterLink', 'precursor intensity', 'sum(precursor intensity)'])
+
+    def __init__(self, peaks, spectrum_id, precursor_mz, parent_mz=None, rt=None):
+        self.peaks = sorted(peaks, key=lambda x: x[0]) # ensure sorted by mz
         self.n_peaks = len(self.peaks)
-        self.max_ms2_intensity = max([intensity for mz,intensity in self.peaks])
-        self.total_ms2_intensity = sum([intensity for mz,intensity in self.peaks])
+        self.max_ms2_intensity = max([intensity for mz, intensity in self.peaks])
+        self.total_ms2_intensity = sum([intensity for mz, intensity in self.peaks])
         self.spectrum_id = str(spectrum_id)
         self.rt = rt
         self.precursor_mz = precursor_mz
@@ -22,20 +26,34 @@ class Spectrum(object):
         self._losses = None
 
     def annotation_from_metadata(self):
-    	annotation = self.get_metadata_value('LibraryID')
-    	if annotation:
-    		self.annotations.append((annotation,'gnps'))
+        annotation = self.get_metadata_value('LibraryID')
+        if annotation:
+            self.annotations.append((annotation, 'gnps'))
 
+    def get_metadata_value(self, key):
+        val = self.metadata.get(key, None)
+        return val
 
-    def get_metadata_value(self,key):
-    	val = self.metadata.get(key,None)
-    	return val
+    @property
+    def strain_list(self):
+        return [k for k in self.metadata.keys() if self.has_strain(k)]
 
-    def has_strain(self,strain):
-    	strain_val = self.metadata.get(strain.name,0)
-    	if strain_val > 0:
-    		return True
-    	return False
+    @property
+    def strain_set(self):
+        return set([k for k in self.metadata.keys() if self.has_strain(k)])
+
+    def has_strain(self, strain):
+        if strain in Spectrum.METADATA_BLACKLIST:
+            return False
+
+        strain_val = self.metadata.get(strain, 0)
+        #  TODO this can throw an exception if a value is a non-integer or None...
+        try:
+            if strain_val > 0:
+                return True
+        except TypeError:
+            print('Warning: has_strain({}) failed because metadata.get returned "{}" (type({}))'.format(strain, strain_val, type(strain_val)))
+        return False
 
     # def print_spectrum(self):
     #     print()
@@ -47,14 +65,14 @@ class Spectrum(object):
     #     plot_spectrum(self.peaks,xlim=xlim,title = "{} {} (m/z= {})".format(self.file_name,self.scan_number,self.parent_mz),**kwargs)
 
 
-    def add_random(self,strain_list):
-    	self.random_spectrum = RandomSpectrum(self,strain_list)
+    def add_random(self, strain_prob_dict):
+        self.random_spectrum = RandomSpectrum(self, strain_prob_dict)
 
     def __str__(self):
         # return "Spectrum {} with {} peaks, max_ms2_intensity {}".format(self.spectrum_id,self.n_peaks,self.max_ms2_intensity)
         return "Spectrum {}".format(self.spectrum_id)
 
-    def __cmp__(self,other):
+    def __cmp__(self, other):
         if self.parent_mz >= other.parent_mz:
             return 1
         else:
@@ -99,151 +117,162 @@ class Spectrum(object):
 
 
 class RandomSpectrum(object):
-	def __init__(self,real_spectrum,strain_prob_dict):
-		self.real_spectrum = real_spectrum
-		n_strains = 0
-		for strain in strain_prob_dict:
-			if self.real_spectrum.has_strain(strain):
-				n_strains += 1
 
-		self.strain_set = set(np.random.choice(list(strain_prob_dict.keys()),n_strains,replace = True,p = list(strain_prob_dict.values())))
+    def __init__(self, real_spectrum, strain_prob_dict):
+        self.real_spectrum = real_spectrum
+        n_strains = 0
+        for strain in strain_prob_dict:
+            if self.real_spectrum.has_strain(strain):
+                n_strains += 1
 
-	def has_strain(self,strain):
-		if strain in self.strain_set:
-			return True
-		else:
-			return False
+        self.metadata = set(np.random.choice(list(strain_prob_dict.keys()), n_strains, replace=True, p=list(strain_prob_dict.values())))
+
+    @property
+    def strain_list(self):
+        return list(self.metadata)
+
+    @property
+    def strain_set(self):
+        return self.metadata
+
+    def has_strain(self, strain):
+        return strain in self.strain_set
 
 def load_spectra(mgf_file):
-	from ms2lda_feature_extraction import LoadMGF
-	ms1,ms2,metadata = LoadMGF(name_field = 'scans').load_spectra([mgf_file])
-	print("Loaded {} molecules".format(len(ms1)))
-	return mols_to_spectra(ms2,metadata)
+    ms1, ms2, metadata = LoadMGF(name_field='scans').load_spectra([mgf_file])
+    print("Loaded {} molecules".format(len(ms1)))
+    return mols_to_spectra(ms2, metadata)
 
-def mols_to_spectra(ms2,metadata):
-	ms2_dict = {}
-	for m in ms2:
-		if not m[3] in ms2_dict:
-			ms2_dict[m[3]] = []
-		ms2_dict[m[3]].append((m[0],m[2]))
-	
-	spectra =[]
-	for m in ms2_dict:
-		new_spectrum = Spectrum(ms2_dict[m],m.name,metadata[m.name]['precursormass'])
-		spectra.append(new_spectrum)
+def mols_to_spectra(ms2, metadata):
+    ms2_dict = {}
+    for m in ms2:
+        if not m[3] in ms2_dict:
+            ms2_dict[m[3]] = []
+        ms2_dict[m[3]].append((m[0], m[2]))
+    
+    spectra = []
+    for m in ms2_dict:
+        new_spectrum = Spectrum(ms2_dict[m], m.name, metadata[m.name]['precursormass'])
+        spectra.append(new_spectrum)
 
-	return spectra
+    return spectra
 
-def load_metadata(spectra,metadata_file):
-	# make a dictionary mapping spectum ids to spectrum
-	spec_dict = {}
-	for spec in spectra:
-		spec_dict[spec.spectrum_id] = spec
+def load_metadata(spectra, metadata_file):
+    # make a dictionary mapping spectum ids to spectrum
+    spec_dict = {}
+    for spec in spectra:
+        spec_dict[spec.spectrum_id] = spec
 
-	import csv
-	with open(metadata_file,'rU') as f:
-		reader = csv.reader(f,delimiter='\t')
-		heads = next(reader)
-		for line in reader:
-			spectrum = spec_dict[line[0]]
-			for i,value in enumerate(line):
-				key = heads[i]
-				try:
-					value = int(value)
-				except ValueError:
-					if value == 'N/A':
-						value = None
-				spectrum.metadata[key] = value
-			spectrum.annotation_from_metadata()
+    # to collect all strains from this source for later use
+    strains = set()
 
-def load_edges(spectra,edge_file):
-	spec_dict = {}
-	for spec in spectra:
-		spec_dict[spec.spectrum_id] = spec
+    with open(metadata_file, 'rU') as f:
+        reader = csv.reader(f, delimiter='\t')
+        heads = next(reader)
+        for line in reader:
+            spectrum = spec_dict[line[0]]
+            for i, value in enumerate(line):
+                key = heads[i]
+                try:
+                    value = int(value)
+                except ValueError:
+                    if value == 'N/A':
+                        value = None
+                spectrum.metadata[key] = value
+                strains.add(key)
+            spectrum.annotation_from_metadata()
 
+    return strains
 
-	with open(edge_file,'rU') as f:
-		reader = csv.reader(f,delimiter='\t')
-		heads = next(reader)
-		for line in reader:
-			spec1_id = line[0]
-			spec2_id = line[1]
-			cosine = float(line[4])
-			family = line[6]
+def load_edges(spectra, edge_file):
+    spec_dict = {}
+    for spec in spectra:
+        spec_dict[spec.spectrum_id] = spec
 
-			spec1 = spec_dict[spec1_id]
-			spec2 = spec_dict[spec2_id]
+    with open(edge_file, 'rU') as f:
+        reader = csv.reader(f, delimiter='\t')
+        heads = next(reader)
+        for line in reader:
+            spec1_id = line[0]
+            spec2_id = line[1]
+            cosine = float(line[4])
+            family = line[6]
 
-			if not family == '-1': # singletons
-				spec1.family = family
-				spec2.family = family
+            spec1 = spec_dict[spec1_id]
+            spec2 = spec_dict[spec2_id]
 
-				spec1.edges.append((spec2.spectrum_id,cosine))
-				spec2.edges.append((spec1.spectrum_id,cosine))
+            if not family == '-1': # singletons
+                spec1.family = family
+                spec2.family = family
 
-			else:
-				spec1.family = family
+                spec1.edges.append((spec2.spectrum_id, cosine))
+                spec2.edges.append((spec1.spectrum_id, cosine))
+            else:
+                spec1.family = family
 
 
 class MolecularFamily(object):
-	def __init__(self,family_id):
-		self.family_id = family_id
-		self.spectra = []
-		self.random_molecular_family = RandomMolecularFamily(self)
+    def __init__(self, family_id):
+        self.family_id = family_id
+        self.spectra = []
+        self.random_molecular_family = RandomMolecularFamily(self)
 
-	def has_strain(self,strain):
-		for spectrum in self.spectra:
-			if spectrum.has_strain(strain):
-				return True
-		return False
+    def has_strain(self, strain):
+        for spectrum in self.spectra:
+            if spectrum.has_strain(strain):
+                return True
 
-	def add_spectrum(self,spectrum):
-		self.spectra.append(spectrum)
+        return False
 
-	def __str__(self):
-		return "Molecular family with {} spectra".format(len(self.spectra))
+    def add_spectrum(self, spectrum):
+        self.spectra.append(spectrum)
+
+    def __str__(self):
+        return "Molecular family with {} spectra".format(len(self.spectra))
 
 class RandomMolecularFamily(object):
-	def __init__(self,molecular_family):
-		self.molecular_family = molecular_family
-	def has_strain(self,strain):
-		for spectrum in self.molecular_family.spectra:
-			try:
-				if spectrum.random_spectrum.has_strain(strain):
-					return True
-			except:
-				print("Spectrum objects need random spectra attached for this functionality")
-		return False
+    def __init__(self, molecular_family):
+        self.molecular_family = molecular_family
+
+    def has_strain(self, strain):
+        for spectrum in self.molecular_family.spectra:
+            try:
+                if spectrum.random_spectrum.has_strain(strain):
+                    return True
+            except:
+                print("Spectrum objects need random spectra attached for this functionality")
+
+        return False
 
 class SingletonFamily(MolecularFamily):
-	def __init__(self):
-		super(SingletonFamily, self).__init__('-1')
-	def __str__(self):
-		return "Singleton molecular family"
+    def __init__(self):
+        super(SingletonFamily, self).__init__('-1')
 
+    def __str__(self):
+        return "Singleton molecular family"
 
 def make_families(spectra):
-	families = []
-	family_dict = {}
-	for spectrum in spectra:
-		family_id = spectrum.family
-		if family_id == '-1': # singleton
-			new_family = SingletonFamily()
-			new_family.add_spectrum(spectrum)
-			spectrum.family = new_family
-			families.append(new_family)
-		else:
-			if not family_id in family_dict:
-				new_family = MolecularFamily(family_id)
-				new_family.add_spectrum(spectrum)
-				spectrum.family = new_family
-				families.append(new_family)
-				family_dict[family_id] = new_family
-			else:
-				family_dict[family_id].add_spectrum(spectrum)
-				spectrum.family = family_dict[family_id]
-	return families
+    families = []
+    family_dict = {}
+    for spectrum in spectra:
+        family_id = spectrum.family
+        if family_id == '-1': # singleton
+            new_family = SingletonFamily()
+            new_family.add_spectrum(spectrum)
+            spectrum.family = new_family
+            families.append(new_family)
+        else:
+            if family_id not in family_dict:
+                new_family = MolecularFamily(family_id)
+                new_family.add_spectrum(spectrum)
+                spectrum.family = new_family
+                families.append(new_family)
+                family_dict[family_id] = new_family
+            else:
+                family_dict[family_id].add_spectrum(spectrum)
+                spectrum.family = family_dict[family_id]
 
+    return families
 
 def read_aa_losses(filename):
     """

--- a/prototype/nplinker_example_script.py.ipynb
+++ b/prototype/nplinker_example_script.py.ipynb
@@ -1996,7 +1996,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/prototype/nplinker_new_scoring.ipynb
+++ b/prototype/nplinker_new_scoring.ipynb
@@ -1,0 +1,203 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, glob\n",
+    "import numpy as np\n",
+    "\n",
+    "from nplinker_constants import nplinker_setup\n",
+    "LDA_PATH = '../../lda/code'\n",
+    "nplinker_setup(LDA_PATH=LDA_PATH)\n",
+    "from metabolomics import load_metadata, load_edges, make_families, load_spectra\n",
+    "from genomics import loadBGC_from_cluster_files\n",
+    "from strainmanager import StrainManager\n",
+    "from scoring import compute_all_scores_multi_np, metcalf_scoring_np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATASET = '/mnt/archive/nplinker_data/crusemann'\n",
+    "MGF_FILE = os.path.join(DATASET, 'gnps/METABOLOMICS-SNETS-c36f90ba-download_clustered_spectra-main.mgf')\n",
+    "NODES_FILE = os.path.join(DATASET, 'gnps/0d51c5b6c73b489185a5503d319977ab..out')\n",
+    "EDGES_FILE = os.path.join(DATASET, 'gnps/9a93d720f69143bb9f971db39b5d2ba2.pairsinfo')\n",
+    "ROOT_PATH = os.path.join(DATASET, 'bigscape/bigscape_corason_crusemann_complete_annotated_mibigs_mix_automode_20180713/network_files/2018-07-13_16-34-11_hybrids_auto_crusemann_bgcs_automode_mix_mibig')\n",
+    "FOLDERS = ['NRPS','Others','PKSI','PKS-NRP_Hybrids','PKSother','RiPPs','Saccharides','Terpene']\n",
+    "ANTISMASH_DIR = os.path.join(DATASET, 'antismash/justin-20181022/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 5930 molecules\n"
+     ]
+    }
+   ],
+   "source": [
+    "spectra = load_spectra(MGF_FILE)\n",
+    "load_edges(spectra, EDGES_FILE)\n",
+    "families = make_families(spectra)\n",
+    "metadata = load_metadata(spectra, NODES_FILE)\n",
+    "\n",
+    "input_files = []\n",
+    "ann_files = []\n",
+    "mibig_bgc_dict = None\n",
+    "\n",
+    "for folder in FOLDERS:\n",
+    "    fam_file = os.path.join(ROOT_PATH, folder)\n",
+    "    cluster_file = glob.glob(fam_file + os.sep + folder + \"_clustering*\")\n",
+    "    annotation_files = glob.glob(fam_file + os.sep + \"Network_*\")\n",
+    "    input_files.append(cluster_file[0])\n",
+    "    ann_files.append(annotation_files[0])\n",
+    "gcf_list,bgc_list, strain_list = loadBGC_from_cluster_files(input_files, ann_files, antismash_dir=ANTISMASH_DIR, antismash_format = 'flat', mibig_bgc_dict=mibig_bgc_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded 199 strains\n"
+     ]
+    }
+   ],
+   "source": [
+    "# merging all strain info into one place\n",
+    "merged_strains = set()\n",
+    "for s in strain_list: # from genomics source\n",
+    "    merged_strains.add(s)\n",
+    "for s in metadata: # from metabolomics source\n",
+    "    merged_strains.add(s)\n",
+    "    \n",
+    "strainmanager = StrainManager(merged_strains)\n",
+    "all_strains = strainmanager.all_strains_np # numpy array\n",
+    "print('Loaded {} strains'.format(len(all_strains)))\n",
+    "\n",
+    "# generate the strain_prob_dict for setting up RandomSpectrum objects\n",
+    "strain_prob_dict = strainmanager.generate_prob_dict(spectra)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# adding random objects and scoring lookup tables\n",
+    "\n",
+    "# numpy.random.choice converts Python lists to numpy arrays internally\n",
+    "# so doing that every time with a large list adds a ton of overhead, doing\n",
+    "# it once beforehand is much much faster\n",
+    "bgc_list = np.array(bgc_list)\n",
+    "for g in gcf_list:\n",
+    "    g.add_random(bgc_list)\n",
+    "    # add a lookup table indicating which strains are present in each object\n",
+    "    g.strains_lookup = strainmanager.generate_lookup_table(g.strains)\n",
+    "    g.random_gcf.strains_lookup = strainmanager.generate_lookup_table(g.random_gcf.strains)\n",
+    "    \n",
+    "# same for spectra\n",
+    "for s in spectra:\n",
+    "    # TODO could probably convert this to numpy format as well\n",
+    "    s.add_random(strain_prob_dict)\n",
+    "    s.strains_lookup = strainmanager.generate_lookup_table(s.strain_set)\n",
+    "    s.random_spectrum.strains_lookup = strainmanager.generate_lookup_table(s.strain_set)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "compute_all_scores_np on CPU 0, processing 742 spectra\n",
+      "compute_all_scores_np on CPU 1, processing 742 spectra\n",
+      "compute_all_scores_np on CPU 2, processing 741 spectra\n",
+      "compute_all_scores_np on CPU 3, processing 741 spectra\n",
+      "compute_all_scores_np on CPU 4, processing 741 spectra\n",
+      "compute_all_scores_np on CPU 5, processing 741 spectra\n",
+      "compute_all_scores_np on CPU 6, processing 741 spectra\n",
+      "compute_all_scores_np on CPU 7, processing 741 spectra\n",
+      "compute_all_scores_np on CPU 5, total time = 23.4s, 31.6 scores/sec\n",
+      "compute_all_scores_np on CPU 3, total time = 23.6s, 31.3 scores/sec\n",
+      "compute_all_scores_np on CPU 4, total time = 23.8s, 31.1 scores/sec\n",
+      "compute_all_scores_np on CPU 2, total time = 24.2s, 30.7 scores/sec\n",
+      "compute_all_scores_np on CPU 0, total time = 32.6s, 22.8 scores/sec\n",
+      "compute_all_scores_np on CPU 1, total time = 32.6s, 22.7 scores/sec\n",
+      "compute_all_scores_np on CPU 7, total time = 32.7s, 22.7 scores/sec\n",
+      "compute_all_scores_np on CPU 6, total time = 32.7s, 22.7 scores/sec\n",
+      "Total time: 57.1 secs, 103.9 scores/sec\n"
+     ]
+    }
+   ],
+   "source": [
+    "# use new scoring code like this:\n",
+    "m_scores = compute_all_scores_multi_np(spectra, gcf_list, all_strains, metcalf_scoring_np, do_random=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/prototype/strainmanager.py
+++ b/prototype/strainmanager.py
@@ -1,0 +1,75 @@
+import numpy as np
+
+# TODO currently not used
+# needed if its only ever going to be a wrapper around a string?
+class Strain(object):
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return 'Strain({})'.format(self.name)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __eq__(self, other):
+        # two strains are equal if they have the same name
+        return isinstance(other, Strain) and self.name == other.name
+
+    def __hash__(self):
+        return hash(self.name)
+
+class StrainManager:
+    """Stores a list of all strains present in a dataset (from both genomics and 
+    metabolomics sources) and provides some utility methods for dealing with scoring etc"""
+
+    def __init__(self, initial_strains):
+        """Initialise the manager object with a collection of strains (should be 
+        a list or set of strain IDs (strings))"""
+        if isinstance(initial_strains, list):
+            # get rid of duplicates
+            initial_strains = set(initial_strains)
+        self.strains = initial_strains
+        self._generate_indexes()
+
+    def add_strains(self, new_strains):
+        """Add new strains to the existing set.
+
+        Note that existing lookup tables will need recreated after doing this"""
+        self.strains.update(new_strains)
+        self._generate_indexes()
+
+    def _generate_indexes(self):
+        """Create a dict mapping strain names to indices in a lookup table"""
+        self.indexes = {}
+        for i, s in enumerate(self.strains):
+            self.indexes[s] = i
+
+    @property
+    def all_strains_set(self):
+        return self.strains
+
+    @property
+    def all_strains_np(self):
+        return np.array(list(self.strains))
+
+    def generate_lookup_table(self, strains):
+        """Given a subset of the full set of known strains, generate a lookup table 
+        containing True for the indices corresponding to those strains"""
+        lookup = np.full((len(self.strains), ), False)
+        indices = [self.indexes[s] for s in strains]
+        lookup[indices] = True
+        return lookup
+
+    def generate_prob_dict(self, spectra):
+        """Generates strain probability dict using code from example notebook"""
+        total = 0
+        strain_counts = {s: 0 for s in self.strains}
+        for spectrum in spectra:
+            for strain in strain_counts.keys():
+                if spectrum.has_strain(strain):
+                    strain_counts[strain] += 1
+                    total += 1
+
+        return {s: v/total for s, v in strain_counts.items()}
+


### PR DESCRIPTION
Various other changes:
- added methods to GCF/Spectrum objects to retrieve strains
- metabolomics.load_metadata returns a list of all strains
- added a blacklist for non-strain metabolomics metadata
- added a StrainManager class with strain-related utility methods
- strains are currently always represented as strings, not objects
- added new notebook to test scoring
- fixed lots of linter warnings