### PR TITLE
use list for returned type of `get_bgcs` methods of BGC loaders

### DIFF
--- a/src/nplinker/genomics/abc.py
+++ b/src/nplinker/genomics/abc.py
@@ -24,12 +24,11 @@ class BGCLoaderBase(ABC):
         """
 
     @abstractmethod
-    def get_bgcs(self) -> dict[str, BGC]:
+    def get_bgcs(self) -> Sequence[BGC]:
         """Get BGC objects.
 
         Returns:
-            dict[str, BGC]: key is BGC name and value is
-                :class:`~nplinker.genomic.BGC` objects
+            Sequence[BGC]: a list of :class:`~nplinker.genomic.BGC` objects
         """
 
 

--- a/src/nplinker/genomics/antismash/antismash_loader.py
+++ b/src/nplinker/genomics/antismash/antismash_loader.py
@@ -35,7 +35,7 @@ class AntismashBGCLoader:
         """
         self.data_dir = data_dir
         self._file_dict = self._parse_data_dir(self.data_dir)
-        self._bgc_dict = self._parse_bgcs(self._file_dict)
+        self._bgcs = self._parse_bgcs(self._file_dict)
 
     def get_bgc_genome_mapping(self) -> dict[str, str]:
         """Get the mapping from BGC to genome.
@@ -85,17 +85,16 @@ class AntismashBGCLoader:
 
         return bgc_files
 
-    def get_bgcs(self) -> dict[str, BGC]:
+    def get_bgcs(self) -> list[BGC]:
         """Get all BGC objects.
 
         Returns:
-            dict[str, BGC]: key is BGC name and value is
-                :class:`~nplinker.genomic.BGC` objects
+            list[BGC]: a list of :class:`~nplinker.genomic.BGC` objects
         """
-        return self._bgc_dict
+        return self._bgcs
 
     @staticmethod
-    def _parse_bgcs(bgc_files: dict[str, str]) -> dict[str, BGC]:
+    def _parse_bgcs(bgc_files: dict[str, str]) -> list[BGC]:
         """Load given BGC files as BGC objects.
 
         Args:
@@ -103,13 +102,9 @@ class AntismashBGCLoader:
                 BGC gbk file, see method :meth:`.bgc_files`.
 
         Returns:
-            dict[str, BGC]: key is BGC name and value is :class:`~nplinker.genomic.BGC` objects
+            list[BGC]: a list of :class:`~nplinker.genomic.BGC` objects
         """
-        bgcs = {}
-        for bgc_id in bgc_files:
-            bgc = parse_bgc_genbank(bgc_files[bgc_id])
-            bgcs[bgc_id] = bgc
-        return bgcs
+        return [parse_bgc_genbank(file) for file in bgc_files.values()]
 
 
 def parse_bgc_genbank(file: str) -> BGC:

--- a/src/nplinker/genomics/mibig/mibig_loader.py
+++ b/src/nplinker/genomics/mibig/mibig_loader.py
@@ -23,7 +23,7 @@ class MibigLoader:
         self.data_dir = data_dir
         self._file_dict = self.parse_data_dir(self.data_dir)
         self._metadata_dict = self._parse_metadatas()
-        self._bgc_dict = self._parse_bgcs()
+        self._bgcs = self._parse_bgcs()
 
     def get_strain_bgc_mapping(self) -> dict[str, str]:
         """Get the mapping from strain to BGC.
@@ -85,27 +85,21 @@ class MibigLoader:
             metadata_dict[name] = metadata
         return metadata_dict
 
-    def get_bgcs(self) -> dict[str, BGC]:
+    def get_bgcs(self) -> list[BGC]:
         """Get BGC objects.
 
         Returns:
-            dict[str, BGC]: key is BGC name and value is
-                :class:`nplinker.genomics.BGC` object
+            list[str, BGC]: a list of :class:`nplinker.genomics.BGC` objects
         """
-        return self._bgc_dict
+        return self._bgcs
 
-    def _parse_bgcs(self) -> dict[str, BGC]:
+    def _parse_bgcs(self) -> list[BGC]:
         """Parse all metadata files as BGC objects.
 
         Returns:
-            dict[str, BGC]: key is BGC accession (file name) and value is
-                BGC object
+            list[BGC]: a list of BGC objects
         """
-        bgc_dict = {}
-        for name, file in self._file_dict.items():
-            bgc = parse_bgc_metadata_json(file)
-            bgc_dict[name] = bgc
-        return bgc_dict
+        return [parse_bgc_metadata_json(file) for file in self._file_dict.values()]
 
 
 def parse_bgc_metadata_json(file: str) -> BGC:

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -431,8 +431,8 @@ class DatasetLoader:
 
         # Step 1: load all BGC objects
         logger.debug("Parsing AntiSMASH directory...")
-        antismash_bgc_dict = AntismashBGCLoader(self.antismash_dir).get_bgcs()
-        raw_bgcs = list(antismash_bgc_dict.values()) + self.mibig_bgcs)
+        antismash_bgcs = AntismashBGCLoader(self.antismash_dir).get_bgcs()
+        raw_bgcs = antismash_bgcs + self.mibig_bgcs
 
         # Step 2: load all GCF objects
         bigscape_cluster_file = (

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -122,7 +122,7 @@ class DatasetLoader:
             os.path.split(self._root)[-1] if not self._remote_loading else self._platform_id
         )
         self.bgcs, self.gcfs, self.spectra, self.molfams = [], [], [], []
-        self.mibig_bgc_dict = {}
+        self.mibig_bgcs = []
         self._mibig_strain_bgc_mapping = {}
         self.product_types = []
         self.strains = StrainCollection()
@@ -377,7 +377,7 @@ class DatasetLoader:
 
     def _load_mibig(self):
         mibig_bgc_loader = MibigLoader(self.mibig_json_dir)
-        self.mibig_bgc_dict = mibig_bgc_loader.get_bgcs()
+        self.mibig_bgcs = mibig_bgc_loader.get_bgcs()
         self._mibig_strain_bgc_mapping = mibig_bgc_loader.get_strain_bgc_mapping()
         return True
 
@@ -432,7 +432,7 @@ class DatasetLoader:
         # Step 1: load all BGC objects
         logger.debug("Parsing AntiSMASH directory...")
         antismash_bgc_dict = AntismashBGCLoader(self.antismash_dir).get_bgcs()
-        raw_bgcs = list(antismash_bgc_dict.values()) + list(self.mibig_bgc_dict.values())
+        raw_bgcs = list(antismash_bgc_dict.values()) + self.mibig_bgcs)
 
         # Step 2: load all GCF objects
         bigscape_cluster_file = (

--- a/src/nplinker/nplinker.py
+++ b/src/nplinker/nplinker.py
@@ -116,7 +116,7 @@ class NPLinker:
         self._strains = None
         self._metadata = {}
         self._molfams = []
-        self._mibig_bgc_dict = {}
+        self._mibig_bgcs = []
         self._chem_classes = None
         self._class_matches = None
 
@@ -267,7 +267,7 @@ class NPLinker:
         self._molfams = self._loader.molfams
         self._bgcs = self._loader.bgcs
         self._gcfs = self._loader.gcfs
-        self._mibig_bgc_dict = self._loader.mibig_bgc_dict
+        self._mibig_bgcs = self._loader.mibig_bgcs
         self._strains = self._loader.strains
         self._product_types = self._loader.product_types
         self._chem_classes = self._loader.chem_classes
@@ -495,8 +495,9 @@ class NPLinker:
         return self._metadata
 
     @property
-    def mibig_bgc_dict(self):
-        return self._mibig_bgc_dict
+    def mibig_bgcs(self):
+        """Get a list of all the MIBiG BGCs in the dataset."""
+        return self._mibig_bgcs
 
     @property
     def product_types(self):

--- a/tests/genomics/antismash/test_antismash_loader.py
+++ b/tests/genomics/antismash/test_antismash_loader.py
@@ -53,12 +53,9 @@ class TestAntismashBGCLoader:
 
     def test_get_bgcs(self, loader):
         bgcs = loader.get_bgcs()
-        assert isinstance(bgcs, dict)
+        assert isinstance(bgcs, list)
         assert len(bgcs) == 44
-        assert isinstance(bgcs["NZ_AZWB01000005.region001"], BGC)
-        assert isinstance(bgcs["NZ_AZWS01000001.region001"], BGC)
-        assert bgcs.get("GCF_000514855.1", "NotExist") == "NotExist"
-        assert bgcs.get("GCF_000514515.1", "NotExist") == "NotExist"
+        assert isinstance(bgcs[0], BGC)
 
 
 def test_parse_bgc_genbank():

--- a/tests/genomics/test_mibig_loader.py
+++ b/tests/genomics/test_mibig_loader.py
@@ -66,11 +66,9 @@ class TestMibigBGCLoader:
 
     def test_get_bgcs(self, loader):
         bgcs = loader.get_bgcs()
-        assert isinstance(bgcs, dict)
+        assert isinstance(bgcs, list)
         assert len(bgcs) == 2502  # MIBiG v3.1 has 2502 BGCs
-        assert "BGC0000001" in bgcs
-        assert "BGC0000246" not in bgcs
-        assert isinstance(bgcs["BGC0000001"], BGC)
+        assert isinstance(bgcs[0], BGC)
 
 
 def test_parse_bgc_metadata_json():


### PR DESCRIPTION
This PR changed the returned value of `get_bgcs` methods in BGC loaders from dict to list, making sure that methods `get_bgcs` and `get_gcfs` have consistent returned type.