### PR TITLE
Allow bigscape run for local mode

### DIFF
--- a/docs/diagrams/arranger.md
+++ b/docs/diagrams/arranger.md
@@ -28,7 +28,7 @@ flowchart TD
     P --> |Yes| P1[Validate the file]
 ```
 
-## GNPS, AntiSMASH and BigScape 
+## GNPS and AntiSMASH 
 ``` mermaid
 flowchart TD
     ConfigError[Dynaconf config validation error]
@@ -36,7 +36,7 @@ flowchart TD
     UseIt[Use the data]
     Download[First remove existing data if relevent, then download or generate data]
 
-    A[GNPS, antiSMASH and BigSCape] --> B{Pass Dynaconf config validation?}
+    A[GNPS or antiSMASH] --> B{Pass Dynaconf config validation?}
     B -->|No | ConfigError
     B -->|Yes| G{Is the mode PODP?}
     
@@ -52,6 +52,32 @@ flowchart TD
     J -->|No | Download --> |try max 2 times| J
     J -->|Yes| UseIt
 ```
+
+## BigScape
+```mermaid
+flowchart TD
+    ConfigError[Dynaconf config validation error]
+    DataError[Data validation error]
+    UseIt[Use the data]
+    Download[First remove existing data if relevent, then download or generate data]
+
+    A[BigSCape] --> B{Pass Dynaconf config validation?}
+    B -->|No | ConfigError
+    B -->|Yes| G{Is the mode PODP?}
+    
+    G -->|No, local mode| G1{Does data dir exist?}
+    G1 -->|No | Download
+    G1 -->|Yes| H{Pass data validation?}
+    H --> |No | DataError
+    H --> |Yes| UseIt 
+
+    G -->|Yes, podp mode| G2{Does data dir exist?}
+    G2 --> |No | Download
+    G2 --> |Yes | J{Pass data validation?}
+    J -->|No | Download --> |try max 2 times| J
+    J -->|Yes| UseIt
+```
+
 
 ## MIBiG Data
 MIBiG data is always downloaded automatically. Users cannot provide their own MIBiG data.


### PR DESCRIPTION
This PR enables the support of running bigscape in local mode when users does not provide bigscape data. If users provide data, then only validate it.

