### PR TITLE
change class method to static method

### DIFF
--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -339,7 +339,7 @@ class DatasetLoader():
             self.strains.generate_strain_mappings(self.strain_mappings_file,
                                                   self.antismash_dir)
         else:
-            sc = StrainCollection().read_json(self.strain_mappings_file)
+            sc = StrainCollection.read_json(self.strain_mappings_file)
             for strain in sc:
                 self.strains.add(strain)
             logger.info('Loaded dataset strain IDs ({} total)'.format(

--- a/src/nplinker/strain_collection.py
+++ b/src/nplinker/strain_collection.py
@@ -110,8 +110,8 @@ class StrainCollection():
             return self._strain_dict_name[name]
         raise KeyError(f"Strain {name} not found in strain collection.")
 
-    @classmethod
-    def read_json(cls, file: str | PathLike) -> 'StrainCollection':
+    @staticmethod
+    def read_json(file: str | PathLike) -> 'StrainCollection':
         """Read a strain mappings JSON file and return a StrainCollection object.
 
         Args:
@@ -123,7 +123,7 @@ class StrainCollection():
         with open(file, 'r') as f:
             json_data = json.load(f)
 
-        strain_collection = cls()
+        strain_collection = StrainCollection()
         for data in json_data['strain_mappings']:
             strain = Strain(data['strain_id'])
             for alias in data['strain_alias']:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def spec_dict() -> dict[str, Spectrum]:
 @pytest.fixture
 def collection_from_file() -> StrainCollection:
     filename = DATA_DIR / STRAIN_MAPPINGS_FILENAME
-    sut = StrainCollection().read_json(filename)
+    sut = StrainCollection.read_json(filename)
     return sut
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -83,6 +83,6 @@ def test_load_strain_mappings(config):
     sut._load_strain_mappings()
 
     actual = sut.strains
-    expected = StrainCollection().read_json(sut.strain_mappings_file)
+    expected = StrainCollection.read_json(sut.strain_mappings_file)
 
     assert actual == expected


### PR DESCRIPTION
The discussion during standup triggered me to reflect on the usage of `@classmethod`. Only one place in the codebase used `@classmethod`, which is actually not suitable . So I change it to static method.

👉 **When to use `@classmethod`?**
Use `@classmethod` when the method needs to affect or make use of **class-level data** (like the `count` below)
```
class MyClass:
    count = 0

    def __init__(self):
        MyClass.count += 1

    @classmethod
    def get_count(cls):
        return cls.count
```
