### PR TITLE
Rename `Downloader` class to `POPDownloader`

### DIFF
--- a/src/nplinker/class_info/runcanopus.py
+++ b/src/nplinker/class_info/runcanopus.py
@@ -79,7 +79,7 @@ def run_canopus(mgf_file,
         result.returncode))
     # use subprocess.CompletedProcess.check_returncode() to test if the CANOPUS
     # process exited successfully. This throws an exception for non-zero returncodes
-    # which will indicate to the Downloader module that something went wrong.
+    # which will indicate to the PODPDownloader module that something went wrong.
     result.check_returncode()
 
     # use presence of this file as a quick way to check if a previous run

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -26,7 +26,7 @@ from nplinker.genomics.mibig import download_and_extract_mibig_metadata
 from nplinker.genomics.mibig import MibigBGCLoader
 from nplinker.logconfig import LogConfig
 from nplinker.metabolomics.metabolomics import load_dataset
-from nplinker.pairedomics.downloader import Downloader
+from nplinker.pairedomics.downloader import PODPDownloader
 from nplinker.pairedomics.runbigscape import run_bigscape
 from nplinker.strain_collection import StrainCollection
 
@@ -185,7 +185,7 @@ class DatasetLoader():
             self._root)[-1] if not self._remote_loading else self._platform_id
 
         if self._remote_loading:
-            self._downloader = Downloader(self._platform_id)
+            self._downloader = PODPDownloader(self._platform_id)
         else:
             self._downloader = None
 

--- a/src/nplinker/pairedomics/downloader.py
+++ b/src/nplinker/pairedomics/downloader.py
@@ -44,7 +44,7 @@ MIBIG_BGC_METADATA_URL = 'https://mibig.secondarymetabolites.org/repository/{}/a
 # MIBIG_BGC_JSON_URL = 'https://mibig.secondarymetabolites.org/repository/{}/{}.json'
 
 
-class Downloader():
+class PODPDownloader():
     # TODO: move to independent config file  ---C.Geng
     PFAM_PATH = os.path.join(sys.prefix, 'nplinker_lib')
 
@@ -121,7 +121,7 @@ class Downloader():
         self.local_download_cache = os.path.join(self.local_cache, 'downloads')
         self.local_file_cache = os.path.join(self.local_cache, 'extracted')    
         os.makedirs(self.local_cache, exist_ok=True)
-        logger.info('Downloader for {}, caching to {}'.format(
+        logger.info('PODPDownloader for {}, caching to {}'.format(
             self.gnps_massive_id, self.local_cache))
 
         # create local cache folders for this dataset

--- a/src/nplinker/pairedomics/downloader.py
+++ b/src/nplinker/pairedomics/downloader.py
@@ -321,7 +321,7 @@ class PODPDownloader():
             logger.info('Found existing metabolomics_zip at %s',
                         self.metabolomics_zip)
             try:
-                mbzip = zipfile.ZipFile(self.metabolomics_zip)
+                mbzip = zipfile.ZipFile(self.metabolomics_zip) # pylint: disable=consider-using-with
                 return mbzip
             except zipfile.BadZipFile:
                 logger.info(
@@ -331,7 +331,7 @@ class PODPDownloader():
         _execute_download(url, self.metabolomics_zip)
 
         # this should throw an exception if zip is malformed etc
-        mbzip = zipfile.ZipFile(self.metabolomics_zip)
+        mbzip = zipfile.ZipFile(self.metabolomics_zip) # pylint: disable=consider-using-with
         return mbzip
 
     def _download_and_load_json(self, url, local_path):

--- a/src/nplinker/pairedomics/downloader.py
+++ b/src/nplinker/pairedomics/downloader.py
@@ -14,18 +14,18 @@
 
 import json
 import os
-import sys
 import shutil
+import sys
 import zipfile
-from deprecated import deprecated
 import httpx
+from deprecated import deprecated
 from progress.spinner import Spinner
+from nplinker.genomics.mibig import download_and_extract_mibig_metadata
 from nplinker.logconfig import LogConfig
 from nplinker.metabolomics.gnps.gnps_downloader import GNPSDownloader
 from nplinker.metabolomics.gnps.gnps_extractor import GNPSExtractor
-from nplinker.strains import Strain
 from nplinker.strain_collection import StrainCollection
-from nplinker.genomics.mibig import download_and_extract_mibig_metadata
+from nplinker.strains import Strain
 from . import download_antismash_data
 
 

--- a/src/nplinker/pairedomics/downloader.py
+++ b/src/nplinker/pairedomics/downloader.py
@@ -82,14 +82,14 @@ class PODPDownloader():
 
             if gnps_massive_id == platform_id:
                 self.pairedomics_id = pairedomics_id
-                logger.debug(
-                    'platform_id %s matched to pairedomics_id %s',
-                    self.gnps_massive_id, self.pairedomics_id)
+                logger.debug('platform_id %s matched to pairedomics_id %s',
+                             self.gnps_massive_id, self.pairedomics_id)
                 break
 
         if self.pairedomics_id is None:
             raise Exception(
-                f'Failed to find a pairedomics project with ID {self.gnps_massive_id}')
+                f'Failed to find a pairedomics project with ID {self.gnps_massive_id}'
+            )
 
         # now get the project JSON data
         self.project_json = None
@@ -116,7 +116,8 @@ class PODPDownloader():
         self.local_download_cache = os.path.join(self.local_cache, 'downloads')
         self.local_file_cache = os.path.join(self.local_cache, 'extracted')
         os.makedirs(self.local_cache, exist_ok=True)
-        logger.info('PODPDownloader for %s, caching to %s', self.gnps_massive_id, self.local_cache)
+        logger.info('PODPDownloader for %s, caching to %s',
+                    self.gnps_massive_id, self.local_cache)
 
         # create local cache folders for this dataset
         self.project_download_cache = os.path.join(self.local_download_cache,
@@ -141,6 +142,7 @@ class PODPDownloader():
                                                   'all_projects.json')
         self.project_json_file = os.path.join(self.local_cache,
                                               f'{self.gnps_massive_id}.json')
+
 
 # CG: download function
 
@@ -178,7 +180,8 @@ class PODPDownloader():
             logger.info('BiG-SCAPE disabled by configuration, not running it')
             return
 
-        logger.info('Running BiG-SCAPE! extra_bigscape_parameters="%s"', extra_bigscape_parameters)
+        logger.info('Running BiG-SCAPE! extra_bigscape_parameters="%s"',
+                    extra_bigscape_parameters)
         try:
             run_bigscape('bigscape.py',
                          os.path.join(self.project_file_cache, 'antismash'),
@@ -200,7 +203,9 @@ class PODPDownloader():
         download_and_extract_mibig_metadata(self.project_download_cache,
                                             output_path, version)
 
-        with open(os.path.join(output_path, 'completed'), 'w', encoding="utf-8"):
+        with open(os.path.join(output_path, 'completed'),
+                  'w',
+                  encoding='utf-8'):
             pass
 
         return True
@@ -245,7 +250,8 @@ class PODPDownloader():
             if accession is None:
                 # this will happen for genomes where we couldn't retrieve data or resolve the ID
                 logger.warning(
-                    'Failed to extract accession from genome with label %s', label)
+                    'Failed to extract accession from genome with label %s',
+                    label)
                 continue
 
             if label in temp:
@@ -255,7 +261,7 @@ class PODPDownloader():
                 gc += 1
 
         logger.info('Extracted %s strains from JSON (met=%s, gen=%s)',
-            len(temp), mc, gc)
+                    len(temp), mc, gc)
         for strain_label, strain_aliases in temp.items():
             strain = Strain(strain_label)
             for alias in strain_aliases:
@@ -280,12 +286,11 @@ class PODPDownloader():
         # - root/metadata_table*
         # - root/DB_result*
 
-        prefixes = ['clusterinfosummarygroup_attributes_withIDs_withcomponentID',
-                    'networkedges_selfloop',
-                    'quantification_table',
-                    'metadata_table',
-                    'DB_result',
-                    'result_specnets_DB']
+        prefixes = [
+            'clusterinfosummarygroup_attributes_withIDs_withcomponentID',
+            'networkedges_selfloop', 'quantification_table', 'metadata_table',
+            'DB_result', 'result_specnets_DB'
+        ]
 
         for member in mbzip.namelist():
             if any(member.startswith(prefix) for prefix in prefixes):
@@ -313,7 +318,8 @@ class PODPDownloader():
 
         # Try read from cache
         if os.path.exists(self.metabolomics_zip):
-            logger.info('Found existing metabolomics_zip at %s', self.metabolomics_zip)
+            logger.info('Found existing metabolomics_zip at %s',
+                        self.metabolomics_zip)
             try:
                 with zipfile.ZipFile(self.metabolomics_zip) as mbzip:
                     return mbzip
@@ -331,7 +337,8 @@ class PODPDownloader():
     def _download_and_load_json(self, url, local_path):
         resp = httpx.get(url, follow_redirects=True)
         if not resp.status_code == 200:
-            raise Exception(f'Failed to download {url} (status code {resp.status_code})')
+            raise Exception(
+                f'Failed to download {url} (status code {resp.status_code})')
 
         content = json.loads(resp.content)
         with open(local_path, 'w', encoding='utf-8') as f:

--- a/src/nplinker/pairedomics/downloader.py
+++ b/src/nplinker/pairedomics/downloader.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .runbigscape import run_bigscape
 import json
 import os
 import shutil
@@ -28,6 +27,7 @@ from nplinker.metabolomics.gnps.gnps_extractor import GNPSExtractor
 from nplinker.strain_collection import StrainCollection
 from nplinker.strains import Strain
 from . import download_antismash_data
+from .runbigscape import run_bigscape
 
 logger = LogConfig.getLogger(__name__)
 
@@ -203,12 +203,15 @@ class PODPDownloader():
         download_and_extract_mibig_metadata(self.project_download_cache,
                                             output_path, version)
 
+        self._create_completed_file(output_path)
+
+        return True
+
+    def _create_completed_file(self, output_path):
         with open(os.path.join(output_path, 'completed'),
                   'w',
                   encoding='utf-8'):
             pass
-
-        return True
 
     def _parse_genome_labels(self, met_records, gen_records):
         temp = {}
@@ -321,7 +324,7 @@ class PODPDownloader():
             logger.info('Found existing metabolomics_zip at %s',
                         self.metabolomics_zip)
             try:
-                mbzip = zipfile.ZipFile(self.metabolomics_zip) # pylint: disable=consider-using-with
+                mbzip = zipfile.ZipFile(self.metabolomics_zip)  # pylint: disable=consider-using-with
                 return mbzip
             except zipfile.BadZipFile:
                 logger.info(
@@ -331,7 +334,7 @@ class PODPDownloader():
         _execute_download(url, self.metabolomics_zip)
 
         # this should throw an exception if zip is malformed etc
-        mbzip = zipfile.ZipFile(self.metabolomics_zip) # pylint: disable=consider-using-with
+        mbzip = zipfile.ZipFile(self.metabolomics_zip)  # pylint: disable=consider-using-with
         return mbzip
 
     def _download_and_load_json(self, url, local_path):

--- a/src/nplinker/pairedomics/downloader.py
+++ b/src/nplinker/pairedomics/downloader.py
@@ -321,8 +321,8 @@ class PODPDownloader():
             logger.info('Found existing metabolomics_zip at %s',
                         self.metabolomics_zip)
             try:
-                with zipfile.ZipFile(self.metabolomics_zip) as mbzip:
-                    return mbzip
+                mbzip = zipfile.ZipFile(self.metabolomics_zip)
+                return mbzip
             except zipfile.BadZipFile:
                 logger.info(
                     'Invalid metabolomics zipfile found, will download again!')
@@ -331,8 +331,8 @@ class PODPDownloader():
         _execute_download(url, self.metabolomics_zip)
 
         # this should throw an exception if zip is malformed etc
-        with zipfile.ZipFile(self.metabolomics_zip) as mbzip:
-            return mbzip
+        mbzip = zipfile.ZipFile(self.metabolomics_zip)
+        return mbzip
 
     def _download_and_load_json(self, url, local_path):
         resp = httpx.get(url, follow_redirects=True)

--- a/src/nplinker/pairedomics/downloader.py
+++ b/src/nplinker/pairedomics/downloader.py
@@ -207,7 +207,8 @@ class PODPDownloader():
 
         return True
 
-    def _create_completed_file(self, output_path):
+    @staticmethod
+    def _create_completed_file(output_path):
         with open(os.path.join(output_path, 'completed'),
                   'w',
                   encoding='utf-8'):

--- a/src/nplinker/pairedomics/podp_antismash_downloader.py
+++ b/src/nplinker/pairedomics/podp_antismash_downloader.py
@@ -9,7 +9,6 @@ from deprecated import deprecated
 from progress.bar import Bar
 from nplinker.logconfig import LogConfig
 
-
 logger = LogConfig.getLogger(__name__)
 
 # urls to be given to download antismash data

--- a/src/nplinker/pairedomics/podp_antismash_downloader.py
+++ b/src/nplinker/pairedomics/podp_antismash_downloader.py
@@ -4,10 +4,11 @@ import re
 import time
 import zipfile
 import httpx
-from deprecated import deprecated
 from bs4 import BeautifulSoup
+from deprecated import deprecated
 from progress.bar import Bar
 from nplinker.logconfig import LogConfig
+
 
 logger = LogConfig.getLogger(__name__)
 

--- a/src/nplinker/pairedomics/runbigscape.py
+++ b/src/nplinker/pairedomics/runbigscape.py
@@ -17,7 +17,6 @@ import subprocess
 import sys
 from ..logconfig import LogConfig
 
-
 logger = LogConfig.getLogger(__name__)
 
 # NOTE: for simplicity this is currently written with assumption it will only be
@@ -37,16 +36,14 @@ def run_bigscape(bigscape_py_path, antismash_path, output_path, pfam_path,
         return True
 
     try:
-        subprocess.run([bigscape_py_path, '-h'],
-                       capture_output=True)
+        subprocess.run([bigscape_py_path, '-h'], capture_output=True)
     except Exception as e:
         raise Exception(
             'Failed to find/run bigscape.py (path={}, err={})'.format(
                 bigscape_py_path, e))
 
     if not os.path.exists(antismash_path):
-        raise Exception(
-            f'antismash_path "{antismash_path}" does not exist!')
+        raise Exception(f'antismash_path "{antismash_path}" does not exist!')
 
     # configure the IO-related parameters, including pfam_dir
     args = [

--- a/src/nplinker/pairedomics/runbigscape.py
+++ b/src/nplinker/pairedomics/runbigscape.py
@@ -64,7 +64,7 @@ def run_bigscape(bigscape_py_path, antismash_path, output_path, pfam_path,
         result.returncode))
     # use subprocess.CompletedProcess.check_returncode() to test if the BiG-SCAPE
     # process exited successfully. This throws an exception for non-zero returncodes
-    # which will indicate to the Downloader module that something went wrong.
+    # which will indicate to the PODPDownloader module that something went wrong.
     result.check_returncode()
 
     # use presence of this file as a quick way to check if a previous run

--- a/tests/pairedomics/test_downloader.py
+++ b/tests/pairedomics/test_downloader.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 from nplinker import utils
 
-from nplinker.pairedomics.downloader import Downloader
+from nplinker.pairedomics.downloader import PODPDownloader
 from nplinker.pairedomics.downloader import _generate_gnps_download_url
 from nplinker.pairedomics.downloader import _execute_download
 from .. import DATA_DIR
@@ -24,7 +24,7 @@ def gnps_url():
 def test_default(expected: Path):
     gnps_id = "MSV000079284"
 
-    sut = Downloader(gnps_id, local_cache=str(expected))
+    sut = PODPDownloader(gnps_id, local_cache=str(expected))
 
     assert sut.gnps_massive_id == gnps_id
     assert sut.local_cache == str(expected)
@@ -42,7 +42,7 @@ def test_default(expected: Path):
     assert sut.project_json_file == str(expected / f"{gnps_id}.json")
 
 def test_download_metabolomics_zipfile(tmp_path):
-    sut = Downloader("MSV000079284", local_cache=tmp_path)
+    sut = PODPDownloader("MSV000079284", local_cache=tmp_path)
     sut._download_metabolomics_zipfile("c22f44b14a3d450eb836d607cb9521bb")
     expected_path = os.path.join(sut.project_download_cache, 'metabolomics_data.zip')
 
@@ -53,7 +53,7 @@ def test_download_metabolomics_zipfile(tmp_path):
 
 
 def test_download_metabolomics_zipfile(tmp_path):
-    sut = Downloader("MSV000079284", local_cache=tmp_path)
+    sut = PODPDownloader("MSV000079284", local_cache=tmp_path)
     sut._download_metabolomics_zipfile("c22f44b14a3d450eb836d607cb9521bb")
     expected_path = os.path.join(sut.project_download_cache, 'c22f44b14a3d450eb836d607cb9521bb.zip')
 
@@ -78,7 +78,7 @@ def test_execute_download(gnps_url: str, tmp_path: Path):
 
 def test_download_gnps_data(tmp_path):
     gnps_task_id = "c22f44b14a3d450eb836d607cb9521bb"
-    sut = Downloader("MSV000079284", local_cache=tmp_path / 'actual')
+    sut = PODPDownloader("MSV000079284", local_cache=tmp_path / 'actual')
     actual = sut._load_gnps_data(gnps_task_id)
 
     expected = zipfile.ZipFile(DATA_DIR / "ProteoSAFe-METABOLOMICS-SNETS-c22f44b1-download_clustered_spectra.zip")
@@ -94,7 +94,7 @@ def test_download_gnps_data(tmp_path):
 
 
 def test_extract_metabolomics_data(tmp_path):
-    sut = Downloader("MSV000079284", local_cache=tmp_path)
+    sut = PODPDownloader("MSV000079284", local_cache=tmp_path)
     archive = zipfile.ZipFile(DATA_DIR / "ProteoSAFe-METABOLOMICS-SNETS-c22f44b1-download_clustered_spectra.zip")
     sut._extract_metabolomics_data(archive)
 


### PR DESCRIPTION
`Downloader` class has been renamed to `POPDownloader` in all inherent files. I also sorted imports, fixed prospector errors and formatted style for src/nplinker/pairedomics/downloader.py module. 

Few comments:
- I wanted to create a new issue starting from subtasks in #121, but the button to do that is not there for me. Does it appear to you? @CunliangGeng 
![image](https://user-images.githubusercontent.com/55382553/229808176-1bb8b573-3f96-4721-ab6a-d21db7f68706.png)

- Running the tests in tests/pairedomics/test_downloader.py gives me this error:
  ```
  FAILED tests/pairedomics/test_downloader.py::test_download_gnps_data - ValueError: Attempt to use ZIP archive that 
  was already closed
  ```
  This is because I added the context manager in `_load_gnps_data` method (it's also deprecated), since it's the best practice for opening a file. But when we test it with `test_download_gnps_data`, the actual zip folder results already closed because of it. Should I remove the context manager, as it was, and suppress the prospector error there? 
