### PR TITLE
simplify error check in unit tests

### DIFF
--- a/src/nplinker/strain/strain_collection.py
+++ b/src/nplinker/strain/strain_collection.py
@@ -108,7 +108,7 @@ class StrainCollection:
                     else:
                         self._strain_dict_name[name] = new_strain_list
         else:
-            raise ValueError(f"Strain {strain} not found in strain collection.")
+            raise ValueError(f"Strain {strain} not found in the strain collection.")
 
     def filter(self, strain_set: set[Strain]):
         """Remove all strains that are not in strain_set from the strain collection.

--- a/tests/unit/genomics/test_antismash_downloader.py
+++ b/tests/unit/genomics/test_antismash_downloader.py
@@ -31,9 +31,8 @@ class TestDownloadAndExtractAntismashData:
     def test_error_nonempty_path(self, tmp_path):
         nonempty_path = tmp_path / "extracted" / "antismash" / f"{self.antismash_id}" / "subdir"
         nonempty_path.mkdir(parents=True)
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError, match="Nonempty directory"):
             download_and_extract_antismash_data(self.antismash_id, tmp_path, tmp_path / "extracted")
-        assert "Nonempty directory" in e.value.args[0]
 
     # test a non-existent ID, which can be either a fake ID, non-existent in NCBI
     # or a valid NCBI genome ID but it does not have BGC data in antismash database

--- a/tests/unit/genomics/test_antismash_loader.py
+++ b/tests/unit/genomics/test_antismash_loader.py
@@ -73,6 +73,5 @@ def test_parse_bgc_genbank():
 
 def test_parse_bgc_genbank_error():
     gbk_file = str(DATA_DIR / "fake_antismash.region001.gbk")
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="Not found product prediction in antiSMASH Genbank file"):
         parse_bgc_genbank(gbk_file)
-    assert "Not found product prediction in antiSMASH Genbank file" in e.value.args[0]

--- a/tests/unit/genomics/test_mibig_downloader.py
+++ b/tests/unit/genomics/test_mibig_downloader.py
@@ -30,14 +30,14 @@ class TestDownloadAndExtractMibigMetadata:
         assert metadata.is_file()
 
     def test_error_same_path(self, tmp_path):
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(
+            ValueError, match="Identical path of download directory and extract directory"
+        ):
             mibig.download_and_extract_mibig_metadata(tmp_path, tmp_path)
-        assert e.value.args[0] == "Identical path of download directory and extract directory"
 
     def test_error_nonempty_path(self, tmp_path):
         nonempty_path = tmp_path / "metadata" / "subdir"
         nonempty_path.mkdir(parents=True)
 
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError, match="Nonempty directory"):
             mibig.download_and_extract_mibig_metadata(tmp_path, nonempty_path.parent)
-        assert "Nonempty directory" in e.value.args[0]

--- a/tests/unit/genomics/test_utils.py
+++ b/tests/unit/genomics/test_utils.py
@@ -113,10 +113,8 @@ def test_add_strain_to_bgc_error(bgcs):
     strains.add(strain1)
     strains.add(strain2)
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="Multiple strain objects found .*"):
         add_strain_to_bgc(strains, bgcs)
-
-    assert "Multiple strain objects found for BGC id 'BGC_01'" in e.value.args[0]
 
 
 def test_add_bgc_to_gcf(bgcs):

--- a/tests/unit/metabolomics/test_gnps_downloader.py
+++ b/tests/unit/metabolomics/test_gnps_downloader.py
@@ -13,9 +13,8 @@ def setup_with_fixture(gnps_website_is_down):
 
 
 def test_unknown_workflow(tmpdir):
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="Unknown workflow type for GNPS task .*"):
         GNPSDownloader("0ad6535e34d449788f297e712f43068a", tmpdir)
-    assert "Unknown workflow type for GNPS task" in str(e.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/metabolomics/test_gnps_extractor.py
+++ b/tests/unit/metabolomics/test_gnps_extractor.py
@@ -6,9 +6,8 @@ from nplinker.metabolomics.gnps import GNPSFormat
 
 
 def test_unknown_workflow(gnps_zip_files, tmpdir):
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match="Unknown workflow type for GNPS archive .*"):
         GNPSExtractor(gnps_zip_files[GNPSFormat.Unknown], tmpdir)
-    assert "Unknown workflow type for GNPS archive" in str(e.value)
 
 
 @pytest.mark.parametrize("workflow", [GNPSFormat.FBMN, GNPSFormat.SNETS, GNPSFormat.SNETSV2])

--- a/tests/unit/strain/test_strain_collection.py
+++ b/tests/unit/strain/test_strain_collection.py
@@ -130,7 +130,7 @@ def test_add_different_id_different_alias(strain: Strain, collection: StrainColl
 
 def test_remove(strain: Strain):
     sc = StrainCollection()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Strain .* not found in the strain collection"):
         sc.remove(strain)
     assert strain not in sc
 
@@ -151,7 +151,7 @@ def test_remove_same_id_different_alias(collection: StrainCollection):
 
 def test_remove_different_id(collection: StrainCollection):
     strain = Strain("strain_2")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Strain .* not found in the strain collection"):
         collection.remove(strain)
     assert len(collection) == 1
     assert strain not in collection
@@ -195,7 +195,7 @@ def test_has_name(collection: StrainCollection):
 def test_lookup(collection: StrainCollection, strain: Strain):
     for name in strain.names:
         assert collection.lookup(name) == [strain]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Strain .* not found in the strain collection"):
         collection.lookup("strain_not_exist")
 
 


### PR DESCRIPTION
To use the `match` of `pytest.rasises(ValueError, match="...")` to check the error message in unit tests, which simplifies the test code.