### PR TITLE
Enable filtering of singleton molecular families

### DIFF
--- a/src/nplinker/metabolomics/abc.py
+++ b/src/nplinker/metabolomics/abc.py
@@ -13,9 +13,8 @@ class SpectrumLoaderBase(ABC):
 
 
 class MolecularFamilyLoaderBase(ABC):
-    @property
     @abstractmethod
-    def families(self) -> Sequence[MolecularFamily]:
+    def get_mfs(self) -> Sequence[MolecularFamily]:
         ...
 
 

--- a/src/nplinker/metabolomics/abc.py
+++ b/src/nplinker/metabolomics/abc.py
@@ -14,8 +14,17 @@ class SpectrumLoaderBase(ABC):
 
 class MolecularFamilyLoaderBase(ABC):
     @abstractmethod
-    def get_mfs(self) -> Sequence[MolecularFamily]:
-        ...
+    def get_mfs(self, keep_singleton: bool) -> Sequence[MolecularFamily]:
+        """Get MolecularFamily objects.
+
+        Args:
+            keep_singleton(bool): True to keep singleton molecular families. A
+                singleton molecular family is a molecular family that contains
+                only one spectrum.
+
+        Returns:
+            Sequence[MolecularFamily]: a list of MolecularFamily objects.
+        """
 
 
 class FileMappingLoaderBase(ABC):

--- a/src/nplinker/metabolomics/gnps/gnps_molecular_family_loader.py
+++ b/src/nplinker/metabolomics/gnps/gnps_molecular_family_loader.py
@@ -38,8 +38,7 @@ class GNPSMolecularFamilyLoader(MolecularFamilyLoaderBase):
         self._validate()
         self._load()
 
-    @property
-    def families(self) -> list[MolecularFamily]:
+    def get_mfs(self) -> list[MolecularFamily]:
         """Get all molecular families.
 
         Returns:

--- a/src/nplinker/metabolomics/gnps/gnps_molecular_family_loader.py
+++ b/src/nplinker/metabolomics/gnps/gnps_molecular_family_loader.py
@@ -38,14 +38,22 @@ class GNPSMolecularFamilyLoader(MolecularFamilyLoaderBase):
         self._validate()
         self._load()
 
-    def get_mfs(self) -> list[MolecularFamily]:
-        """Get all molecular families.
+    def get_mfs(self, keep_singleton: bool = False) -> list[MolecularFamily]:
+        """Get MolecularFamily objects.
+
+        Args:
+            keep_singleton(bool): True to keep singleton molecular families. A
+                singleton molecular family is a molecular family that contains
+                only one spectrum.
 
         Returns:
-            list[MolecularFamily]: List of all molecular family objects with
-                their spectra ids.
+            list[MolecularFamily]: A list of MolecularFamily objects with their
+                spectra ids.
         """
-        return self._mfs
+        mfs = self._mfs
+        if not keep_singleton:
+            mfs = [mf for mf in mfs if not mf.is_singleton()]
+        return mfs
 
     def _validate(self):
         """Validate the GNPS molecular family file."""

--- a/src/nplinker/metabolomics/gnps/gnps_molecular_family_loader.py
+++ b/src/nplinker/metabolomics/gnps/gnps_molecular_family_loader.py
@@ -32,7 +32,7 @@ class GNPSMolecularFamilyLoader(MolecularFamilyLoaderBase):
             >>> print(loader.families[0].spectra_ids)
             {'1', '3', '7', ...}
         """
-        self._families: list[MolecularFamily | SingletonFamily] = []
+        self._mfs: list[MolecularFamily | SingletonFamily] = []
         self._file = file
 
         self._validate()
@@ -46,7 +46,7 @@ class GNPSMolecularFamilyLoader(MolecularFamilyLoaderBase):
             list[MolecularFamily]: List of all molecular family objects with
                 their spectra ids.
         """
-        return self._families
+        return self._mfs
 
     def _validate(self):
         """Validate the GNPS molecular family file."""
@@ -93,8 +93,8 @@ class GNPSMolecularFamilyLoader(MolecularFamilyLoaderBase):
                 for spectrum_id in spectra_ids:
                     family = SingletonFamily()  ## uuid as family id
                     family.spectra_ids = set([spectrum_id])
-                    self._families.append(family)
+                    self._mfs.append(family)
             else:
                 family = MolecularFamily(family_id)
                 family.spectra_ids = spectra_ids
-                self._families.append(family)
+                self._mfs.append(family)

--- a/tests/metabolomics/test_gnps_molecular_family_loader.py
+++ b/tests/metabolomics/test_gnps_molecular_family_loader.py
@@ -9,7 +9,7 @@ from nplinker.metabolomics.gnps import GNPSMolecularFamilyLoader
 )
 def test_has_molecular_families(workflow, num_families, num_spectra, gnps_mf_files):
     loader = GNPSMolecularFamilyLoader(gnps_mf_files[workflow])
-    actual = loader.families
+    actual = loader.get_mfs
     assert len(actual) == num_families
     # test molecular family with id "1" has correct number of spectra ids
     mf = [mf for mf in actual if mf.family_id == "1"][0]

--- a/tests/metabolomics/test_gnps_molecular_family_loader.py
+++ b/tests/metabolomics/test_gnps_molecular_family_loader.py
@@ -4,12 +4,22 @@ from nplinker.metabolomics.gnps import GNPSMolecularFamilyLoader
 
 
 @pytest.mark.parametrize(
-    "workflow, num_families, num_spectra",
-    [(GNPSFormat.SNETS, 25769, 19), (GNPSFormat.SNETSV2, 6902, 10), (GNPSFormat.FBMN, 1105, 5)],
+    "workflow, num_families, num_spectra, keep_singleton",
+    [
+        (GNPSFormat.SNETS, 25769, 19, True),
+        (GNPSFormat.SNETSV2, 6902, 10, True),
+        (GNPSFormat.FBMN, 1105, 5, True),
+        (GNPSFormat.SNETS, 29, 19, False),
+        (GNPSFormat.SNETSV2, 72, 10, False),
+        (GNPSFormat.FBMN, 60, 5, False),
+    ],
 )
-def test_has_molecular_families(workflow, num_families, num_spectra, gnps_mf_files):
+def test_gnps_molecular_family_loader(
+    workflow, num_families, num_spectra, keep_singleton, gnps_mf_files
+):
+    """Test GNPSMolecularFamilyLoader class."""
     loader = GNPSMolecularFamilyLoader(gnps_mf_files[workflow])
-    actual = loader.get_mfs
+    actual = loader.get_mfs(keep_singleton=keep_singleton)
     assert len(actual) == num_families
     # test molecular family with id "1" has correct number of spectra ids
     mf = [mf for mf in actual if mf.family_id == "1"][0]


### PR DESCRIPTION
Similar to PR #181, this PR adds a new parameter `keep_singleton` in the method `get_mfs` of MolecularFamily loader. 

Major changes:
- change class property `families` to method `get_mfs`
- add parameter `keep_singleton` to method `get_mfs`