### PR TITLE
refactor MetcalfScoring methods

### DIFF
--- a/src/nplinker/scoring/abc.py
+++ b/src/nplinker/scoring/abc.py
@@ -21,14 +21,7 @@ class ScoringBase(ABC):
     """
 
     name: str = "ScoringBase"
-
-    def __init__(self, npl: NPLinker):
-        """Initialize the scoring method.
-
-        Args:
-            npl: The NPLinker object.
-        """
-        self.npl = npl
+    npl: NPLinker | None = None
 
     @classmethod
     @abstractmethod

--- a/src/nplinker/scoring/metcalf_scoring.py
+++ b/src/nplinker/scoring/metcalf_scoring.py
@@ -114,11 +114,11 @@ class MetcalfScoring(ScoringBase):
             objects = self.npl.gcfs
 
         # TODO: allow mixed input types?
-        if isinstance_all(*objects, objtype=GCF):
+        if isinstance_all(*objects, type=GCF):
             obj_type = "gcf"
-        elif isinstance_all(*objects, objtype=Spectrum):
+        elif isinstance_all(*objects, type=Spectrum):
             obj_type = "spec"
-        elif isinstance_all(*objects, objtype=MolecularFamily):
+        elif isinstance_all(*objects, type=MolecularFamily):
             obj_type = "mf"
         else:
             types = [type(i) for i in objects]
@@ -297,11 +297,11 @@ class MetcalfScoring(ScoringBase):
         if len(objects) == 0:
             raise ValueError("Empty input objects.")
 
-        if isinstance_all(*objects, objtype=GCF):
+        if isinstance_all(*objects, type=GCF):
             obj_type = "gcf"
-        elif isinstance_all(*objects, objtype=Spectrum):
+        elif isinstance_all(*objects, type=Spectrum):
             obj_type = "spec"
-        elif isinstance_all(*objects, objtype=MolecularFamily):
+        elif isinstance_all(*objects, type=MolecularFamily):
             obj_type = "mf"
         else:
             types = [type(i) for i in objects]

--- a/src/nplinker/scoring/metcalf_scoring.py
+++ b/src/nplinker/scoring/metcalf_scoring.py
@@ -155,49 +155,25 @@ class MetcalfScoring(ScoringBase):
                 scores_list = self._calc_standardised_score_met(scores_list)
 
         links = LinkGraph()
-        if obj_type == "gcf":
-            logger.info(
-                f"MetcalfScoring: input_type=GCF, result_type=Spec/MolFam, "
-                f"#inputs={len(objects)}."
-            )
-            # scores is the DataFrame with index "source", "target", "score"
-            for scores in scores_list:
-                if scores.shape[1] == 0:
-                    logger.info(f'MetcalfScoring: found no "{scores.name}" links')
-                else:
-                    for row in scores.itertuples(index=False):
-                        gcf = self.npl.lookup_gcf(row.gcf)
-                        if scores.name == LINK_TYPES[0]:
-                            met = self.npl.lookup_spectrum(row.spec)
-                        else:
-                            met = self.npl.lookup_mf(row.mf)
-                        links.add_link(
-                            gcf,
-                            met,
-                            metcalf=Score(self.name, row.score, parameters),
-                        )
-                    logger.info(f"MetcalfScoring: found {len(links)} {scores.name} links.")
-        else:
-            logger.info(
-                f"MetcalfScoring: input_type=Spec/MolFam, result_type=GCF, "
-                f"#inputs={len(objects)}."
-            )
-            for scores in scores_list:
-                if scores.shape[1] == 0:
-                    logger.info(f'MetcalfScoring: found no links "{scores.name}" for input objects')
-                else:
-                    for row in scores.itertuples(index=False):
-                        gcf = self.npl.lookup_gcf(row.gcf)
-                        if scores.name == LINK_TYPES[0]:
-                            met = self.npl.lookup_spectrum(row.spec)
-                        else:
-                            met = self.npl.lookup_mf(row.mf)
-                        links.add_link(
-                            met,
-                            gcf,
-                            metcalf=Score(self.name, row.score, parameters),
-                        )
-                    logger.info(f"MetcalfScoring: found {len(links)} {scores.name} links.")
+        logger.info(
+            f"MetcalfScoring: input_type=GCF, result_type=Spec/MolFam, " f"#inputs={len(objects)}."
+        )
+        for scores in scores_list:
+            if scores.shape[1] == 0:
+                logger.info(f'MetcalfScoring: found no "{scores.name}" links')
+            else:
+                for row in scores.itertuples(index=False):
+                    gcf = self.npl.lookup_gcf(row.gcf)
+                    if scores.name == LINK_TYPES[0]:
+                        met = self.npl.lookup_spectrum(row.spec)
+                    else:
+                        met = self.npl.lookup_mf(row.mf)
+                    links.add_link(
+                        gcf,
+                        met,
+                        metcalf=Score(self.name, row.score, parameters),
+                    )
+                logger.info(f"MetcalfScoring: found {len(links)} {scores.name} links.")
 
         logger.info("MetcalfScoring: completed")
         return links

--- a/src/nplinker/scoring/metcalf_scoring.py
+++ b/src/nplinker/scoring/metcalf_scoring.py
@@ -32,6 +32,9 @@ class LinkType(Enum):
     MF_GCF = "mf-gcf"
 
 
+ObjectType = TypeVar("ObjectType", GCF, Spectrum, MolecularFamily)
+
+
 class MetcalfScoring(ScoringBase):
     """Metcalf scoring method.
 
@@ -105,7 +108,7 @@ class MetcalfScoring(ScoringBase):
 
         logger.info("MetcalfScoring.setup completed")
 
-    def get_links(self, *objects: GCF | Spectrum | MolecularFamily, **parameters) -> LinkGraph:
+    def get_links(self, *objects: ObjectType, **parameters) -> LinkGraph:
         """Get links for the given objects.
 
         The given objects are treated as input or source objects, which must be GCF, Spectrum or
@@ -260,8 +263,8 @@ class MetcalfScoring(ScoringBase):
 
     def _get_links(
         self,
-        *objects: tuple[GCF, ...] | tuple[Spectrum, ...] | tuple[MolecularFamily, ...],
         obj_type: str,
+        *objects: ObjectType,
         score_cutoff: float = 0,
     ) -> list[pd.DataFrame]:
         """Get links and scores for given objects.

--- a/src/nplinker/scoring/metcalf_scoring.py
+++ b/src/nplinker/scoring/metcalf_scoring.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import logging
+from enum import Enum
 from typing import TYPE_CHECKING
+from typing import TypeVar
 import numpy as np
 import pandas as pd
 from scipy.stats import hypergeom
@@ -22,7 +24,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-LINK_TYPES = ["spec-gcf", "mf-gcf"]
+
+class LinkType(Enum):
+    """An enumeration of the link types for Metcalf scoring."""
+
+    SPEC_GCF = "spec-gcf"
+    MF_GCF = "mf-gcf"
 
 
 class MetcalfScoring(ScoringBase):
@@ -164,7 +171,7 @@ class MetcalfScoring(ScoringBase):
             else:
                 for row in scores.itertuples(index=False):
                     gcf = self.npl.lookup_gcf(row.gcf)
-                    if scores.name == LINK_TYPES[0]:
+                    if scores.name == LinkType.SPEC_GCF:
                         met = self.npl.lookup_spectrum(row.spec)
                     else:
                         met = self.npl.lookup_mf(row.mf)
@@ -302,7 +309,7 @@ class MetcalfScoring(ScoringBase):
                 self.raw_score_spec_gcf["spec"].isin(obj_ids)
                 & (self.raw_score_spec_gcf["score"] >= score_cutoff)
             ]
-            df.name = LINK_TYPES[0]
+            df.name = LinkType.SPEC_GCF
             links.append(df)
 
         if obj_type == "mf":
@@ -311,7 +318,7 @@ class MetcalfScoring(ScoringBase):
                 self.raw_score_mf_gcf["mf"].isin(obj_ids)
                 & (self.raw_score_mf_gcf["score"] >= score_cutoff)
             ]
-            df.name = LINK_TYPES[1]
+            df.name = LinkType.MF_GCF
             links.append(df)
         return links
 
@@ -325,7 +332,7 @@ class MetcalfScoring(ScoringBase):
         z_scores = []
         for col_index in range(raw_score.shape[1]):
             gcf = self.npl.lookup_gcf(raw_score.loc["target", col_index])
-            if raw_score.name == LINK_TYPES[0]:
+            if raw_score.name == LinkType.SPEC_GCF:
                 met = self.npl.lookup_spectrum(raw_score.at["source", col_index])
             else:
                 met = self.npl.lookup_mf(raw_score.at["source", col_index])
@@ -363,7 +370,7 @@ class MetcalfScoring(ScoringBase):
             z_scores = []
             for col_index in range(raw_score.shape[1]):
                 gcf = self.npl.lookup_gcf(raw_score.loc["source", col_index])
-                if raw_score.name == LINK_TYPES[0]:
+                if raw_score.name == LinkType.SPEC_GCF:
                     met = self.npl.lookup_spectrum(raw_score.at["target", col_index])
                 else:
                     met = self.npl.lookup_mf(raw_score.at["target", col_index])

--- a/src/nplinker/scoring/metcalf_scoring.py
+++ b/src/nplinker/scoring/metcalf_scoring.py
@@ -129,7 +129,6 @@ class MetcalfScoring(ScoringBase):
         if len(objects) == 0:
             objects = self.npl.gcfs
 
-        # TODO: allow mixed input types?
         if isinstance_all(*objects, type=GCF):
             obj_type = "gcf"
         elif isinstance_all(*objects, type=Spectrum):
@@ -286,40 +285,26 @@ class MetcalfScoring(ScoringBase):
             TypeError: If input objects are not GCF, Spectrum or MolecularFamily objects.
         """
         links = []
-        if obj_type == "gcf":
-            obj_ids = [gcf.id for gcf in objects]
-            # spec-gcf
-            df = self.raw_score_spec_gcf[
-                self.raw_score_spec_gcf["gcf"].isin(obj_ids)
-                & (self.raw_score_spec_gcf["score"] >= score_cutoff)
-            ]
-            df.name = LINK_TYPES[0]
-            links.append(df)
-            # mf-gcf
-            df = self.raw_score_mf_gcf[
-                self.raw_score_mf_gcf["gcf"].isin(obj_ids)
-                & (self.raw_score_mf_gcf["score"] >= score_cutoff)
-            ]
-            df.name = LINK_TYPES[1]
-            links.append(df)
+        obj_ids = [obj.id for obj in objects]
 
-        if obj_type == "spec":
-            obj_ids = [spec.id for spec in objects]
+        # spec-gcf
+        if obj_type == "gcf" or obj_type == "spec":
             df = self.raw_score_spec_gcf[
-                self.raw_score_spec_gcf["spec"].isin(obj_ids)
+                self.raw_score_spec_gcf[obj_type].isin(obj_ids)
                 & (self.raw_score_spec_gcf["score"] >= score_cutoff)
             ]
             df.name = LinkType.SPEC_GCF
             links.append(df)
 
-        if obj_type == "mf":
-            obj_ids = [mf.id for mf in objects]
+        # mf-gcf
+        if obj_type == "gcf" or obj_type == "mf":
             df = self.raw_score_mf_gcf[
-                self.raw_score_mf_gcf["mf"].isin(obj_ids)
+                self.raw_score_mf_gcf[obj_type].isin(obj_ids)
                 & (self.raw_score_mf_gcf["score"] >= score_cutoff)
             ]
             df.name = LinkType.MF_GCF
             links.append(df)
+
         return links
 
     def _calc_standardised_score_met(self, results: list) -> list[pd.DataFrame]:

--- a/src/nplinker/scoring/utils.py
+++ b/src/nplinker/scoring/utils.py
@@ -16,7 +16,7 @@ def get_presence_gcf_strain(gcfs: Sequence[GCF], strains: StrainCollection) -> p
     """Get the occurrence of strains in gcfs.
 
     The occurrence is a DataFrame with GCF objects as index and Strain objects as columns, and the
-    values are 1 if the gcf occur in the strain,  0 otherwise.
+    values are 1 if the gcf occurs in the strain,  0 otherwise.
     """
     df_gcf_strain = pd.DataFrame(
         np.zeros((len(gcfs), len(strains))),
@@ -37,7 +37,7 @@ def get_presence_spec_strain(
     """Get the occurrence of strains in spectra.
 
     The occurrence is a DataFrame with Spectrum objects as index and Strain objects as columns, and
-    the values are 1 if the spectrum occur in the strain, 0 otherwise.
+    the values are 1 if the spectrum occurs in the strain, 0 otherwise.
     """
     df_spec_strain = pd.DataFrame(
         np.zeros((len(spectra), len(strains))),
@@ -58,7 +58,7 @@ def get_presence_mf_strain(
     """Get the occurrence of strains in molecular families.
 
     The occurrence is a DataFrame with MolecularFamily objects as index and Strain objects as
-    columns, and the values are 1 if the molecular family occur in the strain, 0 otherwise.
+    columns, and the values are 1 if the molecular family occurs in the strain, 0 otherwise.
     """
     df_mf_strain = pd.DataFrame(
         np.zeros((len(mfs), len(strains))),

--- a/src/nplinker/scoring/utils.py
+++ b/src/nplinker/scoring/utils.py
@@ -12,15 +12,15 @@ if TYPE_CHECKING:
     from nplinker.strain import StrainCollection
 
 
-def isinstance_all(*objects, objtype) -> bool:
+def isinstance_all(*objects, type) -> bool:
     """Check if all objects are of the given type."""
-    return all(isinstance(x, objtype) for x in objects)
+    return all(isinstance(x, type) for x in objects)
 
 
 def get_presence_gcf_strain(gcfs: Sequence[GCF], strains: StrainCollection) -> pd.DataFrame:
-    """Get the occurence of strains in gcfs.
+    """Get the occurrence of strains in gcfs.
 
-    The occurence is a DataFrame with gcfs as rows and strains as columns,
+    The occurrence is a DataFrame with gcfs as rows and strains as columns,
     where index is `gcf.id` and column name is `strain.id`. The values
     are 1 if the gcf contains the strain and 0 otherwise.
     """
@@ -40,9 +40,9 @@ def get_presence_gcf_strain(gcfs: Sequence[GCF], strains: StrainCollection) -> p
 def get_presence_spec_strain(
     spectra: Sequence[Spectrum], strains: StrainCollection
 ) -> pd.DataFrame:
-    """Get the occurence of strains in spectra.
+    """Get the occurrence of strains in spectra.
 
-    The occurence is a DataFrame with spectra as rows and strains as columns,
+    The occurrence is a DataFrame with spectra as rows and strains as columns,
     where index is `spectrum.id` and column name is `strain.id`.
     The values are 1 if the spectrum contains the strain and 0 otherwise.
     """
@@ -62,9 +62,9 @@ def get_presence_spec_strain(
 def get_presence_mf_strain(
     mfs: Sequence[MolecularFamily], strains: StrainCollection
 ) -> pd.DataFrame:
-    """Get the occurence of strains in molecular families.
+    """Get the occurrence of strains in molecular families.
 
-    The occurence is a DataFrame with molecular families as rows and
+    The occurrence is a DataFrame with molecular families as rows and
     strains as columns, where index is `mf.id` and column name is
     `strain.id`. The values are 1 if the molecular family contains the
     strain and 0 otherwise.

--- a/src/nplinker/scoring/utils.py
+++ b/src/nplinker/scoring/utils.py
@@ -15,20 +15,19 @@ if TYPE_CHECKING:
 def get_presence_gcf_strain(gcfs: Sequence[GCF], strains: StrainCollection) -> pd.DataFrame:
     """Get the occurrence of strains in gcfs.
 
-    The occurrence is a DataFrame with gcfs as rows and strains as columns,
-    where index is `gcf.id` and column name is `strain.id`. The values
-    are 1 if the gcf contains the strain and 0 otherwise.
+    The occurrence is a DataFrame with GCF objects as index and Strain objects as columns, and the
+    values are 1 if the gcf occur in the strain,  0 otherwise.
     """
     df_gcf_strain = pd.DataFrame(
         np.zeros((len(gcfs), len(strains))),
-        index=[gcf.id for gcf in gcfs],
-        columns=[strain.id for strain in strains],
+        index=gcfs,
+        columns=list(strains),
         dtype=int,
     )
     for gcf in gcfs:
         for strain in strains:
             if gcf.has_strain(strain):
-                df_gcf_strain.loc[gcf.id, strain.id] = 1
+                df_gcf_strain.loc[gcf, strain] = 1
     return df_gcf_strain
 
 
@@ -37,20 +36,19 @@ def get_presence_spec_strain(
 ) -> pd.DataFrame:
     """Get the occurrence of strains in spectra.
 
-    The occurrence is a DataFrame with spectra as rows and strains as columns,
-    where index is `spectrum.id` and column name is `strain.id`.
-    The values are 1 if the spectrum contains the strain and 0 otherwise.
+    The occurrence is a DataFrame with Spectrum objects as index and Strain objects as columns, and
+    the values are 1 if the spectrum occur in the strain, 0 otherwise.
     """
     df_spec_strain = pd.DataFrame(
         np.zeros((len(spectra), len(strains))),
-        index=[spectrum.id for spectrum in spectra],
-        columns=[strain.id for strain in strains],
+        index=spectra,
+        columns=list(strains),
         dtype=int,
     )
     for spectrum in spectra:
         for strain in strains:
             if spectrum.has_strain(strain):
-                df_spec_strain.loc[spectrum.id, strain.id] = 1
+                df_spec_strain.loc[spectrum, strain] = 1
     return df_spec_strain
 
 
@@ -59,19 +57,17 @@ def get_presence_mf_strain(
 ) -> pd.DataFrame:
     """Get the occurrence of strains in molecular families.
 
-    The occurrence is a DataFrame with molecular families as rows and
-    strains as columns, where index is `mf.id` and column name is
-    `strain.id`. The values are 1 if the molecular family contains the
-    strain and 0 otherwise.
+    The occurrence is a DataFrame with MolecularFamily objects as index and Strain objects as
+    columns, and the values are 1 if the molecular family occur in the strain, 0 otherwise.
     """
     df_mf_strain = pd.DataFrame(
         np.zeros((len(mfs), len(strains))),
-        index=[mf.id for mf in mfs],
-        columns=[strain.id for strain in strains],
+        index=mfs,
+        columns=list(strains),
         dtype=int,
     )
     for mf in mfs:
         for strain in strains:
             if mf.has_strain(strain):
-                df_mf_strain.loc[mf.id, strain.id] = 1
+                df_mf_strain.loc[mf, strain] = 1
     return df_mf_strain

--- a/src/nplinker/scoring/utils.py
+++ b/src/nplinker/scoring/utils.py
@@ -12,11 +12,6 @@ if TYPE_CHECKING:
     from nplinker.strain import StrainCollection
 
 
-def isinstance_all(*objects, type) -> bool:
-    """Check if all objects are of the given type."""
-    return all(isinstance(x, type) for x in objects)
-
-
 def get_presence_gcf_strain(gcfs: Sequence[GCF], strains: StrainCollection) -> pd.DataFrame:
     """Get the occurrence of strains in gcfs.
 

--- a/tests/unit/scoring/conftest.py
+++ b/tests/unit/scoring/conftest.py
@@ -86,6 +86,6 @@ def npl(gcfs, spectra, mfs, strains, tmp_path) -> NPLinker:
 @fixture(scope="function")
 def mc(npl) -> MetcalfScoring:
     """MetcalfScoring object."""
-    mc = MetcalfScoring(npl)
+    mc = MetcalfScoring()
     mc.setup(npl)
     return mc

--- a/tests/unit/scoring/test_utils.py
+++ b/tests/unit/scoring/test_utils.py
@@ -7,9 +7,9 @@ from nplinker.scoring.utils import isinstance_all
 
 
 def test_isinstance_all():
-    assert isinstance_all(1, 2, 3, objtype=int)
-    assert not isinstance_all(1, 2, 3, objtype=str)
-    assert not isinstance_all(1, 2, "3", objtype=int)
+    assert isinstance_all(1, 2, 3, type=int)
+    assert not isinstance_all(1, 2, 3, type=str)
+    assert not isinstance_all(1, 2, "3", type=int)
 
 
 #

--- a/tests/unit/scoring/test_utils.py
+++ b/tests/unit/scoring/test_utils.py
@@ -16,8 +16,8 @@ def test_get_presence_gcf_strain(gcfs, strains):
         presence_gcf_strain,
         pd.DataFrame(
             [[1, 0, 0], [0, 1, 0], [1, 1, 0]],
-            index=["gcf1", "gcf2", "gcf3"],
-            columns=["strain1", "strain2", "strain3"],
+            index=gcfs,
+            columns=list(strains),
         ),
     )
 
@@ -26,11 +26,7 @@ def test_get_presence_spec_strain(spectra, strains):
     presence_spec_strain = get_presence_spec_strain(spectra, strains)
     assert_frame_equal(
         presence_spec_strain,
-        pd.DataFrame(
-            [[1, 0, 0], [0, 1, 0], [1, 1, 0]],
-            index=["spectrum1", "spectrum2", "spectrum3"],
-            columns=["strain1", "strain2", "strain3"],
-        ),
+        pd.DataFrame([[1, 0, 0], [0, 1, 0], [1, 1, 0]], index=spectra, columns=list(strains)),
     )
 
 
@@ -38,9 +34,5 @@ def test_get_presence_mf_strain(mfs, strains):
     presence_mf_strain = get_presence_mf_strain(mfs, strains)
     assert_frame_equal(
         presence_mf_strain,
-        pd.DataFrame(
-            [[1, 0, 0], [0, 1, 0], [1, 1, 0]],
-            index=["mf1", "mf2", "mf3"],
-            columns=["strain1", "strain2", "strain3"],
-        ),
+        pd.DataFrame([[1, 0, 0], [0, 1, 0], [1, 1, 0]], index=mfs, columns=list(strains)),
     )

--- a/tests/unit/scoring/test_utils.py
+++ b/tests/unit/scoring/test_utils.py
@@ -3,13 +3,6 @@ from pandas.testing import assert_frame_equal
 from nplinker.scoring.utils import get_presence_gcf_strain
 from nplinker.scoring.utils import get_presence_mf_strain
 from nplinker.scoring.utils import get_presence_spec_strain
-from nplinker.scoring.utils import isinstance_all
-
-
-def test_isinstance_all():
-    assert isinstance_all(1, 2, 3, type=int)
-    assert not isinstance_all(1, 2, 3, type=str)
-    assert not isinstance_all(1, 2, "3", type=int)
 
 
 #


### PR DESCRIPTION
After refactoring the classes or functions used by scoring methods, now it's time to refactor MetcalfScoring methods.
The basic idea of the refactoring is to simplify the steps of calculating metcalf raw score and standardised score, and try to improve the speed performance of the calculation through e.g. reducing the use of loop and look up.

It's better to review the changes commit by commit, and some commits describe the purpose of the changes.