### PR TITLE
Fix download bugs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -179,7 +178,7 @@
    APPENDIX: How to apply the Apache License to your work.
 
       To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
+      boilerplate notice, with the fields enclosed by brackets "[]"
       replaced with your own identifying information. (Don't include
       the brackets!)  The text should be enclosed in the appropriate
       comment syntax for the file format. We also recommend that a
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [2022] [Netherlands eScience Center, Wageningen University & Research ]
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 NPLinker
-Copyright [2022] The Netherlands eScience Center, Wageningen University & Research
+Copyright 2022-2023 Netherlands eScience Center and Wageningen University & Research.
 
 This product includes software developed at
-The Netherlands eScience Center (https://www.esciencecenter.nl/)
+Netherlands eScience Center (https://www.esciencecenter.nl/)

--- a/src/nplinker/pairedomics/podp_antismash_downloader.py
+++ b/src/nplinker/pairedomics/podp_antismash_downloader.py
@@ -3,7 +3,6 @@ from os import PathLike
 from pathlib import Path
 import re
 import time
-from urllib.error import HTTPError
 from bs4 import BeautifulSoup
 from bs4 import NavigableString
 from bs4 import Tag
@@ -203,7 +202,7 @@ def podp_download_and_extract_antismash_data(
             if output_path.exists():
                 Path.touch(output_path / 'completed', exist_ok=True)
 
-        except HTTPError:
+        except Exception:
             gs_obj.bgc_path = ""
 
     missing = len([gs for gs in gs_dict.values() if not gs.bgc_path])

--- a/src/nplinker/pairedomics/podp_antismash_downloader.py
+++ b/src/nplinker/pairedomics/podp_antismash_downloader.py
@@ -213,7 +213,7 @@ def podp_download_and_extract_antismash_data(
     GenomeStatus.to_json(gs_dict, gs_file)
 
     if missing == len(genome_records):
-        logger.warning('Failed to successfully retrieve ANY genome data!')
+        raise ValueError("No antiSMASH data found for any genome")
 
 
 def get_best_available_genome_id(genome_id_data: dict[str, str]) -> str | None:

--- a/src/nplinker/pairedomics/strain_mappings_generator.py
+++ b/src/nplinker/pairedomics/strain_mappings_generator.py
@@ -306,7 +306,7 @@ def extract_mappings_ms_filename_spectrum_id(
         `GNPSFileMappingLoader`: A class to load GNPS file mapping TSV file.
     """
     loader = GNPSFileMappingLoader(tsv_file)
-    return loader.mapping_reversed()
+    return loader.mapping_reversed
 
 
 def get_mappings_strain_id_spectrum_id(

--- a/src/nplinker/schemas/podp_adapted_schema.json
+++ b/src/nplinker/schemas/podp_adapted_schema.json
@@ -93,17 +93,20 @@
               "GenBank_accession": {
                 "type": "string",
                 "title": "GenBank accession number",
-                "description": "If the publicly available genome got a GenBank accession number assigned, e.g., <a href=\"https://www.ncbi.nlm.nih.gov/nuccore/AL645882\" target=\"_blank\" rel=\"noopener noreferrer\">AL645882</a>, please provide it here. The genome sequence must be submitted to GenBank/ENA/DDBJ (and an accession number must be received) before this form can be filled out. In case of a whole genome sequence, please use master records. At least one identifier must be entered."
+                "description": "If the publicly available genome got a GenBank accession number assigned, e.g., <a href=\"https://www.ncbi.nlm.nih.gov/nuccore/AL645882\" target=\"_blank\" rel=\"noopener noreferrer\">AL645882</a>, please provide it here. The genome sequence must be submitted to GenBank/ENA/DDBJ (and an accession number must be received) before this form can be filled out. In case of a whole genome sequence, please use master records. At least one identifier must be entered.",
+                "minLength": 1
               },
               "RefSeq_accession": {
                 "type": "string",
                 "title": "RefSeq accession number",
-                "description": "For example: <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.ncbi.nlm.nih.gov/nuccore/NC_003888.3\">NC_003888.3</a>"
+                "description": "For example: <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://www.ncbi.nlm.nih.gov/nuccore/NC_003888.3\">NC_003888.3</a>",
+                "minLength": 1
               },
               "JGI_Genome_ID": {
                 "type": "string",
                 "title": "JGI IMG genome ID",
-                "description": "For example: <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://img.jgi.doe.gov/cgi-bin/m/main.cgi?section=TaxonDetail&page=taxonDetail&taxon_oid=641228474\">641228474</a>"
+                "description": "For example: <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://img.jgi.doe.gov/cgi-bin/m/main.cgi?section=TaxonDetail&page=taxonDetail&taxon_oid=641228474\">641228474</a>",
+                "minLength": 1
               }
             }
           },

--- a/src/nplinker/utils.py
+++ b/src/nplinker/utils.py
@@ -173,6 +173,7 @@ def download_url(url: str,
                           url,
                           follow_redirects=allow_http_redirect) as response:
             if not response.is_success:
+                fpath.unlink(missing_ok=True)
                 raise RuntimeError(
                     f"Failed to download url {url} with status code {response.status_code}"
                 )
@@ -182,7 +183,7 @@ def download_url(url: str,
                       unit_divisor=1024,
                       unit="B") as progress:
                 num_bytes_downloaded = response.num_bytes_downloaded
-                for chunk in response.iter_raw():
+                for chunk in response.iter_bytes():
                     fh.write(chunk)
                     progress.update(response.num_bytes_downloaded -
                                     num_bytes_downloaded)

--- a/tests/pairedomics/test_downloader.py
+++ b/tests/pairedomics/test_downloader.py
@@ -35,7 +35,7 @@ def test_download_metabolomics_zipfile(tmp_path):
     try:
         sut._download_metabolomics_zipfile("c22f44b14a3d450eb836d607cb9521bb")
         expected_path = os.path.join(sut.project_downloads_dir,
-                                     'c22f44b14a3d450eb836d607cb9521bb.zip')
+                                     'METABOLOMICS-SNETS-c22f44b14a3d450eb836d607cb9521bb.zip')
 
         assert os.path.exists(expected_path)
         assert (Path(sut.project_results_dir) /

--- a/tests/pairedomics/test_podp_antismash_downloader.py
+++ b/tests/pairedomics/test_podp_antismash_downloader.py
@@ -106,35 +106,41 @@ def test_genome_status_to_json_nofile():
         '"resolve_attempted": false, "bgc_path": ""}], "version": "1.0"}'
 
 
+#------------------------------------------------------------------------------
+# Note that some examples of genomme ID are used in following tests.
+# But it's not guaranteed that these IDs will be valid in the future.
+# Updates in NCBI and antiSMASH databases may cause the tests to fail, in
+# which case the IDs should be replaced with valid ones.
+#------------------------------------------------------------------------------
+
+
 # Test `podp_download_and_extract_antismash_data` function
 # with multiple records containing three types of genome IDs
 def test_multiple_records(download_root, extract_root, genome_status_file):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
-            "JGI_Genome_ID": "2515154188",
-            "RefSeq_accession": "GCF_000514875.1",
-            "GenBank_accession": "GCA_004799605.1"
+            "JGI_Genome_ID": "2515154178",
+            "RefSeq_accession": "GCF_000514775.1",
+            "GenBank_accession": "GCA_000514775.1"
         },
-        "genome_label": "Salinispora arenicola CNX508"
     }, {
         "genome_ID": {
             "genome_type": "genome",
-            "JGI_Genome_ID": "2515154177",
-            "RefSeq_accession": "GCF_000514515.1",
-            "GenBank_accession": "GCA_004799605.1"
+            "JGI_Genome_ID": "640427140",
+            "RefSeq_accession": "GCF_000016425.1",
+            "GenBank_accession": "GCA_000016425.1"
         },
-        "genome_label": "Salinispora pacifica CNT029"
     }]
 
     podp_download_and_extract_antismash_data(genome_records, download_root,
                                              extract_root)
 
-    archive1 = download_root / "GCF_000514875.1.zip"
-    extracted_folder1 = extract_root / "antismash" / "GCF_000514875.1"
+    archive1 = download_root / "GCF_000514775.1.zip"
+    extracted_folder1 = extract_root / "antismash" / "GCF_000514775.1"
     extracted_files1 = list_files(extracted_folder1, keep_parent=True)
-    archive2 = download_root / "GCF_000514515.1.zip"
-    extracted_folder2 = extract_root / "antismash" / "GCF_000514515.1"
+    archive2 = download_root / "GCF_000016425.1.zip"
+    extracted_folder2 = extract_root / "antismash" / "GCF_000016425.1"
     extracted_files2 = list_files(extracted_folder2, keep_parent=True)
     genome_status = GenomeStatus.read_json(genome_status_file)
 
@@ -158,17 +164,16 @@ def test_missing_id(download_root, extract_root, genome_status_file):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
-            "JGI_Genome_ID": "",
-            "RefSeq_accession": ""
+            "JGI_Genome_ID": "2515154188",
+            "RefSeq_accession": "GCF_000514875.1"
         },
-        "genome_label": "Salinispora arenicola CNX508"
     }, {
         "genome_ID": {
             "genome_type": "genome",
-            "JGI_Genome_ID": "2515154177",
-            "RefSeq_accession": "GCF_000514515.1"
+            "JGI_Genome_ID": "640427140",
+            "RefSeq_accession": "GCF_000016425.1",
+            "GenBank_accession": "GCA_000016425.1"
         },
-        "genome_label": "Salinispora pacifica CNT029"
     }]
 
     podp_download_and_extract_antismash_data(genome_records, download_root,
@@ -176,15 +181,15 @@ def test_missing_id(download_root, extract_root, genome_status_file):
 
     archive1 = download_root / "GCF_000514875.1.zip"
     extracted_folder1 = extract_root / "antismash" / "GCF_000514875.1"
-    archive2 = download_root / "GCF_000514515.1.zip"
-    extracted_folder2 = extract_root / "antismash" / "GCF_000514515.1"
+    archive2 = download_root / "GCF_000016425.1.zip"
+    extracted_folder2 = extract_root / "antismash" / "GCF_000016425.1"
     genome_status = GenomeStatus.read_json(genome_status_file)
 
     assert (not archive1.exists() and archive2.exists())
     assert (not archive1.is_file() and archive2.is_file())
     assert (not extracted_folder1.exists() and extracted_folder2.exists())
     assert genome_status_file.is_file()
-    assert len(genome_status) == 1
+    assert len(genome_status) == 2
 
 
 # Test `podp_download_and_extract_antismash_data` function
@@ -193,16 +198,16 @@ def test_caching(download_root, extract_root, genome_status_file, caplog):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
-            "JGI_Genome_ID": "2515154188",
-            "RefSeq_accession": "GCF_000514875.1"
+            "JGI_Genome_ID": "640427140",
+            "RefSeq_accession": "GCF_000016425.1",
+            "GenBank_accession": "GCA_000016425.1"
         },
-        "genome_label": "Salinispora arenicola CNX508"
     }]
 
     podp_download_and_extract_antismash_data(genome_records, download_root,
                                              extract_root)
     genome_status_old = GenomeStatus.read_json(genome_status_file)
-    genome_obj = genome_status_old["GCF_000514875.1"]
+    genome_obj = genome_status_old["GCF_000016425.1"]
     assert Path(genome_obj.bgc_path).exists()
     assert genome_obj.resolve_attempted
     podp_download_and_extract_antismash_data(genome_records, download_root,
@@ -214,45 +219,36 @@ def test_caching(download_root, extract_root, genome_status_file, caplog):
 
 
 # Test `podp_download_and_extract_antismash_data` function
-# when a genome record has an which does not exists in NCBI
-def test_failed_lookup_ncbi(download_root, extract_root, genome_status_file):
+# when a genome record does not exists in NCBI
+def test_failed_lookup_ncbi(download_root, extract_root):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
             "JGI_Genome_ID": "non_existing_ID"
         },
-        "genome_label": "Salinispora arenicola CNX508"
     }]
-
-    podp_download_and_extract_antismash_data(genome_records, download_root,
-                                             extract_root)
-    genome_status = GenomeStatus.read_json(genome_status_file)
-    assert len(genome_status["non_existing_ID"].bgc_path) == 0
-    assert genome_status["non_existing_ID"].resolve_attempted
-    assert not (download_root / "non_existing_ID.zip").exists()
-    assert not (extract_root / "antismash" / "non_existing_ID").exists()
+    with pytest.raises(ValueError) as e:
+        podp_download_and_extract_antismash_data(genome_records, download_root,
+                                                 extract_root)
+    assert str(e.value) == "No antiSMASH data found for any genome"
 
 
 # Test `podp_download_and_extract_antismash_data` function
 # when a genome record has an existing accession ID in NCBI,
 # but not in the antismash database
-def test_failed_lookup_antismash(download_root, extract_root, genome_status_file):
+def test_failed_lookup_antismash(download_root, extract_root):
     broken_id = "GCF_000702345.1"
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
             "RefSeq_accession": broken_id
         },
-        "genome_label": "Salinispora arenicola CNX508"
     }]
-
-    podp_download_and_extract_antismash_data(genome_records, download_root,
-                                             extract_root)
-    genome_status = GenomeStatus.read_json(genome_status_file)
-    assert len(genome_status[broken_id].bgc_path) == 0
-    assert genome_status[broken_id].resolve_attempted
-    assert not (download_root / broken_id / ".zip").exists()
-    assert not (extract_root / "antismash" / broken_id).exists()
+    with pytest.raises(ValueError) as e:
+        podp_download_and_extract_antismash_data(genome_records, download_root,
+                                                 extract_root)
+    assert "No antiSMASH data found for any genome" == str(e.value)
+    assert str(e.value) == "No antiSMASH data found for any genome"
 
 
 # Test `podp_download_and_extract_antismash_data` function
@@ -261,16 +257,15 @@ def test_refseq_id(download_root, extract_root, genome_status_file):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
-            "RefSeq_accession": "GCF_000514875.1"
+            "RefSeq_accession": "GCF_000016425.1"
         },
-        "genome_label": "Salinispora arenicola CNX508"
     }]
 
     podp_download_and_extract_antismash_data(genome_records, download_root,
                                              extract_root)
 
     genome_status = GenomeStatus.read_json(genome_status_file)
-    genome_obj = genome_status["GCF_000514875.1"]
+    genome_obj = genome_status["GCF_000016425.1"]
     archive = download_root / Path(str(genome_obj.resolved_refseq_id) + ".zip")
     extracted_folder = extract_root / "antismash" / genome_obj.resolved_refseq_id
     extracted_files = list_files(extracted_folder, keep_parent=False)
@@ -291,16 +286,15 @@ def test_genbank_id(download_root, extract_root, genome_status_file):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
-            "GenBank_accession": "GCA_004799605.1"
+            "GenBank_accession": "GCA_000016425.1"
         },
-        "genome_label": "Halobacterium salinarum"
     }]
 
     podp_download_and_extract_antismash_data(genome_records, download_root,
                                              extract_root)
 
     genome_status = GenomeStatus.read_json(genome_status_file)
-    genome_obj = genome_status["GCA_004799605.1"]
+    genome_obj = genome_status["GCA_000016425.1"]
     archive = download_root / Path(str(genome_obj.resolved_refseq_id) + ".zip")
     extracted_folder = extract_root / "antismash" / genome_obj.resolved_refseq_id
     extracted_files = list_files(extracted_folder, keep_parent=False)
@@ -321,16 +315,15 @@ def test_jgi_id(download_root, extract_root, genome_status_file):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
-            "JGI_Genome_ID": "2506783052"
+            "JGI_Genome_ID": "640427140"
         },
-        "genome_label": "Halophilic archaeon DL31"
     }]
 
     podp_download_and_extract_antismash_data(genome_records, download_root,
                                              extract_root)
 
     genome_status = GenomeStatus.read_json(genome_status_file)
-    genome_obj = genome_status["2506783052"]
+    genome_obj = genome_status["640427140"]
     archive = download_root / Path(str(genome_obj.resolved_refseq_id) + ".zip")
     extracted_folder = extract_root / "antismash" / genome_obj.resolved_refseq_id
     extracted_files = list_files(extracted_folder, keep_parent=False)
@@ -352,16 +345,16 @@ def test_refseq_jgi_id(download_root, extract_root, genome_status_file):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
-            "RefSeq_accession": "GCF_000514875.1",
-            "JGI_Genome_ID": "2506783052"
-        }
+            "JGI_Genome_ID": "640427140",
+            "RefSeq_accession": "GCF_000016425.1",
+        },
     }]
 
     podp_download_and_extract_antismash_data(genome_records, download_root,
                                              extract_root)
 
     genome_status = GenomeStatus.read_json(genome_status_file)
-    genome_obj = genome_status["GCF_000514875.1"]
+    genome_obj = genome_status["GCF_000016425.1"]
     archive = download_root / Path(str(genome_obj.resolved_refseq_id) + ".zip")
     extracted_folder = extract_root / "antismash" / genome_obj.resolved_refseq_id
     extracted_files = list_files(extracted_folder, keep_parent=False)
@@ -383,8 +376,8 @@ def test_refseq_genbank_id(download_root, extract_root, genome_status_file):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
-            "RefSeq_accession": "GCF_000514875.1",
-            "GenBank_accession": "GCA_004799605.1"
+            "RefSeq_accession": "GCF_000016425.1",
+            "GenBank_accession": "GCA_000016425.1"
         }
     }]
 
@@ -392,7 +385,7 @@ def test_refseq_genbank_id(download_root, extract_root, genome_status_file):
                                              extract_root)
 
     genome_status = GenomeStatus.read_json(genome_status_file)
-    genome_obj = genome_status["GCF_000514875.1"]
+    genome_obj = genome_status["GCF_000016425.1"]
     archive = download_root / Path(str(genome_obj.resolved_refseq_id) + ".zip")
     extracted_folder = extract_root / "antismash" / genome_obj.resolved_refseq_id
     extracted_files = list_files(extracted_folder, keep_parent=False)
@@ -414,8 +407,8 @@ def test_genbank_jgi_id(download_root, extract_root, genome_status_file):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
-            "GenBank_accession": "GCA_004799605.1",
-            "JGI_Genome_ID": "2506783052"
+            "GenBank_accession": "GCA_000016425.1",
+            "JGI_Genome_ID": "640427140"
         }
     }]
 
@@ -423,7 +416,7 @@ def test_genbank_jgi_id(download_root, extract_root, genome_status_file):
                                              extract_root)
 
     genome_status = GenomeStatus.read_json(genome_status_file)
-    genome_obj = genome_status["GCA_004799605.1"]
+    genome_obj = genome_status["GCA_000016425.1"]
     archive = download_root / Path(str(genome_obj.resolved_refseq_id) + ".zip")
     extracted_folder = extract_root / "antismash" / genome_obj.resolved_refseq_id
     extracted_files = list_files(extracted_folder, keep_parent=False)

--- a/tests/pairedomics/test_podp_antismash_downloader.py
+++ b/tests/pairedomics/test_podp_antismash_downloader.py
@@ -159,13 +159,12 @@ def test_multiple_records(download_root, extract_root, genome_status_file):
 
 
 # Test `podp_download_and_extract_antismash_data` function
-# when a genome record has no accession IDs
-def test_missing_id(download_root, extract_root, genome_status_file):
+# when a genome record has empty genome ID (empty string).
+def test_empty_id(download_root, extract_root, genome_status_file):
     genome_records = [{
         "genome_ID": {
             "genome_type": "genome",
-            "JGI_Genome_ID": "2515154188",
-            "RefSeq_accession": "GCF_000514875.1"
+            "RefSeq_accession": ""
         },
     }, {
         "genome_ID": {
@@ -179,17 +178,15 @@ def test_missing_id(download_root, extract_root, genome_status_file):
     podp_download_and_extract_antismash_data(genome_records, download_root,
                                              extract_root)
 
-    archive1 = download_root / "GCF_000514875.1.zip"
-    extracted_folder1 = extract_root / "antismash" / "GCF_000514875.1"
-    archive2 = download_root / "GCF_000016425.1.zip"
-    extracted_folder2 = extract_root / "antismash" / "GCF_000016425.1"
+    archive = download_root / "GCF_000016425.1.zip"
+    extracted_folder = extract_root / "antismash" / "GCF_000016425.1"
     genome_status = GenomeStatus.read_json(genome_status_file)
 
-    assert (not archive1.exists() and archive2.exists())
-    assert (not archive1.is_file() and archive2.is_file())
-    assert (not extracted_folder1.exists() and extracted_folder2.exists())
+    assert archive.exists()
+    assert archive.is_file()
+    assert extracted_folder.exists()
     assert genome_status_file.is_file()
-    assert len(genome_status) == 2
+    assert len(genome_status) == 1
 
 
 # Test `podp_download_and_extract_antismash_data` function

--- a/tests/test_nplinker_local.py
+++ b/tests/test_nplinker_local.py
@@ -31,7 +31,7 @@ def npl() -> NPLinker:
     hash_proj_file = get_file_hash(
         os.path.join(npl._loader._root.parent.parent,
                      npl._loader._platform_id + '.json'))
-    if hash_proj_file != '22e4f20d6f8aa425b2040479d0b6c00e7d3deb03f8fc4a277b3b91eb07c9ad72':
+    if hash_proj_file != '97f31f13f7a4c87c0b7648e2a2bad5ab2f96c38f92c304a5dc17299b44e698c7':
         pytest.exit(
             'PoDP project file has changed, please clean your local cache folder and rerun the tests.'
         )


### PR DESCRIPTION
To fix some bugs or errors in unit tests related to downloading.

Note that unit tests of antismash downloading may fail due to the updates of NCBI or antiSMASH databases. In that case, the genome IDs used in unit tests have to be updated.

ℹ️  Tests have been checked locally. You can ignore the failed tests in github action.