### PR TITLE
fix indentation bug in autodocsting

### DIFF
--- a/.vscode/vscode_docstring_google_adapted.mustache
+++ b/.vscode/vscode_docstring_google_adapted.mustache
@@ -29,4 +29,4 @@ Returns:
 
 Examples:
     >>> {{#placeholder}}
-    {{/placeholder}}
+{{/placeholder}}

--- a/.vscode/vscode_docstring_google_adapted.mustache
+++ b/.vscode/vscode_docstring_google_adapted.mustache
@@ -26,7 +26,3 @@ Returns:
     {{typePlaceholder}}: {{descriptionPlaceholder}}
 {{/returns}}
 {{/returnsExist}}
-
-Examples:
-    >>> {{#placeholder}}
-{{/placeholder}}


### PR DESCRIPTION
Docstrings generated by vscode plugin **autodocstring**  have a wrong indentation for the second `"""`, like the example code below. I fixed this bug by updating the autodocstring template.

Also I removed the `Examples:` section since it is not often used and we have to remove these lines manually when it's not used.

When this PR is merged, the new generated docstrings should have the correct format (you don't need to set or change anything else).

```
  def get_files(self) -> dict[str, str]:
      """_summary_

      _extended_summary_

      Returns:
          dict[str, str]: _description_

      Examples:
          >>>
          """
```