### PR TITLE
Handle two quantification table folders of GNPS feature-based workflow 

### DIFF
--- a/src/nplinker/metabolomics/gnps/gnps_extractor.py
+++ b/src/nplinker/metabolomics/gnps/gnps_extractor.py
@@ -148,9 +148,18 @@ class GNPSExtractor:
             os.renames(self._extract_path / member, self._extract_path / fname)
 
     def _extract_fbmn(self):
+        # there might be two folders for quantification table
+        # "quantification_table_reformatted" and "quantification_table"
+        try:
+            quantification_table_member = self._select_member(
+                "quantification_table_reformatted", ".csv"
+            )
+        except ValueError:
+            quantification_table_member = self._select_member("quantification_table", ".csv")
+
         # the order of members matters
         members = [
-            self._select_member("quantification_table", ".csv"),
+            quantification_table_member,
             self._select_member("spectra", ".mgf"),
             self._select_member("networkedges_selfloop", ".selfloop"),
             self._select_member("DB_result", ".tsv"),


### PR DESCRIPTION
Dora found the following issue:
GNPS FEATURE-BASED-MOLECULAR-NETWORKING workflow might output two folders for quantification table with folder name:
- `quantification_table`
- `quantification_table_reformatted`
In this case, NPLinker will raise an error. However, NPLinker is expected to pick one folder and process the data.

This PR changes NPLinker to make it always first pick the `quantification_table_reformatted` folder, if this folder does not exist, then pick `quantification_table` folder to process the data. If neither exist, raise an error.