### PR TITLE
get_links function now takes Spectrum, MolecularFamily, or GCF object…

### DIFF
--- a/prototype/genomics.py
+++ b/prototype/genomics.py
@@ -37,6 +37,7 @@ class BGC(object):
 
 class GCF(object):
     def __init__(self, gcf_id):
+        self.id = []
         self.gcf_id = gcf_id
         self.short_gcf_id = gcf_id.split(os.sep)[-1]
         self.bgc_list = []
@@ -211,6 +212,9 @@ def loadBGC_from_cluster_files(network_file_list, ann_file_list, antismash_dir=N
                     gcf_list.append(new_gcf)
                 gcf_dict[family].add_bgc(new_bgc)
 
+    # Assign unique ids (int)
+    for i, gcf in enumerate(gcf_list):
+        gcf.id = i
     return gcf_list, bgc_list, strain_list
 
 # this is really slow. But hey, it works. Finally.


### PR DESCRIPTION
get_links() method was changed.
It now takes Spectrum, MolecularFamily, or GCF objects as input (or lists of them).
Still needs some improvements, but should work as a start...