### PR TITLE
Add bgc-genome mapping to BGC loaders

### DIFF
--- a/src/nplinker/genomics/antismash/antismash_loader.py
+++ b/src/nplinker/genomics/antismash/antismash_loader.py
@@ -22,11 +22,11 @@ class AntismashBGCLoader:
         Note:
             AntiSMASH BGC directory must follow the structure below:
             antismash
-                ├── antismash_id_1 (one AntiSMASH output, e.g. GCF_000514775.1)
+                ├── genome_id_1 (one AntiSMASH output, e.g. GCF_000514775.1)
                 │  ├── GCF_000514775.1.gbk
                 │  ├── NZ_AZWO01000004.region001.gbk
                 │  └── ...
-                ├── antismash_id_2
+                ├── genome_id_2
                 │  ├── ...
                 └── ...
 
@@ -37,6 +37,20 @@ class AntismashBGCLoader:
         self.data_dir = data_dir
         self._file_dict = self._parse_data_dir(self.data_dir)
         self._bgc_dict = self._parse_bgcs(self._file_dict)
+
+    def get_bgc_genome_mapping(self) -> dict[str, str]:
+        """Get the mapping from BGC to geonme.
+
+        Note that the directory name of the gbk file is treated as genome id.
+
+        Returns:
+            dict[str, str]: key is BGC name (gbk file name) and value is genome
+                id (the directory name of the gbk file).
+        """
+        return {
+            bid: os.path.basename(os.path.dirname(bpath))
+            for bid, bpath in self._file_dict.items()
+        }
 
     def get_files(self) -> dict[str, str]:
         """Get BGC gbk files
@@ -145,7 +159,8 @@ def _parse_antismash_genbank(record: SeqRecord.SeqRecord) -> dict:
     for feature in record.features:
         if feature.type == "region":
             # biopython assumes region numer is a list, but it's actually an int
-            features["region_number"] = feature.qualifiers.get('region_number')[0]
+            features["region_number"] = feature.qualifiers.get(
+                'region_number')[0]
             features["product"] = feature.qualifiers.get('product')
         if feature.type == "cand_cluster":
             smiles = feature.qualifiers.get('SMILES')

--- a/src/nplinker/genomics/antismash/antismash_loader.py
+++ b/src/nplinker/genomics/antismash/antismash_loader.py
@@ -39,7 +39,7 @@ class AntismashBGCLoader:
         self._bgc_dict = self._parse_bgcs(self._file_dict)
 
     def get_bgc_genome_mapping(self) -> dict[str, str]:
-        """Get the mapping from BGC to geonme.
+        """Get the mapping from BGC to genome.
 
         Note that the directory name of the gbk file is treated as genome id.
 

--- a/src/nplinker/genomics/genomics.py
+++ b/src/nplinker/genomics/genomics.py
@@ -19,7 +19,7 @@ def map_strain_to_bgc(strains: StrainCollection, bgcs: list[BGC],
     This method changes the list `bgcs` in place.
 
     It's assumed that BGC's genome id is used as strain's name or alias, and
-    the genome id is used lookup the representative strain.
+    the genome id is used to lookup the representative strain.
 
     Args:
         strains(StrainCollection): A collection of all strain objects.

--- a/src/nplinker/genomics/genomics.py
+++ b/src/nplinker/genomics/genomics.py
@@ -11,28 +11,37 @@ from .gcf import GCF
 
 logger = LogConfig.getLogger(__name__)
 
-def map_strain_to_bgc(strains: StrainCollection, bgcs: list[BGC]):
+
+def map_strain_to_bgc(strains: StrainCollection, bgcs: list[BGC],
+                      bgc_genome_mapping: dict[str, str]):
     """To set BGC object's strain with representative strain object.
 
     This method changes the list `bgcs` in place.
 
-    It's assumed that BGC.bgc_id is used as strain's name or alias. Then it's
-    possible to lookup the representative strain in the StrainCollection object.
+    It's assumed that BGC's genome id is used as strain's name or alias, and
+    the genome id is used lookup the representative strain.
 
     Args:
         strains(StrainCollection): A collection of all strain objects.
         bgcs(list[BGC]): A list of BGC objects.
+        bgc_genome_mapping(dict[str, str]): The mappings from BGC id (key) to
+            genome id (value).
 
     Raises:
+        KeyError: BGC id not found in the `bgc_genome_mapping` dict.
         KeyError: Strain id not found in the strain collection.
     """
     for bgc in bgcs:
         try:
-            # assume that bgc.bgc_id is a strain name or alias
-            strain = strains.lookup(bgc.bgc_id)
+            genome_id = bgc_genome_mapping[bgc.bgc_id]
         except KeyError as e:
             raise KeyError(
-                f"Strain id {bgc.bgc_id} from BGC object {bgc.bgc_id} "
+                f"Not found BGC id {bgc.bgc_id} in BGC-geonme mappings.") from e
+        try:
+            strain = strains.lookup(genome_id)
+        except KeyError as e:
+            raise KeyError(
+                f"Strain id {genome_id} from BGC object {bgc.bgc_id} "
                 "not found in the StrainCollection object.") from e
         bgc.strain = strain
 

--- a/src/nplinker/genomics/genomics.py
+++ b/src/nplinker/genomics/genomics.py
@@ -36,7 +36,7 @@ def map_strain_to_bgc(strains: StrainCollection, bgcs: list[BGC],
             genome_id = bgc_genome_mapping[bgc.bgc_id]
         except KeyError as e:
             raise KeyError(
-                f"Not found BGC id {bgc.bgc_id} in BGC-geonme mappings.") from e
+                f"Not found BGC id {bgc.bgc_id} in BGC-genome mappings.") from e
         try:
             strain = strains.lookup(genome_id)
         except KeyError as e:

--- a/src/nplinker/genomics/mibig/mibig_loader.py
+++ b/src/nplinker/genomics/mibig/mibig_loader.py
@@ -11,6 +11,7 @@ logger = LogConfig.getLogger(__name__)
 
 
 class MibigBGCLoader:
+
     def __init__(self, data_dir: str):
         """Parse MIBiG metadata files and return BGC objects
 
@@ -24,6 +25,19 @@ class MibigBGCLoader:
         self._file_dict = self.parse_data_dir(self.data_dir)
         self._metadata_dict = self._parse_metadatas()
         self._bgc_dict = self._parse_bgcs()
+
+    def get_bgc_genome_mapping(self) -> dict[str, str]:
+        """Get the mapping from BGC to geonme.
+
+        Note that for MIBiG BGC, same value is used for BGC id and genome id.
+        Users don't have to provide genome id for MIBiG BGCs in the
+        `strain_mapping.csv` file.
+
+        Returns:
+            dict[str, str]: key is BGC id/accession, value is
+                genome id that uses the value of BGC accession.
+        """
+        return {bid: bid for bid in self._file_dict}
 
     def get_files(self) -> dict[str, str]:
         """Get the path of all MIBiG metadata json files.

--- a/src/nplinker/genomics/mibig/mibig_loader.py
+++ b/src/nplinker/genomics/mibig/mibig_loader.py
@@ -27,7 +27,7 @@ class MibigBGCLoader:
         self._bgc_dict = self._parse_bgcs()
 
     def get_bgc_genome_mapping(self) -> dict[str, str]:
-        """Get the mapping from BGC to geonme.
+        """Get the mapping from BGC to genome.
 
         Note that for MIBiG BGC, same value is used for BGC id and genome id.
         Users don't have to provide genome id for MIBiG BGCs in the

--- a/tests/genomics/test_antismash_loader.py
+++ b/tests/genomics/test_antismash_loader.py
@@ -21,6 +21,15 @@ class TestAntismashBGCLoader:
     def test_init(self, loader):
         assert loader.data_dir == str(DATA_DIR / "antismash")
 
+    def test_get_bgc_genome_mapping(self, loader):
+        mapping = loader.get_bgc_genome_mapping()
+        assert isinstance(mapping, dict)
+        assert len(mapping) == 44
+        assert mapping["NZ_AZWB01000005.region001"] == "GCF_000514515.1"
+        assert mapping["NZ_KI911412.1.region001"] == "GCF_000514515.1"
+        assert mapping["NZ_AZWS01000001.region001"] == "GCF_000514855.1"
+        assert mapping["NZ_KI911483.1.region001"] == "GCF_000514855.1"
+
     def test_get_files(self, loader):
         bgc_files = loader.get_files()
         assert isinstance(bgc_files, dict)

--- a/tests/genomics/test_mibig_loader.py
+++ b/tests/genomics/test_mibig_loader.py
@@ -32,6 +32,13 @@ class TestMibigBGCLoader:
     def test_init(self, loader, data_dir):
         assert loader.data_dir == data_dir
 
+    def test_get_bgc_genome_mapping(self, loader):
+        mapping = loader.get_bgc_genome_mapping()
+        assert isinstance(mapping, dict)
+        assert len(mapping) == 2502
+        for bid in mapping:
+            assert bid == mapping[bid]
+
     def test_get_files(self, loader):
         files = loader.get_files()
         assert isinstance(files, dict)


### PR DESCRIPTION
This PR added the BGC-genome mappings based on the idea of two-layer mappings.
For genomics side,  the two-layer mapping is `strain id -> genome id -> bgc id`
-  the mapping of `strain id -> genome id` must be provided by user in the `strain_mapping.csv` file.
-  the mapping of `genome id -> bgc id` can be automatically extracted
    - for AntiSMASH BGC, the `genome id` is the folder name of the gbk file, `bgc id` is the file name of the gbk file.
    - for MIBiG BGC (reference BGCs), same value is used for its genome id and bgc id, which is the BGC accession from MIBiG JSON file.