### PR TITLE
Expand documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 NPLinker is a tool that aims to address the significant bottleneck that exists in the realization of the potential of genome-led metabolite discovery, namely the slow manual matching of predicted biosynthetic gene clusters (BGCs) with metabolites produced during bacterial culture; linking phenotype to genotype. NPLinker implements a new data-centric approach to alleviate this linking problem by searching for patterns of strain presence and absence between groups of similar spectra (molecular families; MF) and groups of similar BGCs (gene cluster families; GCF). Searches can be performed using a number of available analysis methods employed in isolation or together. 
 
+Currently available analysis methods (scoring methods):
+- (Standardised) Metcalf, see [Hjörleifsson Eldjárn G, et al. (2021)](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1008920) and [Doroghazi JR, et al. (2014)](https://www.nature.com/articles/nchembio.1659).
+- Rosetta, see [Hjörleifsson Eldjárn G, et al. (2021)](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1008920) and [Soldatou S, et al. (2021)](https://www.mdpi.com/1660-3397/19/2/103).
+- NPClassScore (currently only available in the python version), see the preprint [Louwen JJR, et al. (2022)](https://www.researchsquare.com/article/rs-1391827/new/v1).
+
 ## Getting Started - Web application
 
 The simplest option for most users will be to run NPLinker as a Dockerised web application, removing the need to install Python and other dependencies as well as providing a graphical interface. The web application can also be used without Docker if required, but it's much simpler to rely on the Docker version. Assuming you have Docker installed already, see the [wiki page](https://github.com/sdrogers/nplinker/wiki/WebappInstallation) for detailed installation and usage instructions. 
@@ -15,7 +20,7 @@ cd nplinker
 pipenv sync
 pipenv shell
 ```
-See the example Jupyter notebook (notebooks/nplinker_demo1.ipynb) for a guided introduction to the NPLinker API which shows how to load and examine a dataset. 
+See the example Jupyter notebook (notebooks/nplinker_demo1.ipynb) for a guided introduction to the NPLinker API which shows how to load and examine a dataset. Other notebooks are present showcasing other scoring methods (like notebooks/npclassscore_linking/NPClassScore_demo.ipynb).
 
 API documentation is still being updated but the latest version is available at [readthedocs](https://nplinker.readthedocs.io/en/latest/).
 


### PR DESCRIPTION
Hi Andrew,

I would like to expand documentation and notebooks for NPClassScore. I think it would be nice if you could bump to v1.2 after that, reflecting changes including NPClassScore. Even though NPClassScore is not yet included in the webapp I think it would be nice to also have the features related to chemical classes included in the new docker image. This way it is a bit clearer for the outside world that NPClassScore is now implemented in NPLinker.

To start, I slightly updated the ReadMe to include the currently available methods. @justinjjvanderhooft if you have more suggestions about the ReadMe or instructions in the wiki, please comment :).

About the wiki though, github doesn't allow pull requests for wikis unfortunately, and I don't have permissions to change them. So for now I think there is enough info there about NPClassScore together with the ReadMe. And otherwise I'll create an issue so you can add some small things.

I'll let you know when I'm done. For now I'm thinking about these changes:
- Adjust ReadMe to give a better short overview of available methods and how to find out about them.
- Restructure my notebooks to better show the analysis done for the preprint.
- Include info in the changelog, after which you could hopefully release an image for v1.2.

As always, thanks a lot for you time and effort :)