### PR TITLE
set ruff to not check docstrings of test files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,9 @@ ignore = [
 fixable = ["A", "B", "C", "D", "E", "F", "I"]
 ignore-init-module-imports = true
 
+[tool.ruff.lint.per-file-ignores]
+# Ignore docstrings in all test files
+"tests/**py" = ["D"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["nplinker"]


### PR DESCRIPTION
Docstings are not really needed for test functions. This PR set ruff not to check the docstrings of test files.