### PR TITLE
Update ruff rules to ignore unused imports in `__init__.py` files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,8 @@ ignore = [
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["A", "B", "C", "D", "E", "F", "I"]
+ignore-init-module-imports = true
+
 
 [tool.ruff.isort]
 known-first-party = ["nplinker"]

--- a/src/nplinker/genomics/mibig/__init__.py
+++ b/src/nplinker/genomics/mibig/__init__.py
@@ -1,4 +1,15 @@
 import logging
+from .mibig_downloader import download_and_extract_mibig_metadata
+from .mibig_loader import MibigLoader
+from .mibig_loader import parse_bgc_metadata_json
+from .mibig_metadata import MibigMetadata
 
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+__all__ = [
+    "download_and_extract_mibig_metadata",
+    "MibigLoader",
+    "MibigMetadata",
+    "parse_bgc_metadata_json",
+]

--- a/tests/genomics/test_bigscape_loader.py
+++ b/tests/genomics/test_bigscape_loader.py
@@ -34,12 +34,8 @@ class TestBigscapelGCFLoader:
         assert isinstance(gcfs[0], GCF)
 
     def test_parse_gcf(self, loader):
-        gcf_dict = BigscapeGCFLoader._parse_gcf(loader.cluster_file)  # noqa
-        assert isinstance(gcf_dict, dict)
-        assert len(gcf_dict) == 114
-        gcf = gcf_dict["135"]
-        assert isinstance(gcf, GCF)
-        assert len(gcf.bgc_ids) == 4
-        assert gcf.bgc_ids == set(
-            ("BGC0000145", "BGC0001041", "NC_009380.1.region004", "NZ_AZWK01000002.region002")
-        )
+        gcf_list = BigscapeGCFLoader._parse_gcf(loader.cluster_file)  # noqa
+        assert isinstance(gcf_list, list)
+        assert len(gcf_list) == 114
+        for gcf in gcf_list:
+            assert isinstance(gcf, GCF)


### PR DESCRIPTION
When using ruff to automatically fix code,  it will remove all [unused imports](https://docs.astral.sh/ruff/rules/unused-import/). However, the imports in `__init__.py` might be unused if they are not used in e.g. `__all__` variable.  But we want to keep unused imports in init files. So set [ignore-init-module-imports](https://docs.astral.sh/ruff/settings/#ignore-init-module-imports)  to true in this PR.

Major changes
- add `ignore-init-module-imports = true` for ruff config
- add back unused imports that were removed with ruff fix
- fix a failed unit test that was not noticed in former PR