### PR TITLE
Add table display for link graph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "rich",
     "scipy",
     "sortedcontainers",
+    "tabulate",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Dora found it confused to handle LinkGraph data. To make it easier, a table display was added, so that user can display the LinkGraph as a table, e.g.

```
  >>> lg = LinkGraph()

  
Display the empty LinkGraph object:
  >>> lg
  |    |   Object 1 |   Object 2 |   Metcalf Score |   Rosetta Score |
  |----|------------|------------|-----------------|-----------------|


  Add a link between a GCF and a Spectrum object:
  >>> lg.add_link(gcf, spectrum, metcalf=Score("metcalf", 1.0, {"cutoff": 0.5}))


  Display all links in LinkGraph object:
  >>> lg
  |    |     Object 1 |               Object 2 |   Metcalf Score |   Rosetta Score |
  |----|--------------|------------------------|-----------------|-----------------|
  |  1 | GCF(id=gcf1) | Spectrum(id=spectrum1) |               1 |               - |

```