### PR TITLE
update logics of loading mibig data

### DIFF
--- a/src/nplinker/genomics/__init__.py
+++ b/src/nplinker/genomics/__init__.py
@@ -5,6 +5,7 @@ from .gcf import GCF
 from .utils import add_bgc_to_gcf
 from .utils import add_strain_to_bgc
 from .utils import generate_mappings_genome_id_bgc_id
+from .utils import get_mibig_from_gcf
 
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -13,7 +14,8 @@ __all__ = [
     "BGCLoaderBase",
     "BGC",
     "GCF",
-    "generate_mappings_genome_id_bgc_id",
     "add_bgc_to_gcf",
     "add_strain_to_bgc",
+    "generate_mappings_genome_id_bgc_id",
+    "get_mibig_from_gcf",
 ]

--- a/src/nplinker/genomics/mibig/mibig_loader.py
+++ b/src/nplinker/genomics/mibig/mibig_loader.py
@@ -17,6 +17,9 @@ class MibigLoader:
         MIBiG metadata file (json) contains annotations/metadata information
         for each BGC. See https://mibig.secondarymetabolites.org/download.
 
+        The MiBIG accession is used as BGC id and strain name. The loaded BGC
+        objects has Strain object as their strain attribute (i.e. `BGC.strain`).
+
         Args:
             data_dir(str): Path to the directory of MIBiG metadata json files
         """
@@ -36,8 +39,7 @@ class MibigLoader:
 
     @staticmethod
     def parse_data_dir(data_dir: str) -> dict[str, str]:
-        """Parse metadata directory and return pathes to all metadata json
-            files.
+        """Parse metadata directory and return pathes to all metadata json files.
 
         Args:
             data_dir(str): path to the directory of MIBiG metadata json files
@@ -78,6 +80,10 @@ class MibigLoader:
     def get_bgcs(self) -> list[BGC]:
         """Get BGC objects.
 
+        The BGC objects use MiBIG accession as id and has Strain object as
+        its strain attribute (i.e. `BGC.strain`), where the name of the Strain
+        object is also MiBIG accession.
+
         Returns:
             list[str, BGC]: a list of :class:`nplinker.genomics.BGC` objects
         """
@@ -94,6 +100,9 @@ class MibigLoader:
 
 def parse_bgc_metadata_json(file: str) -> BGC:
     """Parse MIBiG metadata file and return BGC object.
+
+    Note that the MiBIG accession is used as the BGC id and strain name. The BGC
+    object has Strain object as its strain attribute.
 
     Args:
         file(str): Path to the MIBiG metadata json file

--- a/src/nplinker/genomics/mibig/mibig_loader.py
+++ b/src/nplinker/genomics/mibig/mibig_loader.py
@@ -25,16 +25,6 @@ class MibigLoader:
         self._metadata_dict = self._parse_metadatas()
         self._bgcs = self._parse_bgcs()
 
-    def get_strain_bgc_mapping(self) -> dict[str, str]:
-        """Get the mapping from strain to BGC.
-
-        Note that for MIBiG BGC, same value is used for strain name and BGC id.
-
-        Returns:
-            dict[str, str]: key is strain name, value is BGC id.
-        """
-        return {bid: bid for bid in self._file_dict}
-
     def get_files(self) -> dict[str, str]:
         """Get the path of all MIBiG metadata json files.
 

--- a/src/nplinker/genomics/mibig/mibig_loader.py
+++ b/src/nplinker/genomics/mibig/mibig_loader.py
@@ -18,7 +18,7 @@ class MibigLoader:
         for each BGC. See https://mibig.secondarymetabolites.org/download.
 
         The MiBIG accession is used as BGC id and strain name. The loaded BGC
-        objects has Strain object as their strain attribute (i.e. `BGC.strain`).
+        objects have Strain object as their strain attribute (i.e. `BGC.strain`).
 
         Args:
             data_dir(str): Path to the directory of MIBiG metadata json files
@@ -39,7 +39,7 @@ class MibigLoader:
 
     @staticmethod
     def parse_data_dir(data_dir: str) -> dict[str, str]:
-        """Parse metadata directory and return pathes to all metadata json files.
+        """Parse metadata directory and return paths to all metadata json files.
 
         Args:
             data_dir(str): path to the directory of MIBiG metadata json files
@@ -80,8 +80,8 @@ class MibigLoader:
     def get_bgcs(self) -> list[BGC]:
         """Get BGC objects.
 
-        The BGC objects use MiBIG accession as id and has Strain object as
-        its strain attribute (i.e. `BGC.strain`), where the name of the Strain
+        The BGC objects use MiBIG accession as id and have Strain object as
+        their strain attribute (i.e. `BGC.strain`), where the name of the Strain
         object is also MiBIG accession.
 
         Returns:

--- a/src/nplinker/genomics/utils.py
+++ b/src/nplinker/genomics/utils.py
@@ -158,3 +158,25 @@ def add_bgc_to_gcf(
         f"{len(gcf_missing_bgc)} GCF objects have missing BGC objects."
     )
     return gcf_with_bgc, gcf_without_bgc, gcf_missing_bgc
+
+
+def get_mibig_from_gcf(gcfs: list[GCF]) -> tuple[list[BGC], StrainCollection]:
+    """Get MIBiG BGCs and strains from GCF objects.
+
+    Args:
+        gcfs(list[GCF]): A list of GCF objects.
+
+    Returns:
+        tuple[list[BGC], StrainCollection]: The first is a list of MIBiG BGC
+            objects used in the GCFs; the second is a StrainCollection object
+            that contains all Strain objects used in the GCFs.
+    """
+    mibig_bgcs_in_use = []
+    mibig_strains_in_use = StrainCollection()
+    for gcf in gcfs:
+        for bgc in gcf.bgcs:
+            if bgc.is_mibig():
+                mibig_bgcs_in_use.append(bgc)
+                if bgc.strain is not None:
+                    mibig_strains_in_use.add(bgc.strain)
+    return mibig_bgcs_in_use, mibig_strains_in_use

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -444,10 +444,11 @@ class DatasetLoader:
         all_gcfs_with_bgc, _, _ = add_bgc_to_gcf(all_bgcs_with_strain, raw_gcfs)
 
         # Step 6: get mibig bgcs and strains in use from GCFs
-        mibig_bgcs_in_use = []
         mibig_strains_in_use = StrainCollection()
         if self._use_mibig:
             mibig_bgcs_in_use, mibig_strains_in_use = get_mibig_from_gcf(all_gcfs_with_bgc)
+        else:
+            mibig_bgcs_in_use = []
 
         # Step 7: set attributes with valid objects
         self.bgcs = antismash_bgcs_with_strain + mibig_bgcs_in_use

--- a/tests/genomics/test_mibig_loader.py
+++ b/tests/genomics/test_mibig_loader.py
@@ -30,13 +30,6 @@ class TestMibigBGCLoader:
     def test_init(self, loader, data_dir):
         assert loader.data_dir == data_dir
 
-    def test_get_strain_bgc_mapping(self, loader):
-        mapping = loader.get_strain_bgc_mapping()
-        assert isinstance(mapping, dict)
-        assert len(mapping) == 2502
-        for bid in mapping:
-            assert bid == mapping[bid]
-
     def test_get_files(self, loader):
         files = loader.get_files()
         assert isinstance(files, dict)

--- a/tests/genomics/test_utils.py
+++ b/tests/genomics/test_utils.py
@@ -6,6 +6,7 @@ from nplinker.genomics import GCF
 from nplinker.genomics import add_bgc_to_gcf
 from nplinker.genomics import add_strain_to_bgc
 from nplinker.genomics import generate_mappings_genome_id_bgc_id
+from nplinker.genomics import get_mibig_from_gcf
 from nplinker.globals import GENOME_BGC_MAPPINGS_FILENAME
 from nplinker.strain import Strain
 from nplinker.strain_collection import StrainCollection
@@ -135,3 +136,26 @@ def test_add_bgc_to_gcf(bgcs):
     assert gcf_with_bgc[0].bgcs == {bgcs[0], bgcs[1]}
     assert gcf_with_bgc[1].bgcs == {bgcs[2]}
     assert gcf_without_bgc[0].bgcs == set()
+
+
+def test_get_mibig_from_gcf():
+    """Test get_mibig_from_gcf function."""
+    bgc1 = BGC("BGC_01", "NPR")
+    bgc1.strain = Strain("BGC_01")
+    bgc2 = BGC("BGC_02", "Alkaloid")
+    bgc2.strain = Strain("BGC_02")
+    bgc3 = BGC("antismash_c", "Polyketide")
+    bgc3.strain = Strain("strain_01")
+    gcf1 = GCF("1")
+    gcf1.add_bgc(bgc1)
+    gcf2 = GCF("2")
+    gcf2.add_bgc(bgc2)
+    gcf2.add_bgc(bgc3)
+    gcfs = [gcf1, gcf2]
+
+    mibig_bgcs_in_use, mibig_strains_in_use = get_mibig_from_gcf(gcfs)
+
+    assert len(mibig_bgcs_in_use) == 2
+    assert len(mibig_strains_in_use) == 2
+    assert bgc3 not in mibig_bgcs_in_use
+    assert bgc3.strain not in mibig_strains_in_use


### PR DESCRIPTION
Loading mibig data is optional, controlled by the setting `DatasetLoader._use_mibig`.  
Mibig data is genomics information and can be loaded to BGC objects and also Strain objects. This PR refactored the logics of loading mibig data according to the workflow below:

![image](https://github.com/NPLinker/nplinker/assets/9798985/63a878a6-9736-47bd-97ab-6d109e1d4f77)


Major changes:
- move mibig loading code from `self._load` to `self._load_genomics`
- Usually mibig has >2k bgcs, most of which will not be used in nplinker. So it's better to add the used mibig bgcs only to the attribute `self.bgcs` , and add the used mibig strains only to attribute `self.strains`.
- remove method `get_strain_bgc_mapping` from MibigLoader
- add util function `get_mibig_from_gcf`