### PR TITLE
rename `molfam` to `mf` to uniform the abbreviation for MolecularFamily

### DIFF
--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -35,7 +35,7 @@ class DatasetLoader:
         bgcs: A list of BGC objects.
         gcfs: A list of GCF objects.
         spectra: A list of Spectrum objects.
-        molfams: A list of MolecularFamily objects.
+        mfs: A list of MolecularFamily objects.
         mibig_bgcs: A list of MIBiG BGC objects.
         mibig_strains_in_use: A StrainCollection object that contains the strains in use from MIBiG.
         product_types: A list of product types.
@@ -60,7 +60,7 @@ class DatasetLoader:
         """
         self.config = config
 
-        self.bgcs, self.gcfs, self.spectra, self.molfams = [], [], [], []
+        self.bgcs, self.gcfs, self.spectra, self.mfs = [], [], [], []
         self.mibig_bgcs = []
         self.mibig_strains_in_use = StrainCollection()
         self.product_types = []
@@ -114,7 +114,7 @@ class DatasetLoader:
         objects added (i.e. `Spectrum.strains` updated). If a Spectrum object does not have Strain
         objects, it is not added to `self.spectra`.
 
-        The attribute of `self.molfams` is set to the loaded MolecularFamily objects that have
+        The attribute of `self.mfs` is set to the loaded MolecularFamily objects that have
         Strain objects added (i.e. `MolecularFamily._strains` updated). This means only Spectra
         objects with updated strains (i.e. `self.spectra`) can be added to MolecularFamily objects.
         """
@@ -129,7 +129,7 @@ class DatasetLoader:
             gnps_dir / defaults.GNPS_ANNOTATIONS_FILENAME
         ).annotations
         # Step 3: load all MolecularFamily objects
-        raw_molfams = GNPSMolecularFamilyLoader(
+        raw_mfs = GNPSMolecularFamilyLoader(
             gnps_dir / defaults.GNPS_MOLECULAR_FAMILY_FILENAME
         ).get_mfs(keep_singleton=False)
 
@@ -139,11 +139,11 @@ class DatasetLoader:
         spectra_with_strains, _ = add_strains_to_spectrum(self.strains, raw_spectra)
 
         # Step 6: add Spectrum objects to MolecularFamily
-        mf_with_spec, _, _ = add_spectrum_to_mf(spectra_with_strains, raw_molfams)
+        mf_with_spec, _, _ = add_spectrum_to_mf(spectra_with_strains, raw_mfs)
 
-        # Step 7: set attributes of self.spectra and self.molfams with valid objects
+        # Step 7: set attributes of self.spectra and self.mfs with valid objects
         self.spectra = spectra_with_strains
-        self.molfams = mf_with_spec
+        self.mfs = mf_with_spec
 
         logger.info("Loading metabolomics data completed\n")
         return True
@@ -266,10 +266,10 @@ class DatasetLoader:
 
         # load Chem_class_predictions (canopus, molnetenhancer are loaded)
         chem_classes = ChemClassPredictions(self.canopus_dir, self.molnetenhancer_dir, self._root)  # noqa
-        # if no molfam classes transfer them from spectra (due to old style MN)
-        if not chem_classes.canopus.molfam_classes and chem_classes.canopus.spectra_classes:
+        # if no mf classes transfer them from spectra (due to old style MN)
+        if not chem_classes.canopus.mf_classes and chem_classes.canopus.spectra_classes:
             logger.info("Added chemical compound classes for MFs")
-            chem_classes.canopus.transfer_spec_classes_to_molfams(self.molfams)
+            chem_classes.canopus.transfer_spec_classes_to_mfs(self.mfs)
         # include them in loader
         self.chem_classes = chem_classes
         return True

--- a/src/nplinker/nplinker.py
+++ b/src/nplinker/nplinker.py
@@ -61,7 +61,7 @@ class NPLinker:
         self._gcfs = []
         self._strains = None
         self._metadata = {}
-        self._molfams = []
+        self._mfs = []
         self._mibig_bgcs = []
         self._chem_classes = None
         self._class_matches = None
@@ -147,7 +147,7 @@ class NPLinker:
         loader.load()
 
         self._spectra = loader.spectra
-        self._molfams = loader.molfams
+        self._mfs = loader.mfs
         self._bgcs = loader.bgcs
         self._gcfs = loader.gcfs
         self._mibig_bgcs = loader.mibig_bgcs
@@ -160,7 +160,7 @@ class NPLinker:
     def get_links(
         self, input_objects: list, scoring_methods: list, and_mode: bool = True
     ) -> LinkCollection:
-        """Find links for a set of input objects (BGCs/GCFs/Spectra/MolFams).
+        """Find links for a set of input objects (BGCs/GCFs/Spectra/mfs).
 
         The input objects can be any mix of the following NPLinker types:
 
@@ -303,9 +303,9 @@ class NPLinker:
         return self._spectra
 
     @property
-    def molfams(self):
+    def mfs(self):
         """Returns a list of all the MolecularFamilies in the dataset."""
-        return self._molfams
+        return self._mfs
 
     @property
     def metadata(self):

--- a/src/nplinker/pickler.py
+++ b/src/nplinker/pickler.py
@@ -75,7 +75,7 @@ class NPLinkerUnpickler(pickle.Unpickler):
         elif obj_type == "Spectrum":
             return self.nplinker.spectra[obj_id]
         elif obj_type == "MolecularFamily":
-            return self.nplinker.molfams[obj_id]
+            return self.nplinker.mfs[obj_id]
         elif obj_type == "ScoringMethod":
             return self.nplinker.scoring_method(obj_id)
 

--- a/src/nplinker/scoring/metcalf_scoring.py
+++ b/src/nplinker/scoring/metcalf_scoring.py
@@ -102,14 +102,14 @@ class MetcalfScoring(ScoringBase):
 
         logger.info(
             f"MetcalfScoring.setup starts: #bgcs={len(npl.bgcs)}, #gcfs={len(npl.gcfs)}, "
-            f"#spectra={len(npl.spectra)}, #molfams={len(npl.molfams)}, #strains={npl.strains}"
+            f"#spectra={len(npl.spectra)}, #mfs={len(npl.mfs)}, #strains={npl.strains}"
         )
         cls.npl = npl
 
         # calculate presence of gcfs/spectra/mfs with respect to strains
         cls.presence_gcf_strain = get_presence_gcf_strain(npl.gcfs, npl.strains)
         cls.presence_spec_strain = get_presence_spec_strain(npl.spectra, npl.strains)
-        cls.presence_mf_strain = get_presence_mf_strain(npl.molfams, npl.strains)
+        cls.presence_mf_strain = get_presence_mf_strain(npl.mfs, npl.strains)
 
         # calculate raw Metcalf scores for spec-gcf links
         raw_score_spec_gcf = cls._calc_raw_score(

--- a/src/nplinker/scoring/np_class_scoring.py
+++ b/src/nplinker/scoring/np_class_scoring.py
@@ -44,7 +44,7 @@ class NPClassScoring(ScoringBase):
         target (if obj is BGC then  obj_classes should be classes for the BGC).
         Can be:
             - BGC/GCF classes: {'as_classes': list(str), 'bigscape_class': str}
-            - Spectrum/Molfam classes: tuple of (classes, class_names_indices),
+            - Spectrum/mf classes: tuple of (classes, class_names_indices),
             where classes is a list of list of tuples/None, where each
             tuple is a class and a score (str, float), and class_names_indices
             is a list of ints that relate to the name of a class ontology lvl
@@ -157,7 +157,7 @@ class NPClassScoring(ScoringBase):
         """Get the targets based upon instance of test_id, returns list of targets.
 
         Args:
-            test_id: one of the NPLinker objects: BGC, GCF, Spectrum, Molfam
+            test_id: one of the NPLinker objects: BGC, GCF, Spectrum, mf
         Returns:
             List of one or more of one of the NPLinker objects
         """
@@ -174,7 +174,7 @@ class NPClassScoring(ScoringBase):
                 targets = self.npl.bgcs
             else:
                 targets = self.npl.gcfs
-        else:  # obj are molfam
+        else:  # obj are mf
             if self.equal_targets:
                 targets = self.npl.gcfs
             else:
@@ -183,15 +183,15 @@ class NPClassScoring(ScoringBase):
 
     def _get_targets_genomics(self, test_id):
         if self.both_targets:  # no matter BGC or GCF take both spec and MF
-            targets = self.npl.spectra + self.npl.molfams
+            targets = self.npl.spectra + self.npl.mfs
         elif isinstance(test_id, BGC):  # obj are BGC
             if self.equal_targets:  # take
                 targets = self.npl.spectra
             else:
-                targets = self.npl.molfams
+                targets = self.npl.mfs
         else:  # obj are GCF
             if self.equal_targets:
-                targets = self.npl.molfams
+                targets = self.npl.mfs
             else:
                 targets = self.npl.spectra
         return targets
@@ -236,10 +236,10 @@ class NPClassScoring(ScoringBase):
         return bgc_like_classes_dict
 
     def _get_met_classes(self, spec_like, method="mix"):
-        """Get chemical classes for a Spectrum or MolFam based on method.
+        """Get chemical classes for a Spectrum or mf based on method.
 
         Args:
-            spec_like: Spectrum or MolFam, one of the NPLinker input types
+            spec_like: Spectrum or mf, one of the NPLinker input types
             method: str, one of the appropriate methods for chemical class
                 predictions (mix, canopus...), default='mix'
         Returns:
@@ -248,7 +248,7 @@ class NPClassScoring(ScoringBase):
             tuple is a class and a score (str, float), and class_names_indices
             is a list of ints that relate to the name of a class ontology lvl
         """
-        # assess if spectrum or molfam
+        # assess if spectrum or mf
         is_spectrum = isinstance(spec_like, Spectrum)
 
         # gather classes for spectra, using right method
@@ -280,11 +280,11 @@ class NPClassScoring(ScoringBase):
                 spec_like_classes_names_inds = (
                     self.npl.chem_classes.canopus.spectra_classes_names_inds
                 )
-            else:  # molfam
+            else:  # mf
                 fam_id = spec_like.family.id
                 if fam_id.startswith("singleton-"):  # account for singleton families
                     fam_id += f"_{spec_like.spectra[0].id}"
-                all_classes = self.npl.chem_classes.canopus.molfam_classes.get(fam_id)
+                all_classes = self.npl.chem_classes.canopus.mf_classes.get(fam_id)
                 if all_classes:
                     spec_like_classes = [
                         cls_per_lvl
@@ -292,21 +292,19 @@ class NPClassScoring(ScoringBase):
                         for i, cls_per_lvl in enumerate(lvl)
                         if i == 0
                     ]
-                spec_like_classes_names_inds = (
-                    self.npl.chem_classes.canopus.molfam_classes_names_inds
-                )
+                spec_like_classes_names_inds = self.npl.chem_classes.canopus.mf_classes_names_inds
         if use_mne and not spec_like_classes:
             # if mne or when main/canopus does not get classes
             if is_spectrum:
                 spec_like_classes = self.npl.chem_classes.molnetenhancer.spectra_classes(
                     spec_like.id
                 )
-            else:  # molfam
+            else:  # mf
                 fam_id = spec_like.family.id
                 if fam_id.startswith("singleton"):  # account for singleton families
                     fam_id += f"_{spec_like.spectra[0].id}"
-                spec_like_classes = self.npl.chem_classes.molnetenhancer.molfam_classes.get(fam_id)
-            # classes are same for molfam and spectrum so names are irrespective of is_spectrum
+                spec_like_classes = self.npl.chem_classes.molnetenhancer.mf_classes.get(fam_id)
+            # classes are same for mf and spectrum so names are irrespective of is_spectrum
             spec_like_classes_names_inds = (
                 self.npl.chem_classes.molnetenhancer.spectra_classes_names_inds
             )

--- a/tests/integration/test_nplinker_local.py
+++ b/tests/integration/test_nplinker_local.py
@@ -61,5 +61,5 @@ def test_load_data(npl: NPLinker):
     assert len(npl.bgcs) == 390
     assert len(npl.gcfs) == 64
     assert len(npl.spectra) == 24652
-    assert len(npl.molfams) == 29
+    assert len(npl.mfs) == 29
     assert len(npl.strains) == 46

--- a/tests/unit/class_info/test_chem_classes.py
+++ b/tests/unit/class_info/test_chem_classes.py
@@ -13,9 +13,9 @@ from .. import DATA_DIR
 #     def test_running(self):
 #         for i, elem in enumerate([
 #                 self._cr.spectra_classes, self._cr.spectra_classes_names,
-#                 self._cr.spectra_classes_names_inds, self._cr.molfam_classes,
-#                 self._cr.molfam_classes_names,
-#                 self._cr.molfam_classes_names_inds]):
+#                 self._cr.spectra_classes_names_inds, self._cr.mf_classes,
+#                 self._cr.mf_classes_names,
+#                 self._cr.mf_classes_names_inds]):
 #             self.assertTrue(len(elem) != 0, f"Element {i} failed to load")
 
 #     def test_can_treemap(self):
@@ -32,10 +32,10 @@ class TestMolNetEnhancerResults(unittest.TestCase):
     def test_running(self):
         for i, elem in enumerate(
             [
-                self._mr.spectra2molfam,
+                self._mr.spectra2mf,
                 self._mr.spectra_classes_names,
                 self._mr.spectra_classes_names_inds,
-                self._mr.molfam_classes,
+                self._mr.mf_classes,
             ]
         ):
             self.assertTrue(len(elem) != 0, f"Element {i} failed to load")

--- a/tests/unit/scoring/conftest.py
+++ b/tests/unit/scoring/conftest.py
@@ -75,7 +75,7 @@ def npl(gcfs, spectra, mfs, strains, tmp_path) -> NPLinker:
     npl = NPLinker(CONFIG_FILE_LOCAL_MODE)
     npl._gcfs = gcfs
     npl._spectra = spectra
-    npl._molfams = mfs
+    npl._mfs = mfs
     npl._strains = strains
     npl._gcf_lookup = {gcf.id: gcf for gcf in gcfs}
     npl._mf_lookup = {mf.id: mf for mf in mfs}


### PR DESCRIPTION
A simple PR: just renaming.