### PR TITLE
Specify config file explicitly for initializing NPLinker

### DIFF
--- a/src/nplinker/arranger.py
+++ b/src/nplinker/arranger.py
@@ -263,7 +263,7 @@ class DatasetArranger:
         if self.config.mode == "podp":
             for _ in range(3):
                 try:
-                    validate_bigscape(self.bigscape_dir)
+                    validate_bigscape(self.bigscape_dir, self.config.bigscape.cutoff)
                     pass_validation = True
                     break
                 except FileNotFoundError:
@@ -271,7 +271,7 @@ class DatasetArranger:
                     self._run_bigscape()
 
         if not pass_validation:
-            validate_bigscape(self.bigscape_dir)
+            validate_bigscape(self.bigscape_dir, self.config.bigscape.cutoff)
 
     def _run_bigscape(self) -> None:
         """Run BiG-SCAPE to generate the clustering file.
@@ -460,7 +460,7 @@ def validate_antismash(antismash_dir: Path) -> None:
             raise FileNotFoundError(f"No BGC files found in antiSMASH sub-directory {sub_dir}")
 
 
-def validate_bigscape(bigscape_dir: Path) -> None:
+def validate_bigscape(bigscape_dir: Path, cutoff: str) -> None:
     """Validate the BiG-SCAPE data directory and its contents.
 
     The BiG-SCAPE data directory must exist and contain the clustering file
@@ -473,6 +473,7 @@ def validate_bigscape(bigscape_dir: Path) -> None:
 
     Args:
         bigscape_dir: Path to the BiG-SCAPE data directory.
+        cutoff: The BiG-SCAPE cutoff value.
 
     Raises:
         FileNotFoundError: If the BiG-SCAPE data directory or the clustering file is not found.
@@ -480,7 +481,7 @@ def validate_bigscape(bigscape_dir: Path) -> None:
     if not bigscape_dir.exists():
         raise FileNotFoundError(f"BiG-SCAPE data directory not found at {bigscape_dir}")
 
-    clustering_file = bigscape_dir / f"mix_clustering_c{self.config.bigscape.cutoff}.tsv"
+    clustering_file = bigscape_dir / f"mix_clustering_c{cutoff}.tsv"
     database_file = bigscape_dir / "data_sqlite.db"
     if not clustering_file.exists() and not database_file.exists():
         raise FileNotFoundError(f"BiG-SCAPE data not found in {clustering_file} or {database_file}")

--- a/src/nplinker/config.py
+++ b/src/nplinker/config.py
@@ -1,34 +1,44 @@
-import os
+from __future__ import annotations
+from os import PathLike
 from pathlib import Path
 from dynaconf import Dynaconf
 from dynaconf import Validator
 from nplinker.utils import transform_to_full_path
 
 
-# The Dynaconf library is used for loading NPLinker config file.
-# Users can set the config file location via the NPLINKER_CONFIG_FILE environment variable before
-# running/importing NPLinker. If not set, we default to 'nplinker.toml' file in the current working
-# directory.
-# The loaded config data is available by importing this module and accessing the 'config' variable.
+def load_config(config_file: str | PathLike):
+    """Load and validate the configuration file.
 
-__all__ = ["config"]
+    Args:
+        config_file: Path to the configuration file.
 
-# Locate the user's config file
-user_config_file = os.environ.get("NPLINKER_CONFIG_FILE", "nplinker.toml")
-if not os.path.exists(user_config_file):
-    raise FileNotFoundError(f"Config file '{user_config_file}' not found")
+    Returns:
+        Dynaconf: A Dynaconf object containing the configuration settings.
 
-# Locate the default config file
-default_config_file = Path(__file__).resolve().parent / "nplinker_default.toml"
+    Raises:
+        FileNotFoundError: If the configuration file does not exist.
+    """
+    config_file = transform_to_full_path(config_file)
+    if not config_file.exists():
+        raise FileNotFoundError(f"Config file '{config_file}' not found")
 
-# Load config files
-config = Dynaconf(settings_files=[user_config_file], preload=[default_config_file])
+    # Locate the default config file
+    default_config_file = Path(__file__).resolve().parent / "nplinker_default.toml"
 
-# Validate config
+    # Load config files
+    config = Dynaconf(settings_files=[config_file], preload=[default_config_file])
+
+    # Validate configs
+    config.validators.register(*CONFIG_VALIDATORS)
+    config.validators.validate()
+
+    return config
+
+
 # Note:
 # Validataor parameter `required=False` means the setting (e.g. "loglevel") must not exist rather
 # than being optional. So don't set the parameter `required` if the key is optional.
-validators = [
+CONFIG_VALIDATORS = [
     # General settings
     ## `root_dir` value is transformed to a `pathlib.Path` object and must be a directory.
     Validator(
@@ -72,5 +82,3 @@ validators = [
         condition=lambda v: set(v).issubset({"metcalf", "rosetta"}),
     ),
 ]
-config.validators.register(*validators)
-config.validators.validate()

--- a/src/nplinker/config.py
+++ b/src/nplinker/config.py
@@ -6,7 +6,7 @@ from dynaconf import Validator
 from nplinker.utils import transform_to_full_path
 
 
-def load_config(config_file: str | PathLike):
+def load_config(config_file: str | PathLike) -> Dynaconf:
     """Load and validate the configuration file.
 
     Args:

--- a/src/nplinker/defaults.py
+++ b/src/nplinker/defaults.py
@@ -1,7 +1,3 @@
-from pathlib import Path
-from nplinker.config import config
-
-
 STRAIN_MAPPINGS_FILENAME = "strain_mappings.json"
 GENOME_BGC_MAPPINGS_FILENAME = "genome_bgc_mappings.json"
 GENOME_STATUS_FILENAME = "genome_status.json"
@@ -13,10 +9,10 @@ GNPS_FILE_MAPPINGS_CSV = "file_mappings.csv"
 STRAINS_SELECTED_FILENAME = "strains_selected.json"
 
 
-DOWNLOADS_DEFAULT_PATH: Path = config.root_dir / "downloads"
-MIBIG_DEFAULT_PATH: Path = config.root_dir / "mibig"
-GNPS_DEFAULT_PATH: Path = config.root_dir / "gnps"
-ANTISMASH_DEFAULT_PATH: Path = config.root_dir / "antismash"
-BIGSCAPE_DEFAULT_PATH: Path = config.root_dir / "bigscape"
-BIGSCAPE_RUNNING_OUTPUT_PATH: Path = BIGSCAPE_DEFAULT_PATH / "bigscape_running_output"
-OUTPUT_DEFAULT_PATH: Path = config.root_dir / "output"
+DOWNLOADS_DIRNAME = "downloads"
+MIBIG_DIRNAME = "mibig"
+GNPS_DIRNAME = "gnps"
+ANTISMASH_DIRNAME = "antismash"
+BIGSCAPE_DIRNAME = "bigscape"
+BIGSCAPE_RUNNING_OUTPUT_DIRNAME = "bigscape_running_output"
+OUTPUT_DIRNAME = "output"

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -41,7 +41,7 @@ class DatasetLoader:
         product_types: A list of product types.
         strains: A StrainCollection object that contains all strains.
         class_matches: A ClassMatches object that contains class match info.
-        chem_classes: A ChemClassPredictions object that contains chemical class predictions
+        chem_classes: A ChemClassPredictions object that contains chemical class predictions.
     """
 
     RUN_CANOPUS_DEFAULT = False

--- a/src/nplinker/scoring/metcalf_scoring.py
+++ b/src/nplinker/scoring/metcalf_scoring.py
@@ -4,7 +4,6 @@ import os
 from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
-from nplinker.defaults import OUTPUT_DEFAULT_PATH
 from nplinker.genomics import GCF
 from nplinker.metabolomics import MolecularFamily
 from nplinker.metabolomics import Spectrum
@@ -72,8 +71,7 @@ class MetcalfScoring(ScoringMethod):
             )
         )
 
-        OUTPUT_DEFAULT_PATH.mkdir(exist_ok=True)
-        cache_file = OUTPUT_DEFAULT_PATH / MetcalfScoring.CACHE
+        cache_file = npl.output_dir / MetcalfScoring.CACHE
 
         # the metcalf preprocessing can take a long time for large datasets, so it's
         # better to cache as the data won't change unless the number of objects does

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -46,8 +46,6 @@ def pytest_sessionstart(session):
             zip_ref.extractall(temp_dir)
     # NPLinker setting `root_dir` must be a path that exists, so setting it to a temporary directory.
     os.environ["NPLINKER_ROOT_DIR"] = nplinker_root_dir
-    # # Specify the config file via environment variable before importing nplinker in any test.
-    os.environ["NPLINKER_CONFIG_FILE"] = str(DATA_DIR / "nplinker_local_mode.toml")
 
 
 def pytest_sessionfinish(session):

--- a/tests/integration/test_nplinker_local.py
+++ b/tests/integration/test_nplinker_local.py
@@ -2,6 +2,7 @@ import hashlib
 from pathlib import Path
 import pytest
 from nplinker.nplinker import NPLinker
+from . import DATA_DIR
 
 
 # Only tests related to data arranging and loading should be put here.
@@ -23,7 +24,7 @@ def get_file_hash(file_path):
 
 @pytest.fixture(scope="module")
 def npl() -> NPLinker:
-    npl = NPLinker()
+    npl = NPLinker(DATA_DIR / "nplinker_local_mode.toml")
     npl.load_data()
     # remove cached score results before running tests
     root_dir = Path(npl.root_dir)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -3,3 +3,4 @@ from pathlib import Path
 
 DATA_DIR = Path(__file__).resolve().parent / "data"
 GNPS_DATA_DIR = DATA_DIR / "gnps"
+CONFIG_FILE_LOCAL_MODE = DATA_DIR / "nplinker_local_mode.toml"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import tempfile
-from . import DATA_DIR
 
 
 nplinker_root_dir = os.path.join(tempfile.gettempdir(), "nplinker_unit_test")
@@ -26,8 +25,6 @@ def pytest_sessionstart(session):
         os.mkdir(nplinker_root_dir)
     # NPLinker setting `root_dir` must be a path that exists, so setting it to a temporary directory.
     os.environ["NPLINKER_ROOT_DIR"] = nplinker_root_dir
-    # # Specify the config file via environment variable before importing nplinker in any test.
-    os.environ["NPLINKER_CONFIG_FILE"] = str(DATA_DIR / "nplinker_local_mode.toml")
 
 
 def pytest_sessionfinish(session):

--- a/tests/unit/scoring/conftest.py
+++ b/tests/unit/scoring/conftest.py
@@ -8,6 +8,7 @@ from nplinker.scoring.linking import DataLinks
 from nplinker.scoring.linking import LinkFinder
 from nplinker.strain import Strain
 from nplinker.strain import StrainCollection
+from .. import CONFIG_FILE_LOCAL_MODE
 
 
 @fixture(scope="session")
@@ -86,7 +87,7 @@ def npl(gcfs, spectra, mfs, strains, tmp_path_factory) -> NPLinker:
     The config file `nplinker_demo1.toml` does not affect the tests, just
     making sure the NPLinker object can be created succesfully.
     """
-    npl = NPLinker()
+    npl = NPLinker(CONFIG_FILE_LOCAL_MODE)
     npl._gcfs = gcfs
     npl._spectra = spectra
     npl._molfams = mfs

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,9 +1,11 @@
-from nplinker.config import config
+from nplinker.config import load_config
+from . import CONFIG_FILE_LOCAL_MODE
 
 
 def test_config():
     """Test loading the default config file."""
-    # The default config file is set in "./conftest.py", which is "data/nplinker_local_mode.toml"
+    config = load_config(CONFIG_FILE_LOCAL_MODE)
+
     assert config.mode == "local"
     assert config.log.level == "DEBUG"
     assert config["log.level"] == "DEBUG"


### PR DESCRIPTION
Change how to initialise NPLinker class, from `npl = NPLinker()` to `npl = NPLinker("the_config_file.toml")`. The change makes sure that the use of config file is explicit, improving clarity for end users.