### PR TITLE
Refactor loading genomics

### DIFF
--- a/src/nplinker/genomics/gcf.py
+++ b/src/nplinker/genomics/gcf.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from nplinker.logconfig import LogConfig
 from nplinker.strain_collection import StrainCollection
 
+
 if TYPE_CHECKING:
     from nplinker.strains import Strain
     from .bgc import BGC
@@ -33,8 +34,6 @@ class GCF():
         self.gcf_id = gcf_id
         self._bgcs: set[BGC] = set()
         self.bigscape_class: str | None = None
-        # CG TODO: remove attribute id, see issue 103
-        #    https://github.com/NPLinker/nplinker/issues/103
         self.bgc_ids: set[str] = set()
         self.strains: StrainCollection = StrainCollection()
 

--- a/src/nplinker/genomics/gcf.py
+++ b/src/nplinker/genomics/gcf.py
@@ -82,11 +82,11 @@ class GCF():
                     return
             self.strains.remove(bgc.strain)
 
-    def has_strain(self, strain: str | Strain) -> bool:
+    def has_strain(self, strain: Strain) -> bool:
         """Check if the given strain exists.
 
         Args:
-            strain(str | Strain): strain id or `Strain` object.
+            strain(Strain): `Strain` object.
 
         Returns:
             bool: True when the given strain exist.

--- a/src/nplinker/genomics/genomics.py
+++ b/src/nplinker/genomics/genomics.py
@@ -83,12 +83,17 @@ def map_strain_to_bgc(strains: StrainCollection, bgcs: list[BGC]):
     """
     for bgc in bgcs:
         try:
-            strain = strains.lookup(bgc.bgc_id)
+            strain_list = strains.lookup(bgc.bgc_id)
+            if len(strain_list) > 1:
+                raise KeyError(
+                    f"Multiple strain objects found for BGC id '{bgc.bgc_id}'."
+                    f"BGC object accept only one strain."
+                )
         except KeyError as e:
             raise KeyError(
                 f"Strain id '{bgc.bgc_id}' from BGC object '{bgc.bgc_id}' "
                 "not found in the strain collection.") from e
-        bgc.strain = strain
+        bgc.strain = strain_list[0]
 
 
 def map_bgc_to_gcf(bgcs: list[BGC], gcfs: list[GCF]):

--- a/src/nplinker/genomics/genomics.py
+++ b/src/nplinker/genomics/genomics.py
@@ -79,7 +79,8 @@ def map_strain_to_bgc(strains: StrainCollection, bgcs: list[BGC]):
         bgcs(list[BGC]): A list of BGC objects.
 
     Raises:
-        KeyError: Strain id not found in the strain collection.
+        ValueError: Strain id not found in the strain collection.
+        ValueError: Multiple strain objects found for a BGC id.
     """
     for bgc in bgcs:
         try:

--- a/src/nplinker/genomics/genomics.py
+++ b/src/nplinker/genomics/genomics.py
@@ -69,38 +69,25 @@ def generate_mappings_genome_id_bgc_id(
     logger.info("Generated genome-BGC mappings file: %s", output_file)
 
 
-def map_strain_to_bgc(strains: StrainCollection, bgcs: list[BGC],
-                      bgc_genome_mapping: dict[str, str]):
+def map_strain_to_bgc(strains: StrainCollection, bgcs: list[BGC]):
     """To set BGC object's strain with representative strain object.
 
     This method changes the list `bgcs` in place.
 
-    It's assumed that BGC's genome id is used as strain's name or alias, and
-    the genome id is used to lookup the representative strain.
-
     Args:
         strains(StrainCollection): A collection of all strain objects.
         bgcs(list[BGC]): A list of BGC objects.
-        bgc_genome_mapping(dict[str, str]): The mappings from BGC id (key) to
-            genome id (value).
 
     Raises:
-        KeyError: BGC id not found in the `bgc_genome_mapping` dict.
         KeyError: Strain id not found in the strain collection.
     """
     for bgc in bgcs:
         try:
-            genome_id = bgc_genome_mapping[bgc.bgc_id]
+            strain = strains.lookup(bgc.bgc_id)
         except KeyError as e:
             raise KeyError(
-                f"Not found BGC id {bgc.bgc_id} in BGC-genome mappings."
-            ) from e
-        try:
-            strain = strains.lookup(genome_id)
-        except KeyError as e:
-            raise KeyError(
-                f"Strain id {genome_id} from BGC object {bgc.bgc_id} "
-                "not found in the StrainCollection object.") from e
+                f"Strain id '{bgc.bgc_id}' from BGC object '{bgc.bgc_id}' "
+                "not found in the strain collection.") from e
         bgc.strain = strain
 
 
@@ -122,8 +109,9 @@ def map_bgc_to_gcf(bgcs: list[BGC], gcfs: list[GCF]):
             try:
                 bgc = bgc_dict[bgc_id]
             except KeyError as e:
-                raise KeyError(f"BGC id {bgc_id} from GCF object {gcf.gcf_id} "
-                               "not found in the list of BGC objects.") from e
+                raise KeyError(
+                    f"BGC id '{bgc_id}' from GCF object '{gcf.gcf_id}' "
+                    "not found in the list of BGC objects.") from e
             gcf.add_bgc(bgc)
 
 
@@ -153,6 +141,7 @@ def get_strains_from_bgcs(bgcs: list[BGC]) -> StrainCollection:
         else:
             logger.warning("Strain is None for BGC %s", bgc.bgc_id)
     return sc
+
 
 
 @deprecated(version="1.3.3", reason="It is split to separate functions: " \

--- a/src/nplinker/genomics/genomics.py
+++ b/src/nplinker/genomics/genomics.py
@@ -84,15 +84,14 @@ def map_strain_to_bgc(strains: StrainCollection, bgcs: list[BGC]):
     for bgc in bgcs:
         try:
             strain_list = strains.lookup(bgc.bgc_id)
-            if len(strain_list) > 1:
-                raise KeyError(
-                    f"Multiple strain objects found for BGC id '{bgc.bgc_id}'."
-                    f"BGC object accept only one strain."
-                )
-        except KeyError as e:
-            raise KeyError(
+        except ValueError as e:
+            raise ValueError(
                 f"Strain id '{bgc.bgc_id}' from BGC object '{bgc.bgc_id}' "
                 "not found in the strain collection.") from e
+        if len(strain_list) > 1:
+            raise ValueError(
+                f"Multiple strain objects found for BGC id '{bgc.bgc_id}'."
+                f"BGC object accept only one strain.")
         bgc.strain = strain_list[0]
 
 

--- a/src/nplinker/genomics/mibig/__init__.py
+++ b/src/nplinker/genomics/mibig/__init__.py
@@ -1,6 +1,8 @@
 import logging
 from .mibig_downloader import download_and_extract_mibig_metadata
-from .mibig_loader import MibigBGCLoader, parse_bgc_metadata_json
+from .mibig_loader import MibigLoader
+from .mibig_loader import parse_bgc_metadata_json
 from .mibig_metadata import MibigMetadata
+
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/nplinker/genomics/mibig/mibig_loader.py
+++ b/src/nplinker/genomics/mibig/mibig_loader.py
@@ -10,7 +10,7 @@ from .mibig_metadata import MibigMetadata
 logger = LogConfig.getLogger(__name__)
 
 
-class MibigBGCLoader:
+class MibigLoader:
 
     def __init__(self, data_dir: str):
         """Parse MIBiG metadata files and return BGC objects
@@ -129,4 +129,4 @@ def parse_bgc_metadata_json(file: str) -> BGC:
 
 
 # register as virtual class to prevent metaclass conflicts
-BGCLoaderBase.register(MibigBGCLoader)
+BGCLoaderBase.register(MibigLoader)

--- a/src/nplinker/genomics/mibig/mibig_loader.py
+++ b/src/nplinker/genomics/mibig/mibig_loader.py
@@ -26,16 +26,13 @@ class MibigLoader:
         self._metadata_dict = self._parse_metadatas()
         self._bgc_dict = self._parse_bgcs()
 
-    def get_bgc_genome_mapping(self) -> dict[str, str]:
-        """Get the mapping from BGC to genome.
+    def get_strain_bgc_mapping(self) -> dict[str, str]:
+        """Get the mapping from strain to BGC.
 
-        Note that for MIBiG BGC, same value is used for BGC id and genome id.
-        Users don't have to provide genome id for MIBiG BGCs in the
-        `strain_mappings.json` file.
+        Note that for MIBiG BGC, same value is used for strain name and BGC id.
 
         Returns:
-            dict[str, str]: key is BGC id/accession, value is
-                genome id that uses the value of BGC accession.
+            dict[str, str]: key is strain name, value is BGC id.
         """
         return {bid: bid for bid in self._file_dict}
 

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -205,6 +205,9 @@ class DatasetLoader():
 
     def _start_downloads(self):
         downloader = PODPDownloader(self._platform_id)
+        # TODO CG: this step generates the real path for _root. Should generate
+        # it before loading process starts. Otherwise, npl.root_dir will get
+        # wrong value if loading from local data or not using download.
         self._root = Path(downloader.project_results_dir)
         logger.debug('remote loading mode, configuring root=%s', self._root)
         # CG: to download both MET and GEN data

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -9,7 +9,7 @@ from nplinker.genomics import generate_mappings_genome_id_bgc_id
 from nplinker.genomics import load_gcfs
 from nplinker.genomics.antismash import AntismashBGCLoader
 from nplinker.genomics.mibig import download_and_extract_mibig_metadata
-from nplinker.genomics.mibig import MibigBGCLoader
+from nplinker.genomics.mibig import MibigLoader
 from nplinker.globals import GENOME_BGC_MAPPINGS_FILENAME
 from nplinker.globals import GENOME_STATUS_FILENAME
 from nplinker.globals import GNPS_FILE_MAPPINGS_FILENAME
@@ -426,7 +426,7 @@ class DatasetLoader():
         # and update self.strains with mibig strains
         #----------------------------------------------------------------------
         logger.debug(f'MibigBGCLoader({self.mibig_json_dir})')
-        mibig_bgc_loader = MibigBGCLoader(self.mibig_json_dir)
+        mibig_bgc_loader = MibigLoader(self.mibig_json_dir)
         self.mibig_bgc_dict = mibig_bgc_loader.get_bgcs()
 
         # add mibig bgc strains

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -28,6 +28,7 @@ from nplinker.pairedomics.strain_mappings_generator import \
 from nplinker.strain_collection import StrainCollection
 from nplinker.strains import Strain
 
+
 try:
     from importlib.resources import files
 except ImportError:
@@ -564,13 +565,14 @@ class DatasetLoader():
             for line_num, sid in enumerate(strain_list):
                 sid = sid.strip()  # get rid of newline
                 try:
-                    strain_obj = self.strains.lookup(sid)
+                    strain_ref_list = self.strains.lookup(sid)
                 except KeyError:
                     logger.warning(
                         'Line {} of {}: invalid/unknown strain ID "{}"'.format(
                             line_num + 1, self.include_strains_file, sid))
                     continue
-                self.include_only_strains.add(strain_obj)
+                for strain in strain_ref_list:
+                    self.include_only_strains.add(strain)
             logger.debug('Found {} strain IDs in include_strains'.format(
                 len(self.include_only_strains)))
 

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -484,19 +484,6 @@ class DatasetLoader():
         return True
 
     def _load_genomics_extra(self):
-        if not os.path.exists(self.mibig_json_dir):
-            if self._use_mibig:
-                logger.info(
-                    'Attempting to download MiBIG JSON database (v{})...'.
-                    format(self._mibig_version))
-                download_and_extract_mibig_metadata(self._root,
-                                                    self.mibig_json_dir,
-                                                    self._mibig_version)
-            else:
-                logger.warning(
-                    'Not downloading MiBIG database automatically, use_mibig = false'
-                )
-
         if not os.path.exists(self.bigscape_dir):
             should_run_bigscape = self._config_docker.get(
                 'run_bigscape', self.RUN_BIGSCAPE_DEFAULT)

--- a/src/nplinker/metabolomics/gnps/gnps_file_mapping_loader.py
+++ b/src/nplinker/metabolomics/gnps/gnps_file_mapping_loader.py
@@ -26,6 +26,7 @@ class GNPSFileMappingLoader(FileMappingLoaderBase):
             NotImplementedError: Raises NotImplementedError if the GNPS format is not recognized.
         """
         self._file: Path = Path(file)
+        # TODO CG: change list to set to avoid duplicates of spectra
         self._mapping: dict[str, list[str]] = {}
         self._gnps_format = gnps_format_from_file_mapping(file, False)
 

--- a/src/nplinker/metabolomics/molecular_family.py
+++ b/src/nplinker/metabolomics/molecular_family.py
@@ -31,11 +31,11 @@ class MolecularFamily():
                 strains.add(strain)
         return strains
 
-    def has_strain(self, strain: str | Strain) -> bool:
+    def has_strain(self, strain: Strain) -> bool:
         """Check if the given strain exists.
 
         Args:
-            strain(str | Strain): strain id or `Strain` object.
+            strain(Strain): `Strain` object.
 
         Returns:
             bool: True when the given strain exist.

--- a/src/nplinker/metabolomics/spectrum.py
+++ b/src/nplinker/metabolomics/spectrum.py
@@ -1,5 +1,6 @@
 
 from nplinker.strain_collection import StrainCollection
+from nplinker.strains import Strain
 from nplinker.utils import sqrt_normalise
 
 
@@ -97,7 +98,7 @@ class Spectrum():
         val = self.metadata.get(key, None)
         return val
 
-    def has_strain(self, strain):
+    def has_strain(self, strain: Strain):
         return strain in self.strains
 
     def get_growth_medium(self, strain):

--- a/src/nplinker/nplinker.py
+++ b/src/nplinker/nplinker.py
@@ -263,14 +263,8 @@ class NPLinker():
                 return False
         else:
             # CG: only reload genomics data when changing bigscape cutoff
-            # TODO: this part should be removed, reload everything if bigscape data changes.
-            # 1. change the cutoff (which by itself doesn't do anything)
             self._loader._bigscape_cutoff = new_bigscape_cutoff
-            # 2. reload the strain mappings (MiBIG filtering may have removed strains
-            # that were originally present, need to restore them all so the filtering
-            # won't break when it runs again in next stage)
-            self._loader._load_strain_mappings()
-            # 3. reload the genomics data with the new cutoff applied
+            # TODO: only need to reload gcfs using load_gcfs()
             self._loader._load_genomics()
 
         self._spectra = self._loader.spectra

--- a/src/nplinker/pairedomics/strain_mappings_generator.py
+++ b/src/nplinker/pairedomics/strain_mappings_generator.py
@@ -97,7 +97,7 @@ def podp_generate_strain_mappings(
     # Create StrainCollection
     sc = StrainCollection()
     for strain_id, bgc_ids in mappings.items():
-        if strain_id not in sc:
+        if not sc.has_name(strain_id):
             strain = Strain(strain_id)
             for bgc_id in bgc_ids:
                 strain.add_alias(bgc_id)

--- a/src/nplinker/pairedomics/strain_mappings_generator.py
+++ b/src/nplinker/pairedomics/strain_mappings_generator.py
@@ -103,9 +103,10 @@ def podp_generate_strain_mappings(
                 strain.add_alias(bgc_id)
             sc.add(strain)
         else:
-            strain = sc.lookup(strain_id)
+            # strain_list has only one element
+            strain_list = sc.lookup(strain_id)
             for bgc_id in bgc_ids:
-                strain.add_alias(bgc_id)
+                strain_list[0].add_alias(bgc_id)
 
     # Write strain mappings JSON file
     sc.to_json(output_json_file)

--- a/src/nplinker/scoring/linking/data_links.py
+++ b/src/nplinker/scoring/linking/data_links.py
@@ -149,8 +149,8 @@ class DataLinks():
                 if filter_no_shared and len(shared_strains) == 0:
                     continue
                 results[(obj, gcf)] = [
-                    self._strains.lookup(strain_id)
-                    for strain_id in shared_strains
+                    strain for strain_id in shared_strains
+                    for strain in self._strains.lookup(strain_id)
                 ]
         return results
 

--- a/src/nplinker/strain_collection.py
+++ b/src/nplinker/strain_collection.py
@@ -87,6 +87,17 @@ class StrainCollection():
             if strain not in strain_set:
                 self.remove(strain)
 
+    def has_name(self, name: str) -> bool:
+        """Check if the strain collection contains the given strain name (id or alias).
+
+        Args:
+            name(str): Strain name (id or alias) to check.
+
+        Returns:
+            bool: True if the strain name is in the collection, False otherwise.
+        """
+        return name in self._strain_dict_name
+
     def lookup(self, name: str) -> Strain:
         """Lookup a strain by name (id or alias).
 

--- a/src/nplinker/strain_collection.py
+++ b/src/nplinker/strain_collection.py
@@ -14,9 +14,9 @@ class StrainCollection():
 
     def __init__(self):
         """A collection of Strain objects."""
+        # the order of strains is needed for scoring part, so use a list
         self._strains: list[Strain] = []
-        # dict of strain name (id and alias) to primary strain object
-        self._strain_dict_name: dict[str, Strain] = {}
+        self._strain_dict_name: dict[str, list[Strain]] = {}
 
     def __repr__(self) -> str:
         return str(self)
@@ -55,28 +55,46 @@ class StrainCollection():
         Args:
             strain(Strain): The strain to add.
         """
-        # if the strain exists, merge the aliases
-        if strain.id in self._strain_dict_name:
-            existing: Strain = self.lookup(strain.id)
-            for alias in strain.aliases:
-                existing.add_alias(alias)
-                self._strain_dict_name[alias] = existing
+        if strain in self._strains:
+            # only one strain object per id
+            strain_ref = self._strain_dict_name[strain.id][0]
+            new_aliases = [alias for alias in strain.aliases if alias not in strain_ref.aliases]
+            for alias in new_aliases:
+                strain_ref.add_alias(alias)
+                if alias not in self._strain_dict_name:
+                    self._strain_dict_name[alias] = [strain_ref]
+                else:
+                    self._strain_dict_name[alias].append(strain_ref)
         else:
             self._strains.append(strain)
-            self._strain_dict_name[strain.id] = strain
-            for alias in strain.aliases:
-                self._strain_dict_name[alias] = strain
+            for name in strain.names:
+                if name not in self._strain_dict_name:
+                    self._strain_dict_name[name] = [strain]
+                else:
+                    self._strain_dict_name[name].append(strain)
 
     def remove(self, strain: Strain):
         """Remove a strain from the collection.
 
+        It removes the given strain object from the collection by strain id.
+        If the strain id is not found, it does nothing.
+
         Args:
             strain(Strain): The strain to remove.
         """
-        if strain.id in self._strain_dict_name:
+        if strain in self._strains:
             self._strains.remove(strain)
-            for name in strain.names:
-                del self._strain_dict_name[name]
+            # only one strain object per id
+            strain_ref = self._strain_dict_name[strain.id][0]
+            for name in strain_ref.names:
+                if name in self._strain_dict_name:
+                    new_strain_list = [
+                        s for s in self._strain_dict_name[name] if s.id != strain.id
+                    ]
+                    if not new_strain_list:
+                        del self._strain_dict_name[name]
+                    else:
+                        self._strain_dict_name[name] = new_strain_list
 
     def filter(self, strain_set: set[Strain]):
         """
@@ -98,7 +116,7 @@ class StrainCollection():
         """
         return name in self._strain_dict_name
 
-    def lookup(self, name: str) -> Strain:
+    def lookup(self, name: str) -> list[Strain]:
         """Lookup a strain by name (id or alias).
 
         Args:
@@ -106,7 +124,7 @@ class StrainCollection():
             name(str): Strain name (id or alias) to lookup.
 
         Returns:
-            Strain: Strain identified by the given name.
+            list[Strain]: List of Strain objects with the given name.
 
         Raises:
             KeyError: If the strain name is not found.

--- a/src/nplinker/strain_collection.py
+++ b/src/nplinker/strain_collection.py
@@ -1,14 +1,10 @@
 import json
 from os import PathLike
-from pathlib import Path
 from typing import Iterator
-from deprecated import deprecated
 from jsonschema import validate
 from nplinker.schemas import STRAIN_MAPPINGS_SCHEMA
 from .logconfig import LogConfig
 from .strains import Strain
-from .utils import list_dirs
-from .utils import list_files
 
 
 logger = LogConfig.getLogger(__name__)
@@ -41,16 +37,12 @@ class StrainCollection():
                     and self._strain_dict_name == other._strain_dict_name)
         return NotImplemented
 
-    def __contains__(self, item: str | Strain) -> bool:
-        """Check if the strain collection contains the given strain.
-
-        The given strain could be a Strain object, or a strain id or alias.
+    def __contains__(self, item: Strain) -> bool:
+        """Check if the strain collection contains the given Strain object.
         """
-        if isinstance(item, str):
-            return item in self._strain_dict_name
         if isinstance(item, Strain):
             return item.id in self._strain_dict_name
-        raise TypeError(f"Expected Strain or str, got {type(item)}")
+        raise TypeError(f"Expected Strain, got {type(item)}")
 
     def __iter__(self) -> Iterator[Strain]:
         return iter(self._strains)
@@ -83,9 +75,8 @@ class StrainCollection():
         """
         if strain.id in self._strain_dict_name:
             self._strains.remove(strain)
-            del self._strain_dict_name[strain.id]
-            for alias in strain.aliases:
-                del self._strain_dict_name[alias]
+            for name in strain.names:
+                del self._strain_dict_name[name]
 
     def filter(self, strain_set: set[Strain]):
         """
@@ -109,7 +100,7 @@ class StrainCollection():
         Raises:
             KeyError: If the strain name is not found.
         """
-        if name in self:
+        if name in self._strain_dict_name:
             return self._strain_dict_name[name]
         raise KeyError(f"Strain {name} not found in strain collection.")
 

--- a/src/nplinker/strain_collection.py
+++ b/src/nplinker/strain_collection.py
@@ -77,10 +77,13 @@ class StrainCollection():
         """Remove a strain from the collection.
 
         It removes the given strain object from the collection by strain id.
-        If the strain id is not found, it does nothing.
+        If the strain id is not found, raise ValueError.
 
         Args:
             strain(Strain): The strain to remove.
+
+        Raises:
+            ValueError: If the strain is not found in the collection.
         """
         if strain in self._strains:
             self._strains.remove(strain)
@@ -95,6 +98,8 @@ class StrainCollection():
                         del self._strain_dict_name[name]
                     else:
                         self._strain_dict_name[name] = new_strain_list
+        else:
+            raise ValueError(f"Strain {strain} not found in strain collection.")
 
     def filter(self, strain_set: set[Strain]):
         """

--- a/src/nplinker/strain_collection.py
+++ b/src/nplinker/strain_collection.py
@@ -127,11 +127,11 @@ class StrainCollection():
             list[Strain]: List of Strain objects with the given name.
 
         Raises:
-            KeyError: If the strain name is not found.
+            ValueError: If the strain name is not found.
         """
         if name in self._strain_dict_name:
             return self._strain_dict_name[name]
-        raise KeyError(f"Strain {name} not found in strain collection.")
+        raise ValueError(f"Strain {name} not found in the strain collection.")
 
     @staticmethod
     def read_json(file: str | PathLike) -> 'StrainCollection':

--- a/src/nplinker/strains.py
+++ b/src/nplinker/strains.py
@@ -44,6 +44,15 @@ class Strain():
         return alias in self._aliases
 
     @property
+    def names(self) -> set[str]:
+        """Get the set of strain names including id and aliases.
+
+        Returns:
+            set[str]: A set of names associated with the strain.
+        """
+        return self._aliases | {self.id}
+
+    @property
     def aliases(self) -> set[str]:
         """Get the set of known aliases.
 

--- a/tests/genomics/test_gcf.py
+++ b/tests/genomics/test_gcf.py
@@ -55,8 +55,8 @@ def test_add_bgc_wo_strain(bgc_without_strain, caplog):
 def test_has_strain(bgc_with_strain):
     gcf = GCF("1")
     gcf.add_bgc(bgc_with_strain)
-    assert gcf.has_strain("strain001") is True
-    assert gcf.has_strain("strain002") is False
+    assert gcf.has_strain(Strain("strain001")) is True
+    assert gcf.has_strain(Strain("strain002")) is False
 
 def test_has_mibig_only():
     mibig_bgc = BGC("BGC0000001", "NPR")

--- a/tests/genomics/test_genomics.py
+++ b/tests/genomics/test_genomics.py
@@ -73,121 +73,106 @@ def test_generate_mappings_genome_id_bgc_id_empty_dir(tmp_path, caplog):
 @pytest.fixture
 def strain_collection() -> StrainCollection:
     sc = StrainCollection()
-    sc.add(Strain("G-SAMPLE0001"))
 
-    strain = Strain("S-EXAMPLE002")
-    strain.add_alias("G-SAMPLE0002")
+    strain = Strain("STRAIN_01")
+    strain.add_alias("BGC_01")
     sc.add(strain)
 
-    sc.add(Strain("BGC0000001"))
-    sc.add(Strain("BGC0000002"))
+    strain = Strain("STRAIN_02")
+    strain.add_alias("BGC_02")
+    strain.add_alias("BGC_02_1")
+    sc.add(strain)
+
+    strain = Strain("SAMPLE_BGC_03")
+    sc.add(strain)
+
     return sc
-
-
-@pytest.fixture
-def bgc_genome_mapping() -> dict[str, str]:
-    return {
-        "SAMPLE0001": "G-SAMPLE0001",
-        "SAMPLE0002": "G-SAMPLE0002",
-        "BGC0000001": "BGC0000001",
-        "BGC0000002": "BGC0000002"
-    }
 
 
 @pytest.fixture
 def bgc_list() -> list[BGC]:
     return [
-        BGC("SAMPLE0001", "NPR"),
-        BGC("SAMPLE0002", "Alkaloid"),
-        BGC("BGC0000001", "Polyketide"),
-        BGC("BGC0000002", "Terpene")
+        BGC("BGC_01", "NPR"),
+        BGC("BGC_02", "Alkaloid"),
+        BGC("SAMPLE_BGC_03", "Polyketide")
     ]
 
 
 @pytest.fixture
 def gcf_list() -> list[GCF]:
     gcf1 = GCF("1")
-    gcf1.bgc_ids |= set(("SAMPLE0001", "SAMPLE0002"))
+    gcf1.bgc_ids |= {"BGC_01"}
     gcf2 = GCF("2")
-    gcf2.bgc_ids |= set(("BGC0000001", "BGC0000002"))
+    gcf2.bgc_ids |= {"BGC_02", "SAMPLE_BGC_03"}
     return [gcf1, gcf2]
 
 
 @pytest.fixture
 def gcf_list_error() -> list[GCF]:
     gcf1 = GCF("1")
-    gcf1.bgc_ids |= set(("SAMPLE0001", "SAMPLE0003"))
+    gcf1.bgc_ids |= {"SAMPLE_BGC_03", "BGC_04"}
     return [gcf1]
 
 
-def test_map_strain_to_bgc(strain_collection, bgc_list, bgc_genome_mapping):
+def test_map_strain_to_bgc(strain_collection, bgc_list):
     for bgc in bgc_list:
         assert bgc.strain is None
-    map_strain_to_bgc(strain_collection, bgc_list, bgc_genome_mapping)
+    map_strain_to_bgc(strain_collection, bgc_list)
     for bgc in bgc_list:
         assert bgc.strain is not None
-    assert bgc_list[0].strain.id == "G-SAMPLE0001"
-    assert bgc_list[1].strain.id == "S-EXAMPLE002"
-    assert bgc_list[2].strain.id == "BGC0000001"
-    assert bgc_list[3].strain.id == "BGC0000002"
+    assert bgc_list[0].strain.id == "STRAIN_01"
+    assert bgc_list[1].strain.id == "STRAIN_02"
+    assert bgc_list[2].strain.id == "SAMPLE_BGC_03"
 
 
 def test_map_strain_to_bgc_error(strain_collection):
-    bgc_genome_mapping = {"SAMPLE0003": "G-SAMPLE0003"}
-    bgcs = [BGC("BGC0000003", ["Polyketide"])]
+    bgcs = [BGC("BGC_04", "NPR")]
     with pytest.raises(KeyError) as e:
-        map_strain_to_bgc(strain_collection, bgcs, bgc_genome_mapping)
-    assert "Not found BGC id BGC0000003 in BGC-genome mappings." in e.value.args[
-        0]
-
-    bgcs = [BGC("SAMPLE0003", ["NPR"])]
-    with pytest.raises(KeyError) as e:
-        map_strain_to_bgc(strain_collection, bgcs, bgc_genome_mapping)
-    assert "Strain id G-SAMPLE0003 from BGC object SAMPLE0003 not found" in e.value.args[
+        map_strain_to_bgc(strain_collection, bgcs)
+    assert "Strain id 'BGC_04' from BGC object 'BGC_04' not found" in e.value.args[
         0]
 
 
 def test_map_bgc_to_gcf(bgc_list, gcf_list):
-    assert gcf_list[0].bgc_ids == set(("SAMPLE0001", "SAMPLE0002"))
-    assert gcf_list[1].bgc_ids == set(("BGC0000001", "BGC0000002"))
+    assert gcf_list[0].bgc_ids == {"BGC_01"}
+    assert gcf_list[1].bgc_ids == {"BGC_02", "SAMPLE_BGC_03"}
     assert len(gcf_list[0].bgcs) == 0
     assert len(gcf_list[1].bgcs) == 0
     map_bgc_to_gcf(bgc_list, gcf_list)
-    assert gcf_list[0].bgc_ids == set(("SAMPLE0001", "SAMPLE0002"))
-    assert gcf_list[1].bgc_ids == set(("BGC0000001", "BGC0000002"))
-    assert len(gcf_list[0].bgcs) == 2
+    assert gcf_list[0].bgc_ids == {"BGC_01"}
+    assert gcf_list[1].bgc_ids == {"BGC_02", "SAMPLE_BGC_03"}
+    assert len(gcf_list[0].bgcs) == 1
     assert len(gcf_list[1].bgcs) == 2
-    assert gcf_list[0].bgcs == set(bgc_list[:2])
-    assert gcf_list[1].bgcs == set(bgc_list[2:])
+    assert gcf_list[0].bgcs == set(bgc_list[:1])
+    assert gcf_list[1].bgcs == set(bgc_list[1:])
 
 
 def test_map_bgc_to_gcf_error(bgc_list, gcf_list_error):
-    assert gcf_list_error[0].bgc_ids == set(("SAMPLE0001", "SAMPLE0003"))
+    assert gcf_list_error[0].bgc_ids == {"SAMPLE_BGC_03", "BGC_04"}
     assert len(gcf_list_error[0].bgcs) == 0
     with pytest.raises(KeyError) as e:
         map_bgc_to_gcf(bgc_list, gcf_list_error)
-    assert "BGC id SAMPLE0003 from GCF object 1 not found" in e.value.args[0]
+    assert "BGC id 'BGC_04' from GCF object '1' not found" in e.value.args[0]
 
 
 def test_filter_mibig_only_gcf(bgc_list, gcf_list):
     map_bgc_to_gcf(bgc_list, gcf_list)
     gcfs = filter_mibig_only_gcf(gcf_list)
     assert len(gcfs) == 1
-    assert gcfs[0].gcf_id == "1"
+    assert gcfs[0].gcf_id == "2"
 
 
 def test_get_bgcs_from_gcfs(bgc_list, gcf_list):
     map_bgc_to_gcf(bgc_list, gcf_list)
     bgcs = get_bgcs_from_gcfs(gcf_list)
     assert isinstance(bgcs, list)
-    assert len(bgcs) == 4
+    assert len(bgcs) == 3
     for i in bgcs:
         assert isinstance(i, BGC)
 
 
-def test_get_strains_from_bgcs(strain_collection, bgc_list,
-                               bgc_genome_mapping):
-    map_strain_to_bgc(strain_collection, bgc_list, bgc_genome_mapping)
+def test_get_strains_from_bgcs(strain_collection, bgc_list):
+    map_strain_to_bgc(strain_collection, bgc_list)
     strains = get_strains_from_bgcs(bgc_list)
     assert isinstance(strains, StrainCollection)
     assert strains == strain_collection

--- a/tests/genomics/test_genomics.py
+++ b/tests/genomics/test_genomics.py
@@ -127,7 +127,7 @@ def test_map_strain_to_bgc(strain_collection, bgc_list):
 
 def test_map_strain_to_bgc_error(strain_collection):
     bgcs = [BGC("BGC_04", "NPR")]
-    with pytest.raises(KeyError) as e:
+    with pytest.raises(ValueError) as e:
         map_strain_to_bgc(strain_collection, bgcs)
     assert "Strain id 'BGC_04' from BGC object 'BGC_04' not found" in e.value.args[
         0]

--- a/tests/genomics/test_mibig_loader.py
+++ b/tests/genomics/test_mibig_loader.py
@@ -3,7 +3,7 @@ import pytest
 from nplinker.genomics import BGC
 from nplinker.genomics import BGCLoaderBase
 from nplinker.genomics.mibig import download_and_extract_mibig_metadata
-from nplinker.genomics.mibig import MibigBGCLoader
+from nplinker.genomics.mibig import MibigLoader
 from nplinker.genomics.mibig import parse_bgc_metadata_json
 from nplinker.genomics.mibig.mibig_metadata import MibigMetadata
 from .. import DATA_DIR
@@ -22,11 +22,11 @@ class TestMibigBGCLoader:
 
     @pytest.fixture
     def loader(self, data_dir):
-        loader = MibigBGCLoader(data_dir)
+        loader = MibigLoader(data_dir)
         yield loader
 
     def test_abc(self, loader):
-        assert issubclass(MibigBGCLoader, BGCLoaderBase)
+        assert issubclass(MibigLoader, BGCLoaderBase)
         assert isinstance(loader, BGCLoaderBase)
 
     def test_init(self, loader, data_dir):
@@ -49,7 +49,7 @@ class TestMibigBGCLoader:
         assert os.path.exists(files["BGC0000001"])
 
     def test_parse_data_dir(self, data_dir):
-        files = MibigBGCLoader.parse_data_dir(data_dir)
+        files = MibigLoader.parse_data_dir(data_dir)
         assert isinstance(files, dict)
         assert len(files) == 2502  # MIBiG v3.1 has 2502 BGCs
         assert "BGC0000001" in files

--- a/tests/genomics/test_mibig_loader.py
+++ b/tests/genomics/test_mibig_loader.py
@@ -32,8 +32,8 @@ class TestMibigBGCLoader:
     def test_init(self, loader, data_dir):
         assert loader.data_dir == data_dir
 
-    def test_get_bgc_genome_mapping(self, loader):
-        mapping = loader.get_bgc_genome_mapping()
+    def test_get_strain_bgc_mapping(self, loader):
+        mapping = loader.get_strain_bgc_mapping()
         assert isinstance(mapping, dict)
         assert len(mapping) == 2502
         for bid in mapping:

--- a/tests/test_strain.py
+++ b/tests/test_strain.py
@@ -26,10 +26,16 @@ def test_hash(strain: Strain):
     assert hash(strain) == hash("strain_1")
 
 
+def test_names(strain: Strain):
+    assert strain.names == {"strain_1", "strain_1_a"}
+
+
 def test_alias(strain: Strain):
     assert len(strain.aliases) == 1
+    assert "strain_1_a" in strain.aliases
 
 
 def test_add_alias(strain: Strain):
     strain.add_alias("strain_1_b")
     assert len(strain.aliases) == 2
+    assert "strain_1_b" in strain.aliases

--- a/tests/test_strain_collection.py
+++ b/tests/test_strain_collection.py
@@ -31,10 +31,8 @@ def test_eq(collection: StrainCollection, strain: Strain):
 
 def test_contains(collection: StrainCollection, strain: Strain):
     assert strain in collection
-    assert strain.id in collection
-    for alias in strain.aliases:
-        assert alias in collection
-    assert "strain_not_exist" not in collection
+    strain2 = Strain("strain_2")
+    assert strain2 not in collection
 
 
 def test_iter(collection: StrainCollection, strain: Strain):
@@ -46,31 +44,25 @@ def test_add(strain: Strain):
     sut = StrainCollection()
     sut.add(strain)
     assert strain in sut
-    for alias in strain.aliases:
-        assert alias in sut
+    for name in strain.names:
+        assert name in sut._strain_dict_name
 
 
 def test_remove(collection: StrainCollection, strain: Strain):
-    assert strain in collection
     collection.remove(strain)
-    with pytest.raises(KeyError):
-        _ = collection._strain_dict_name[strain.id]
     assert strain not in collection
 
 
 def test_filter(collection: StrainCollection, strain: Strain):
-    assert strain in collection
     collection.add(Strain("strain_2"))
     collection.filter({strain})
-    assert strain in collection
-    assert "strain_2" not in collection
+    assert "strain_2" not in collection._strain_dict_name
     assert len(collection) == 1
 
 
 def test_lookup(collection: StrainCollection, strain: Strain):
-    assert collection.lookup(strain.id) == strain
-    for alias in strain.aliases:
-        assert collection.lookup(alias) == strain
+    for name in strain.names:
+        assert collection.lookup(name) == strain
     with pytest.raises(KeyError):
         collection.lookup("strain_not_exist")
 
@@ -85,7 +77,8 @@ def json_file(tmp_path):
             "strain_id": "strain_2",
             "strain_alias": ["alias_3", "alias_4"]
         }],
-        "version": "1.0"
+        "version":
+        "1.0"
     }
     file_path = tmp_path / "test.json"
     with open(file_path, "w") as f:

--- a/tests/test_strain_collection.py
+++ b/tests/test_strain_collection.py
@@ -43,14 +43,84 @@ def test_iter(collection: StrainCollection, strain: Strain):
 def test_add(strain: Strain):
     sut = StrainCollection()
     sut.add(strain)
+    assert len(sut) == 1
     assert strain in sut
     for name in strain.names:
         assert name in sut._strain_dict_name
 
 
-def test_remove(collection: StrainCollection, strain: Strain):
+def test_add_same_id_same_alias(strain: Strain, collection: StrainCollection):
+    collection.add(strain)
+    assert strain in collection
+    assert len(collection) == 1
+    assert len(collection._strain_dict_name) == 2
+
+
+def test_add_same_id_different_alias(collection: StrainCollection):
+    strain = Strain("strain_1")
+    strain.add_alias("strain_1_b")
+    collection.add(strain)
+    assert len(collection) == 1
+    assert strain in collection
+    assert len(collection._strain_dict_name) == 3
+    assert collection._strain_dict_name["strain_1"] == [strain]
+    assert collection._strain_dict_name["strain_1_b"] == [strain]
+
+
+def test_add_different_id_same_alias(strain: Strain,
+                                     collection: StrainCollection):
+    strain2 = Strain("strain_2")
+    strain2.add_alias("strain_1_a")
+    collection.add(strain2)
+    assert len(collection) == 2
+    assert strain2 in collection
+    assert len(collection._strain_dict_name) == 3
+    assert collection._strain_dict_name["strain_1"] == [strain]
+    assert collection._strain_dict_name["strain_2"] == [strain2]
+    assert collection._strain_dict_name["strain_1_a"] == [strain, strain2]
+
+
+def test_add_different_id_different_alias(strain: Strain,
+                                          collection: StrainCollection):
+    strain2 = Strain("strain_2")
+    strain2.add_alias("strain_2_a")
+    collection.add(strain2)
+    assert len(collection) == 2
+    assert strain2 in collection
+    assert len(collection._strain_dict_name) == 4
+    assert collection._strain_dict_name["strain_1"] == [strain]
+    assert collection._strain_dict_name["strain_1_a"] == [strain]
+    assert collection._strain_dict_name["strain_2"] == [strain2]
+    assert collection._strain_dict_name["strain_2_a"] == [strain2]
+
+
+def test_remove(strain: Strain):
+    sc = StrainCollection()
+    sc.remove(strain)
+    assert strain not in sc
+
+
+def test_remove_same_id_same_alias(collection: StrainCollection,
+                                   strain: Strain):
     collection.remove(strain)
     assert strain not in collection
+
+
+def test_remove_same_id_different_alias(collection: StrainCollection):
+    strain = Strain("strain_1")
+    strain.add_alias("strain_1_b")
+    collection.remove(strain)
+    assert len(collection) == 0
+    assert strain not in collection
+    assert len(collection._strain_dict_name) == 0
+
+
+def test_remove_different_id(collection: StrainCollection):
+    strain = Strain("strain_2")
+    collection.remove(strain)
+    assert len(collection) == 1
+    assert strain not in collection
+    assert len(collection._strain_dict_name) == 2
 
 
 def test_filter(collection: StrainCollection, strain: Strain):
@@ -68,7 +138,7 @@ def test_has_name(collection: StrainCollection):
 
 def test_lookup(collection: StrainCollection, strain: Strain):
     for name in strain.names:
-        assert collection.lookup(name) == strain
+        assert collection.lookup(name) == [strain]
     with pytest.raises(KeyError):
         collection.lookup("strain_not_exist")
 

--- a/tests/test_strain_collection.py
+++ b/tests/test_strain_collection.py
@@ -60,6 +60,12 @@ def test_filter(collection: StrainCollection, strain: Strain):
     assert len(collection) == 1
 
 
+def test_has_name(collection: StrainCollection):
+    assert collection.has_name("strain_1")
+    assert collection.has_name("strain_1_a")
+    assert not collection.has_name("strain_2")
+
+
 def test_lookup(collection: StrainCollection, strain: Strain):
     for name in strain.names:
         assert collection.lookup(name) == strain

--- a/tests/test_strain_collection.py
+++ b/tests/test_strain_collection.py
@@ -96,7 +96,8 @@ def test_add_different_id_different_alias(strain: Strain,
 
 def test_remove(strain: Strain):
     sc = StrainCollection()
-    sc.remove(strain)
+    with pytest.raises(ValueError):
+        sc.remove(strain)
     assert strain not in sc
 
 
@@ -117,7 +118,8 @@ def test_remove_same_id_different_alias(collection: StrainCollection):
 
 def test_remove_different_id(collection: StrainCollection):
     strain = Strain("strain_2")
-    collection.remove(strain)
+    with pytest.raises(ValueError):
+        collection.remove(strain)
     assert len(collection) == 1
     assert strain not in collection
     assert len(collection._strain_dict_name) == 2

--- a/tests/test_strain_collection.py
+++ b/tests/test_strain_collection.py
@@ -139,7 +139,7 @@ def test_has_name(collection: StrainCollection):
 def test_lookup(collection: StrainCollection, strain: Strain):
     for name in strain.names:
         assert collection.lookup(name) == [strain]
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         collection.lookup("strain_not_exist")
 
 


### PR DESCRIPTION
This PR intends to refactor the loading of strain mappings for genomics part, which involves the loading of not only the strain mappings but also genomics data (e.g. BGC, GCF).

The major changes:
- Update the logics of  `DatasetLoader._load_genomics` method with newly created/refactored functions/classes
- Update the logics of `StrainCollection` methods `add`, `remove` and `lookup`
- Update or add methods to classes `GCF`, `MibigBGCLoader`, `Strain` and `StrainCollection`

Expected Failed test: `test_load_metabolomics`