### PR TITLE
remove loading of optional data

### DIFF
--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -76,7 +76,6 @@ class DatasetLoader:
     OR_MIBIG_JSON = "mibig_json_dir"
     OR_STRAINS = "strain_mappings_file"
     # misc files
-    OR_PARAMS = "gnps_params_file"
     OR_DESCRIPTION = "description_file"
     OR_INCLUDE_STRAINS = "include_strains_file"
     # class predictions
@@ -241,9 +240,6 @@ class DatasetLoader:
         self._init_metabolomics_paths()
 
         self._init_genomics_paths()
-
-        # 12. MISC: <root>/params.xml
-        self.params_file = os.path.join(self._root, "params.xml")
 
         # 13. MISC: <root>/description.txt
         self.description_file = os.path.join(self._root, "description.txt")
@@ -577,20 +573,6 @@ class DatasetLoader:
         return True
 
     def _load_optional(self):
-        self.gnps_params = {}
-        if os.path.exists(self.params_file):
-            logger.debug("Loading params.xml")
-            tree = ET.parse(self.params_file)
-            root = tree.getroot()
-            # this file has a simple structure:
-            # <parameters>
-            #   <parameter name="something">value</parameter>
-            # </parameters>
-            for param in root:
-                self.gnps_params[param.attrib["name"]] = param.text
-
-            logger.debug(f"Parsed {len(self.gnps_params)} GNPS params")
-
         self.description_text = "<no description>"
         if os.path.exists(self.description_file):
             self.description_text = open(self.description_file).read()

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -76,7 +76,6 @@ class DatasetLoader:
     OR_MIBIG_JSON = "mibig_json_dir"
     OR_STRAINS = "strain_mappings_file"
     # misc files
-    OR_DESCRIPTION = "description_file"
     OR_INCLUDE_STRAINS = "include_strains_file"
     # class predictions
     OR_CANOPUS = "canopus_dir"
@@ -199,8 +198,6 @@ class DatasetLoader:
         if not self._load_genomics():
             return False
 
-        self._load_optional()
-
         # Restrict strain list to only relevant strains (those that are present
         # in both genomic and metabolomic data)
         # TODO add a config file option for this?
@@ -240,9 +237,6 @@ class DatasetLoader:
         self._init_metabolomics_paths()
 
         self._init_genomics_paths()
-
-        # 13. MISC: <root>/description.txt
-        self.description_file = os.path.join(self._root, "description.txt")
 
         # 14. MISC: <root>/include_strains.csv / include_strains_file=<override>
         self.include_strains_file = self._config_overrides.get(
@@ -571,12 +565,6 @@ class DatasetLoader:
         # include them in loader
         self.chem_classes = chem_classes
         return True
-
-    def _load_optional(self):
-        self.description_text = "<no description>"
-        if os.path.exists(self.description_file):
-            self.description_text = open(self.description_file).read()
-            logger.debug("Parsed description text")
 
     def _filter_only_common_strains(self):
         """Filter strain population to only strains present in both genomic and molecular data."""

--- a/src/nplinker/nplinker.py
+++ b/src/nplinker/nplinker.py
@@ -215,15 +215,6 @@ class NPLinker:
         return NPLINKER_APP_DATA_DIR
 
     @property
-    def gnps_params(self):
-        """Returns a dict containing data from GNPS params.xml (if available).
-
-        Returns:
-            dict: GNPS parameters, or an empty dict if none exist in the dataset
-        """
-        return self._loader.gnps_params
-
-    @property
     def dataset_description(self):
         """Returns dataset description.
 

--- a/src/nplinker/nplinker.py
+++ b/src/nplinker/nplinker.py
@@ -215,18 +215,6 @@ class NPLinker:
         return NPLINKER_APP_DATA_DIR
 
     @property
-    def dataset_description(self):
-        """Returns dataset description.
-
-        If nplinker finds a 'description.txt' file in the root directory of the
-        dataset, the content will be parsed and made available through this property.
-
-        Returns:
-            str: the content of description.txt or '<no description>'
-        """
-        return self._loader.description_text
-
-    @property
     def bigscape_cutoff(self):
         """Returns the current BiGSCAPE clustering cutoff value."""
         return self._loader._bigscape_cutoff


### PR DESCRIPTION
The optional data, including GNPS params.xml file and description text, are not needed for core business of NPLinker. To keep the loading process simple (to keep refactored NPLinker as a minimum viable product), the loading of optional data is removed.  If these data are needed in the future, specific loaders should be added for them.