### PR TITLE
Handle 404 NOT FOUND error for `download_and_extract_antismash_data`

### DIFF
--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -1,8 +1,8 @@
 import os
+import shutil
+import urllib
 from os import PathLike
 from pathlib import Path
-import urllib
-import shutil
 from nplinker.logconfig import LogConfig
 from nplinker.utils import download_and_extract_archive
 from nplinker.utils import list_dirs

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-import urllib
+from urllib.error import HTTPError
 from os import PathLike
 from pathlib import Path
 from nplinker.logconfig import LogConfig

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -76,7 +76,7 @@ def download_and_extract_antismash_data(antismash_id: str,
     except urllib.error.HTTPError as e:
         shutil.rmtree(extract_path)
         logger.warning(e)
-        raise urllib.error.HTTPError(e.url, e.code, f"Could not find a valid url for {antismash_id}", e.hdrs, e.fp)
+        raise urllib.error.HTTPError(e.url, e.code, f"Could not find a valid url for {antismash_id}", e.hdrs, e.fp) from e
 
 
 def _check_roots(download_root: PathLike, extract_root: PathLike):

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -1,6 +1,7 @@
 import os
 from os import PathLike
 from pathlib import Path
+import urllib
 import shutil
 from nplinker.logconfig import LogConfig
 from nplinker.utils import download_and_extract_archive
@@ -45,29 +46,37 @@ def download_and_extract_antismash_data(antismash_id: str,
     extract_root = Path(extract_root)
     extract_path = extract_root / "antismash" / antismash_id
     _check_roots(download_root, extract_root)
-    if extract_path.exists():
-        _check_extract_path(extract_path)
-    else:
-        extract_path.mkdir(parents=True, exist_ok=True)
 
-    for base_url in [ANTISMASH_DB_DOWNLOAD_URL, ANTISMASH_DBV2_DOWNLOAD_URL]:
-        url = base_url.format(antismash_id, antismash_id + '.zip')
-        download_and_extract_archive(url, download_root, extract_path,
-                                     antismash_id + '.zip')
-        break
+    try:
+        if extract_path.exists():
+            _check_extract_path(extract_path)
+        else:
+            extract_path.mkdir(parents=True, exist_ok=True)
 
-    # delete subdirs
-    for subdir_path in list_dirs(extract_path):
-        shutil.rmtree(subdir_path)
+        for base_url in [ANTISMASH_DB_DOWNLOAD_URL, ANTISMASH_DBV2_DOWNLOAD_URL]:
+            url = base_url.format(antismash_id, antismash_id + '.zip')
+            download_and_extract_archive(url, download_root, extract_path,
+                                        antismash_id + '.zip')
+            break
 
-    # delete unnecessary files
-    files_to_keep = list_files(extract_path, suffix=(".json", ".gbk"))
-    for file in list_files(extract_path):
-        if file not in files_to_keep:
-            os.remove(file)
 
-    logger.info('antiSMASH BGC data of %s is downloaded and extracted.',
-                antismash_id)
+        # delete subdirs
+        for subdir_path in list_dirs(extract_path):
+            shutil.rmtree(subdir_path)
+
+        # delete unnecessary files
+        files_to_keep = list_files(extract_path, suffix=(".json", ".gbk"))
+        for file in list_files(extract_path):
+            if file not in files_to_keep:
+                os.remove(file)
+
+        logger.info('antiSMASH BGC data of %s is downloaded and extracted.',
+                    antismash_id)
+        
+    except urllib.error.HTTPError as e:
+        shutil.rmtree(extract_path)
+        logger.warning(e)
+        raise urllib.error.HTTPError(e.url, e.code, f"Could not find a valid url for {antismash_id}", e.hdrs, e.fp)
 
 
 def _check_roots(download_root: PathLike, extract_root: PathLike):

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -73,12 +73,12 @@ def download_and_extract_antismash_data(antismash_id: str,
         logger.info('antiSMASH BGC data of %s is downloaded and extracted.',
                     antismash_id)
 
-    except urllib.error.HTTPError as e:
+    except HTTPError as e:
         shutil.rmtree(extract_path)
         logger.warning(e)
-        raise urllib.error.HTTPError(
+        raise HTTPError(
             e.url, e.code, f"Could not find a valid url for {antismash_id}",
-            e.hdrs, e.fp) from e
+            e.headers, e.fp) from e
 
 
 def _check_roots(download_root: PathLike, extract_root: PathLike):

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -8,7 +8,6 @@ from nplinker.utils import download_and_extract_archive
 from nplinker.utils import list_dirs
 from nplinker.utils import list_files
 
-
 logger = LogConfig.getLogger(__name__)
 
 # urls to be given to download antismash data
@@ -53,12 +52,13 @@ def download_and_extract_antismash_data(antismash_id: str,
         else:
             extract_path.mkdir(parents=True, exist_ok=True)
 
-        for base_url in [ANTISMASH_DB_DOWNLOAD_URL, ANTISMASH_DBV2_DOWNLOAD_URL]:
+        for base_url in [
+                ANTISMASH_DB_DOWNLOAD_URL, ANTISMASH_DBV2_DOWNLOAD_URL
+        ]:
             url = base_url.format(antismash_id, antismash_id + '.zip')
             download_and_extract_archive(url, download_root, extract_path,
-                                        antismash_id + '.zip')
+                                         antismash_id + '.zip')
             break
-
 
         # delete subdirs
         for subdir_path in list_dirs(extract_path):
@@ -72,11 +72,13 @@ def download_and_extract_antismash_data(antismash_id: str,
 
         logger.info('antiSMASH BGC data of %s is downloaded and extracted.',
                     antismash_id)
-        
+
     except urllib.error.HTTPError as e:
         shutil.rmtree(extract_path)
         logger.warning(e)
-        raise urllib.error.HTTPError(e.url, e.code, f"Could not find a valid url for {antismash_id}", e.hdrs, e.fp) from e
+        raise urllib.error.HTTPError(
+            e.url, e.code, f"Could not find a valid url for {antismash_id}",
+            e.hdrs, e.fp) from e
 
 
 def _check_roots(download_root: PathLike, extract_root: PathLike):

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -176,12 +176,12 @@ class DatasetLoader():
         return True
 
     def _start_downloads(self):
-        downloader = PODPDownloader(self._platform_id)
-        self._root = downloader.project_file_cache
+        self._downloader = PODPDownloader(self._platform_id)
+        self._root = self._downloader.project_file_cache
         logger.debug('remote loading mode, configuring root=%s', self._root)
         # CG: to download both MET and GEN data
         # CG: Continue to understand how strain_mappings.json is generated
-        downloader.get(
+        self._downloader.get(
             self._config_docker.get('run_bigscape', self.RUN_BIGSCAPE_DEFAULT),
             self._config_docker.get('extra_bigscape_parameters',
                                     self.EXTRA_BIGSCAPE_PARAMS_DEFAULT),

--- a/src/nplinker/pairedomics/podp_antismash_downloader.py
+++ b/src/nplinker/pairedomics/podp_antismash_downloader.py
@@ -1,13 +1,13 @@
 import json
-from os import PathLike
-from pathlib import Path
-import urllib
 import re
 import time
+import urllib
+from os import PathLike
+from pathlib import Path
+import httpx
 from bs4 import BeautifulSoup
 from bs4 import NavigableString
 from bs4 import Tag
-import httpx
 from nplinker.genomics.antismash import download_and_extract_antismash_data
 from nplinker.logconfig import LogConfig
 

--- a/src/nplinker/pairedomics/podp_antismash_downloader.py
+++ b/src/nplinker/pairedomics/podp_antismash_downloader.py
@@ -11,7 +11,6 @@ from bs4 import Tag
 from nplinker.genomics.antismash import download_and_extract_antismash_data
 from nplinker.logconfig import LogConfig
 
-
 logger = LogConfig.getLogger(__name__)
 
 NCBI_LOOKUP_URL = 'https://www.ncbi.nlm.nih.gov/assembly/?term={}'
@@ -177,7 +176,7 @@ def podp_download_and_extract_antismash_data(
             # give up on this one
             logger.warning(f'Failed lookup for genome ID {raw_genome_id}')
             continue
-        
+
         # if resolved id is valid, try to download and extract antismash data
         try:
             download_and_extract_antismash_data(gs_obj.resolved_refseq_id,
@@ -186,10 +185,10 @@ def podp_download_and_extract_antismash_data(
 
             gs_obj.bgc_path = str(
                 Path(project_download_root,
-                    gs_obj.resolved_refseq_id + '.zip').absolute())
+                     gs_obj.resolved_refseq_id + '.zip').absolute())
 
             output_path = Path(project_extract_root, 'antismash',
-                            gs_obj.resolved_refseq_id)
+                               gs_obj.resolved_refseq_id)
             if output_path.exists():
                 Path.touch(output_path / 'completed', exist_ok=True)
 

--- a/src/nplinker/pairedomics/podp_antismash_downloader.py
+++ b/src/nplinker/pairedomics/podp_antismash_downloader.py
@@ -1,7 +1,7 @@
 import json
 import re
 import time
-import urllib
+from urllib.error import HTTPError
 from os import PathLike
 from pathlib import Path
 import httpx
@@ -192,7 +192,7 @@ def podp_download_and_extract_antismash_data(
             if output_path.exists():
                 Path.touch(output_path / 'completed', exist_ok=True)
 
-        except urllib.error.HTTPError:
+        except HTTPError:
             gs_obj.bgc_path = ""
 
     missing = len([gs for gs in gs_dict.values() if not gs.bgc_path])

--- a/src/nplinker/strain_collection.py
+++ b/src/nplinker/strain_collection.py
@@ -194,4 +194,4 @@ class StrainCollection():
                 strain.add_alias(gbk_filename)
 
         logger.info(f'Saving strains to {strain_mappings_file}')
-        self.save_to_file(strain_mappings_file)
+        self.to_json(strain_mappings_file)

--- a/tests/genomics/antismash/test_antismash_downloader.py
+++ b/tests/genomics/antismash/test_antismash_downloader.py
@@ -54,8 +54,5 @@ class TestDownloadAndExtractAntismashData():
         with pytest.raises(urllib.error.HTTPError):
             download_and_extract_antismash_data(broken_antismash_id, download_root,
                                                 extract_root)
-            archive = download_root / broken_antismash_id / ".zip"
-            extracted_folder = extract_root / "antismash" / broken_antismash_id
-            assert not archive.exists()
-            assert not archive.is_file()
-            assert not extracted_folder.exists()
+        extracted_folder = extract_root / "antismash" / broken_antismash_id
+        assert not extracted_folder.exists()

--- a/tests/genomics/antismash/test_antismash_downloader.py
+++ b/tests/genomics/antismash/test_antismash_downloader.py
@@ -1,7 +1,8 @@
-import pytest
 import urllib
+import pytest
 from nplinker.genomics.antismash import download_and_extract_antismash_data
-from nplinker.utils import list_files, extract_archive
+from nplinker.utils import extract_archive
+from nplinker.utils import list_files
 
 
 class TestDownloadAndExtractAntismashData():

--- a/tests/genomics/antismash/test_antismash_downloader.py
+++ b/tests/genomics/antismash/test_antismash_downloader.py
@@ -45,8 +45,20 @@ class TestDownloadAndExtractAntismashData():
                                                 tmp_path / "extracted")
         assert "Nonempty directory" in e.value.args[0]
 
-    def test_broken_url(self, tmp_path):
-        broken_antismash_id = 'broken_id'
+    def test_nonexisting_id(self, tmp_path):
+        nonexisting_antismash_id = 'nonexisting_id'
+        download_root = tmp_path / "download"
+        download_root.mkdir()
+        extract_root = tmp_path / "extracted"
+        extract_root.mkdir()
+        with pytest.raises(urllib.error.HTTPError):
+            download_and_extract_antismash_data(nonexisting_antismash_id, download_root,
+                                                extract_root)
+        extracted_folder = extract_root / "antismash" / nonexisting_antismash_id
+        assert not extracted_folder.exists()
+
+    def test_broken_id(self, tmp_path):
+        broken_antismash_id = 'GCF_000702345.1'
         download_root = tmp_path / "download"
         download_root.mkdir()
         extract_root = tmp_path / "extracted"

--- a/tests/genomics/antismash/test_antismash_downloader.py
+++ b/tests/genomics/antismash/test_antismash_downloader.py
@@ -1,4 +1,4 @@
-import urllib
+from urllib.error import HTTPError
 import pytest
 from nplinker.genomics.antismash import download_and_extract_antismash_data
 from nplinker.utils import extract_archive
@@ -55,7 +55,7 @@ class TestDownloadAndExtractAntismashData():
         extract_root = tmp_path / "extracted"
         extract_root.mkdir()
         for test_id in nonexisting_ids:
-            with pytest.raises(urllib.error.HTTPError):
+            with pytest.raises(HTTPError):
                 download_and_extract_antismash_data(test_id, download_root,
                                                     extract_root)
             extracted_folder = extract_root / "antismash" / test_id

--- a/tests/genomics/antismash/test_antismash_downloader.py
+++ b/tests/genomics/antismash/test_antismash_downloader.py
@@ -1,4 +1,5 @@
 import pytest
+import urllib
 from nplinker.genomics.antismash import download_and_extract_antismash_data
 from nplinker.utils import list_files, extract_archive
 
@@ -43,3 +44,18 @@ class TestDownloadAndExtractAntismashData():
             download_and_extract_antismash_data(self.antismash_id, tmp_path,
                                                 tmp_path / "extracted")
         assert "Nonempty directory" in e.value.args[0]
+
+    def test_broken_url(self, tmp_path):
+        broken_antismash_id = 'broken_id'
+        download_root = tmp_path / "download"
+        download_root.mkdir()
+        extract_root = tmp_path / "extracted"
+        extract_root.mkdir()
+        with pytest.raises(urllib.error.HTTPError):
+            download_and_extract_antismash_data(broken_antismash_id, download_root,
+                                                extract_root)
+            archive = download_root / broken_antismash_id / ".zip"
+            extracted_folder = extract_root / "antismash" / broken_antismash_id
+            assert not archive.exists()
+            assert not archive.is_file()
+            assert not extracted_folder.exists()

--- a/tests/genomics/antismash/test_antismash_downloader.py
+++ b/tests/genomics/antismash/test_antismash_downloader.py
@@ -46,26 +46,17 @@ class TestDownloadAndExtractAntismashData():
                                                 tmp_path / "extracted")
         assert "Nonempty directory" in e.value.args[0]
 
+    # test a non-existent ID, which can be either a fake ID, non-existent in NCBI
+    # or a "broken" antismash ID, which does not exist anymore in the antismash database
     def test_nonexisting_id(self, tmp_path):
-        nonexisting_antismash_id = 'nonexisting_id'
+        nonexisting_ids = ['non_existent_ID', 'GCF_000702345.1']
         download_root = tmp_path / "download"
         download_root.mkdir()
         extract_root = tmp_path / "extracted"
         extract_root.mkdir()
-        with pytest.raises(urllib.error.HTTPError):
-            download_and_extract_antismash_data(nonexisting_antismash_id, download_root,
-                                                extract_root)
-        extracted_folder = extract_root / "antismash" / nonexisting_antismash_id
-        assert not extracted_folder.exists()
-
-    def test_broken_id(self, tmp_path):
-        broken_antismash_id = 'GCF_000702345.1'
-        download_root = tmp_path / "download"
-        download_root.mkdir()
-        extract_root = tmp_path / "extracted"
-        extract_root.mkdir()
-        with pytest.raises(urllib.error.HTTPError):
-            download_and_extract_antismash_data(broken_antismash_id, download_root,
-                                                extract_root)
-        extracted_folder = extract_root / "antismash" / broken_antismash_id
-        assert not extracted_folder.exists()
+        for test_id in nonexisting_ids:
+            with pytest.raises(urllib.error.HTTPError):
+                download_and_extract_antismash_data(test_id, download_root,
+                                                    extract_root)
+            extracted_folder = extract_root / "antismash" / test_id
+            assert not extracted_folder.exists()

--- a/tests/genomics/antismash/test_antismash_downloader.py
+++ b/tests/genomics/antismash/test_antismash_downloader.py
@@ -47,7 +47,7 @@ class TestDownloadAndExtractAntismashData():
         assert "Nonempty directory" in e.value.args[0]
 
     # test a non-existent ID, which can be either a fake ID, non-existent in NCBI
-    # or a "broken" antismash ID, which does not exist anymore in the antismash database
+    # or a valid NCBI genome ID but it does not have BGC data in antismash database
     def test_nonexisting_id(self, tmp_path):
         nonexisting_ids = ['non_existent_ID', 'GCF_000702345.1']
         download_root = tmp_path / "download"

--- a/tests/pairedomics/test_podp_antismash_downloader.py
+++ b/tests/pairedomics/test_podp_antismash_downloader.py
@@ -230,7 +230,29 @@ def test_failed_lookup(download_root, extract_root, genome_status_file):
     assert len(genome_status["non_existing_ID"].bgc_path) == 0
     assert genome_status["non_existing_ID"].resolve_attempted
     assert not (download_root / "non_existing_ID.zip").exists()
-    assert not (extract_root / "antismash" / "non_existing_ID.zip").exists()
+    assert not (extract_root / "antismash" / "non_existing_ID").exists()
+
+
+# Test `podp_download_and_extract_antismash_data` function
+# when a genome record has an existing accession ID, but the antismash link is broken
+# 404 error
+def test_broken_lookup(download_root, extract_root, genome_status_file):
+    broken_id = "GCF_000702345.1"
+    genome_records = [{
+        "genome_ID": {
+            "genome_type": "genome",
+            "RefSeq_accession": broken_id
+        },
+        "genome_label": "Salinispora arenicola CNX508"
+    }]
+
+    podp_download_and_extract_antismash_data(genome_records, download_root,
+                                             extract_root)
+    genome_status = GenomeStatus.read_json(genome_status_file)
+    assert len(genome_status[broken_id].bgc_path) == 0
+    assert genome_status[broken_id].resolve_attempted
+    assert not (download_root / broken_id / ".zip").exists()
+    assert not (extract_root / "antismash" / broken_id).exists()
 
 
 # Test `podp_download_and_extract_antismash_data` function

--- a/tests/pairedomics/test_podp_antismash_downloader.py
+++ b/tests/pairedomics/test_podp_antismash_downloader.py
@@ -235,7 +235,7 @@ def test_failed_lookup_ncbi(download_root, extract_root, genome_status_file):
 
 # Test `podp_download_and_extract_antismash_data` function
 # when a genome record has an existing accession ID in NCBI,
-# but not in the antismash databased
+# but not in the antismash database
 def test_failed_lookup_antismash(download_root, extract_root, genome_status_file):
     broken_id = "GCF_000702345.1"
     genome_records = [{

--- a/tests/pairedomics/test_podp_antismash_downloader.py
+++ b/tests/pairedomics/test_podp_antismash_downloader.py
@@ -214,8 +214,8 @@ def test_caching(download_root, extract_root, genome_status_file, caplog):
 
 
 # Test `podp_download_and_extract_antismash_data` function
-# when a genome record has a non existing accession ID
-def test_failed_lookup(download_root, extract_root, genome_status_file):
+# when a genome record has an which does not exists in NCBI
+def test_failed_lookup_ncbi(download_root, extract_root, genome_status_file):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
@@ -234,9 +234,9 @@ def test_failed_lookup(download_root, extract_root, genome_status_file):
 
 
 # Test `podp_download_and_extract_antismash_data` function
-# when a genome record has an existing accession ID, but the antismash link is broken
-# 404 error
-def test_broken_lookup(download_root, extract_root, genome_status_file):
+# when a genome record has an existing accession ID in NCBI,
+# but not in the antismash databased
+def test_failed_lookup_antismash(download_root, extract_root, genome_status_file):
     broken_id = "GCF_000702345.1"
     genome_records = [{
         "genome_ID": {

--- a/tests/test_nplinker_local.py
+++ b/tests/test_nplinker_local.py
@@ -5,7 +5,6 @@ import pytest
 from nplinker.nplinker import NPLinker
 from . import DATA_DIR
 
-
 # NOTE: This file only contains tests that run locally and are skipped on CI.
 # Basically, only tests related to data loading should be put here.
 # For tests on scoring/links, add them to `scoring/test_nplinker_scoring.py`.
@@ -29,10 +28,12 @@ def npl() -> NPLinker:
     npl = NPLinker(str(DATA_DIR / 'nplinker_demo1.toml'))
     npl.load_data()
     hash_proj_file = get_file_hash(
-        os.path.join(
-        npl._downloader.local_cache, npl._loader._platform_id + '.json'))
+        os.path.join(npl._downloader.local_cache,
+                     npl._loader._platform_id + '.json'))
     if hash_proj_file != '22e4f20d6f8aa425b2040479d0b6c00e7d3deb03f8fc4a277b3b91eb07c9ad72':
-        pytest.exit('PoDP project file has changed, please clean your local cache folder and rerun the tests.')
+        pytest.exit(
+            'PoDP project file has changed, please clean your local cache folder and rerun the tests.'
+        )
     # remove cached score results before running tests
     root_dir = Path(npl.root_dir)
     score_cache = root_dir / 'metcalf' / 'metcalf_scores.pckl'

--- a/tests/test_nplinker_local.py
+++ b/tests/test_nplinker_local.py
@@ -1,6 +1,6 @@
+import hashlib
 import os
 from pathlib import Path
-import hashlib
 import pytest
 from nplinker.nplinker import NPLinker
 from . import DATA_DIR

--- a/tests/test_nplinker_local.py
+++ b/tests/test_nplinker_local.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import hashlib
 import pytest
 from nplinker.nplinker import NPLinker
 from . import DATA_DIR
@@ -10,11 +11,29 @@ from . import DATA_DIR
 # For tests on scoring/links, add them to `scoring/test_nplinker_scoring.py`.
 
 
+def get_digest(file_path):
+    h = hashlib.sha256()
+    with open(file_path, 'rb') as file:
+        while True:
+            # Reading is buffered, so we can read smaller chunks.
+            chunk = file.read(h.block_size)
+            if not chunk:
+                break
+            h.update(chunk)
+
+    return h.hexdigest()
+
+
 @pytest.fixture(scope='module')
 def npl() -> NPLinker:
     npl = NPLinker(str(DATA_DIR / 'nplinker_demo1.toml'))
     npl.load_data()
-    # remove cached results before running tests
+    hash_proj_file = get_digest(
+        os.path.join(
+        npl._downloader.local_cache, npl._loader._platform_id + '.json'))
+    if hash_proj_file != '22e4f20d6f8aa425b2040479d0b6c00e7d3deb03f8fc4a277b3b91eb07c9ad72':
+        pytest.exit('PoDP project file has changed, please clean your local cache folder and rerun the tests.')
+    # remove cached score results before running tests
     root_dir = Path(npl.root_dir)
     score_cache = root_dir / 'metcalf' / 'metcalf_scores.pckl'
     score_cache.unlink(missing_ok=True)
@@ -24,6 +43,7 @@ def npl() -> NPLinker:
 @pytest.mark.skipif(os.environ.get('CI') == 'true',
                     reason="Skip when running on CI")
 def test_load_data(npl: NPLinker):
+
     assert len(npl.bgcs) == 390
     assert len(npl.gcfs) == 113
     assert len(npl.spectra) == 25935

--- a/tests/test_nplinker_local.py
+++ b/tests/test_nplinker_local.py
@@ -11,7 +11,7 @@ from . import DATA_DIR
 # For tests on scoring/links, add them to `scoring/test_nplinker_scoring.py`.
 
 
-def get_digest(file_path):
+def get_file_hash(file_path):
     h = hashlib.sha256()
     with open(file_path, 'rb') as file:
         while True:

--- a/tests/test_nplinker_local.py
+++ b/tests/test_nplinker_local.py
@@ -28,7 +28,7 @@ def get_file_hash(file_path):
 def npl() -> NPLinker:
     npl = NPLinker(str(DATA_DIR / 'nplinker_demo1.toml'))
     npl.load_data()
-    hash_proj_file = get_digest(
+    hash_proj_file = get_file_hash(
         os.path.join(
         npl._downloader.local_cache, npl._loader._platform_id + '.json'))
     if hash_proj_file != '22e4f20d6f8aa425b2040479d0b6c00e7d3deb03f8fc4a277b3b91eb07c9ad72':


### PR DESCRIPTION
**With this PR:**
- Now the hash of the project's json file (MSV000079284.json in our test case) is checked, and if the file changes an error is raised
- Now two try-except statements handle better the creation of antismash extracted folders, which happens only if the corresponding zip folder has been downloaded. Also, the `genome_status.json` file now contains an empty string value for the key `bgc_path` in the cases in which no zip folder has been downloaded and no folder has been extracted.  
- I added one test in tests/genomics/antismash/test_antismash_downloader.py to assess that `download_and_extract_antismash_data` does not create an empty folder when the id does not exist in NCBI and when the id does exist there but not in the antismash database (404 error).
- I added two tests in tests/pairedomics/test_podp_antismash_downloader.py to assess that `podp_download_and_extract_antismash_data` does not create an empty folder when the id does not exist in NCBI and when the id does exist there but not in the antismash database (404 error); they also check for the correctness of the genome status file.

In conclusion, we were already handling cases in which the genome id was non-existing, but we weren't handling cases in which the genome id was existing in NCBI but not in the antismash database. Now we handle both cases. 

**Notes** for @CunliangGeng:
- tests/test_nplinker_local.py still fails, but it's an error unrelated to this PR (maybe it will be solved with #116?):
```bash
ERROR tests/test_nplinker_local.py::test_load_data - Exception: Failed to find *ANY* strains, missing strain_mappings.json?
```
- running mypy on src/nplinker/genomics/antismash/antismash_downloader.py gives me an error about `os.scandir`, but I didn't find how to solve it: 
```bash
src/nplinker/genomics/antismash/antismash_downloader.py:91: error: Value of type variable "AnyStr" of "scandir" cannot be "Union[PathLike[Any], Any]"  [type-var]
```