### PR TITLE
Handle unavailable GNPS service

### DIFF
--- a/tests/metabolomics/test_gnps_format.py
+++ b/tests/metabolomics/test_gnps_format.py
@@ -1,10 +1,10 @@
 import zipfile
 import pytest
-
-from nplinker.metabolomics.gnps.gnps_format import GNPSFormat
+from requests.exceptions import ReadTimeout
+from nplinker.metabolomics.gnps.gnps_format import gnps_format_from_archive
 from nplinker.metabolomics.gnps.gnps_format import gnps_format_from_file_mapping
 from nplinker.metabolomics.gnps.gnps_format import gnps_format_from_task_id
-from nplinker.metabolomics.gnps.gnps_format import gnps_format_from_archive
+from nplinker.metabolomics.gnps.gnps_format import GNPSFormat
 from .. import DATA_DIR
 
 
@@ -24,8 +24,11 @@ def test_identify_gnps_format(filename, expected):
     ["c22f44b14a3d450eb836d607cb9521bb", GNPSFormat.AllFiles]
 ])
 def test_gnps_format_from_task_id(task_id: str, expected: GNPSFormat):
-    actual = gnps_format_from_task_id(task_id)
-    assert actual is expected
+    try:
+        actual = gnps_format_from_task_id(task_id)
+        assert actual is expected
+    except ReadTimeout:
+        pytest.skip("GNPS is down")
 
 @pytest.mark.parametrize("archive_path, expected", [
     ["ProteoSAFe-FEATURE-BASED-MOLECULAR-NETWORKING-92036537-download_cytoscape_data.zip", GNPSFormat.FBMN],

--- a/tests/pairedomics/test_downloader.py
+++ b/tests/pairedomics/test_downloader.py
@@ -46,7 +46,7 @@ def test_download_metabolomics_zipfile(tmp_path):
     assert (Path(sut.project_file_cache) / "spectra/METABOLOMICS-SNETS-c22f44b1-download_clustered_spectra-main.mgf").is_file()
 
 
-def test_download_metabolomics_zipfile(tmp_path):
+def test_download_metabolomics_zipfile_scenario2(tmp_path):
     sut = PODPDownloader("MSV000079284", local_cache=tmp_path)
     sut._download_metabolomics_zipfile("c22f44b14a3d450eb836d607cb9521bb")
     expected_path = os.path.join(sut.project_download_cache, 'c22f44b14a3d450eb836d607cb9521bb.zip')

--- a/tests/pairedomics/test_downloader.py
+++ b/tests/pairedomics/test_downloader.py
@@ -1,14 +1,10 @@
-import filecmp
 import os
 from pathlib import Path
-import zipfile
-import numpy
 import pytest
 from pytest_lazyfixture import lazy_fixture
-from nplinker import utils
+from requests.exceptions import ReadTimeout
 from nplinker.pairedomics.downloader import PODPDownloader
 from nplinker.pairedomics.downloader import STRAIN_MAPPINGS_FILENAME
-from .. import DATA_DIR
 
 
 @pytest.mark.parametrize("expected", [
@@ -37,21 +33,27 @@ def test_default(expected: Path):
 
 def test_download_metabolomics_zipfile(tmp_path):
     sut = PODPDownloader("MSV000079284", local_cache=tmp_path)
-    sut._download_metabolomics_zipfile("c22f44b14a3d450eb836d607cb9521bb")
-    expected_path = os.path.join(sut.project_download_cache, 'metabolomics_data.zip')
+    try:
+        sut._download_metabolomics_zipfile("c22f44b14a3d450eb836d607cb9521bb")
+        expected_path = os.path.join(sut.project_download_cache, 'metabolomics_data.zip')
 
-    assert os.path.exists(expected_path)
-    assert (Path(sut.project_file_cache) / "networkedges_selfloop/6da5be36f5b14e878860167fa07004d6.pairsinfo").is_file()
-    assert (Path(sut.project_file_cache) / "clusterinfosummarygroup_attributes_withIDs_withcomponentID/d69356c8e5044c2a9fef3dd2a2f991e1.tsv").is_file()
-    assert (Path(sut.project_file_cache) / "spectra/METABOLOMICS-SNETS-c22f44b1-download_clustered_spectra-main.mgf").is_file()
+        assert os.path.exists(expected_path)
+        assert (Path(sut.project_file_cache) / "networkedges_selfloop/6da5be36f5b14e878860167fa07004d6.pairsinfo").is_file()
+        assert (Path(sut.project_file_cache) / "clusterinfosummarygroup_attributes_withIDs_withcomponentID/d69356c8e5044c2a9fef3dd2a2f991e1.tsv").is_file()
+        assert (Path(sut.project_file_cache) / "spectra/METABOLOMICS-SNETS-c22f44b1-download_clustered_spectra-main.mgf").is_file()
+    except ReadTimeout:
+        pytest.skip("GNPS is down")
 
 
 def test_download_metabolomics_zipfile_scenario2(tmp_path):
     sut = PODPDownloader("MSV000079284", local_cache=tmp_path)
-    sut._download_metabolomics_zipfile("c22f44b14a3d450eb836d607cb9521bb")
-    expected_path = os.path.join(sut.project_download_cache, 'c22f44b14a3d450eb836d607cb9521bb.zip')
+    try:
+        sut._download_metabolomics_zipfile("c22f44b14a3d450eb836d607cb9521bb")
+        expected_path = os.path.join(sut.project_download_cache, 'c22f44b14a3d450eb836d607cb9521bb.zip')
 
-    assert os.path.exists(expected_path)
-    assert (Path(sut.project_file_cache) / "molecular_families.pairsinfo").is_file()
-    assert (Path(sut.project_file_cache) / "file_mappings.tsv").is_file()
-    assert (Path(sut.project_file_cache) / "spectra.mgf").is_file()
+        assert os.path.exists(expected_path)
+        assert (Path(sut.project_file_cache) / "molecular_families.pairsinfo").is_file()
+        assert (Path(sut.project_file_cache) / "file_mappings.tsv").is_file()
+        assert (Path(sut.project_file_cache) / "spectra.mgf").is_file()
+    except ReadTimeout:
+        pytest.skip("GNPS is down")


### PR DESCRIPTION
GPNS service is down in 11 July 2023 (see below). This leads to failed unit tests of downloading GNPS data.
![image](https://github.com/NPLinker/nplinker/assets/9798985/d0e15c75-00cd-47a2-a228-667b92af2687)

To handle the down service:
- Add time out (5s) to the http request to GNPS to avoid hanging infinitely. When time is out, an `ReadTimeout` error is raised.
- Also removed the deprecated functions for downloading GNPS data. These functions have been replaced by GNPSDownloader.
