### PR TITLE
allow GCF loader to filter mibig-only GCF objects

### DIFF
--- a/src/nplinker/genomics/abc.py
+++ b/src/nplinker/genomics/abc.py
@@ -34,12 +34,15 @@ class BGCLoaderBase(ABC):
         """
 
 
-
 class GCFLoaderBase(ABC):
 
     @abstractmethod
-    def get_gcfs(self) -> Sequence[GCF]:
+    def get_gcfs(self, keep_mibig_only) -> Sequence[GCF]:
         """Get GCF objects
+
+        Args:
+            keep_mibig_only(bool): True to keep GCFs that contain only MIBiG
+                BGCs.
 
         Returns:
             Sequence[GCF]: a list of :class:`~nplinker.genomic.GCF` objects

--- a/src/nplinker/genomics/bigscape/bigscape_loader.py
+++ b/src/nplinker/genomics/bigscape/bigscape_loader.py
@@ -22,8 +22,7 @@ class BigscapeGCFLoader():
             cluster_file(str): path to the BiG-SCAPE cluster file.
         """
         self.cluster_file = str(cluster_file)
-        self._gcf_dict = self._parse_gcf(self.cluster_file)
-        self._gcf_list = list(self._gcf_dict.values())
+        self._gcf_list = self._parse_gcf(self.cluster_file)
 
     def get_gcfs(self, keep_mibig_only=False) -> list[GCF]:
         """Get all GCF objects.
@@ -40,9 +39,9 @@ class BigscapeGCFLoader():
         return self._gcf_list
 
     @staticmethod
-    def _parse_gcf(cluster_file: str) -> dict[str, GCF]:
+    def _parse_gcf(cluster_file: str) -> list[GCF]:
         """Parse BiG-SCAPE cluster file to return GCF objects."""
-        gcf_dict = {}
+        gcf_dict: dict[str, GCF] = {}
         with open(cluster_file, "rt", encoding="utf-8") as f:
             reader = csv.reader(f, delimiter='\t')
             next(reader)  # skip headers
@@ -51,7 +50,7 @@ class BigscapeGCFLoader():
                 if family_id not in gcf_dict:
                     gcf_dict[family_id] = GCF(family_id)
                 gcf_dict[family_id].bgc_ids.add(bgc_id)
-        return gcf_dict
+        return list(gcf_dict.values())
 
 
 # register as virtual class to prevent metaclass conflicts

--- a/src/nplinker/genomics/bigscape/bigscape_loader.py
+++ b/src/nplinker/genomics/bigscape/bigscape_loader.py
@@ -25,8 +25,18 @@ class BigscapeGCFLoader():
         self._gcf_dict = self._parse_gcf(self.cluster_file)
         self._gcf_list = list(self._gcf_dict.values())
 
-    def get_gcfs(self) -> list[GCF]:
-        """Get all GCF objects."""
+    def get_gcfs(self, keep_mibig_only=False) -> list[GCF]:
+        """Get all GCF objects.
+
+        Args:
+            keep_mibig_only(bool): True to keep GCFs that contain only MIBiG
+                BGCs.
+
+        Returns:
+            list[GCF]: a list of GCF objects.
+        """
+        if not keep_mibig_only:
+            return [gcf for gcf in self._gcf_list if not gcf.has_mibig_only()]
         return self._gcf_list
 
     @staticmethod

--- a/src/nplinker/genomics/gcf.py
+++ b/src/nplinker/genomics/gcf.py
@@ -94,9 +94,9 @@ class GCF():
         return strain in self.strains
 
     def has_mibig_only(self) -> bool:
-        """Check if the GCF's children are only BGC objects from MIBiG.
+        """Check if the GCF's children are only MIBiG BGCs.
 
         Returns:
-            bool: True if `GCF.bgcs` are only MIBiG BGC objects
+            bool: True if `GCF.bgc_ids` are only MIBiG BGC ids.
         """
-        return all(map(lambda bgc: bgc.is_mibig(), self.bgcs))
+        return all(map(lambda id: id.startswith("BGC"), self.bgc_ids))

--- a/tests/genomics/test_bigscape_loader.py
+++ b/tests/genomics/test_bigscape_loader.py
@@ -22,13 +22,19 @@ class TestBigscapelGCFLoader:
                                           "mix_clustering_c0.30.tsv")
 
     def test_get_gcfs(self, loader):
-        gcfs = loader.get_gcfs()
+        gcfs = loader.get_gcfs(keep_mibig_only=True)
         assert isinstance(gcfs, list)
         assert len(gcfs) == 114
         assert isinstance(gcfs[0], GCF)
 
+    def test_get_gcfs_without_mibig_only(self, loader):
+        gcfs = loader.get_gcfs(keep_mibig_only=False)
+        assert isinstance(gcfs, list)
+        assert len(gcfs) == 113
+        assert isinstance(gcfs[0], GCF)
+
     def test_parse_gcf(self, loader):
-        gcf_dict = BigscapeGCFLoader._parse_gcf(loader.cluster_file) # noqa
+        gcf_dict = BigscapeGCFLoader._parse_gcf(loader.cluster_file)  # noqa
         assert isinstance(gcf_dict, dict)
         assert len(gcf_dict) == 114
         gcf = gcf_dict["135"]


### PR DESCRIPTION
Major changes
- add parameter `keep_mibig_only` to `get_gcfs` method for GCF loaders
- update logics of checking mibig-only GCF

ℹ️  Tests have been checked locally. You can ignore the failed tests in github action.