### PR TITLE
Adding feature: strain mapping locally

### DIFF
--- a/notebooks/local_strain_mapping.ipynb
+++ b/notebooks/local_strain_mapping.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Strain info to get the genome_id and spectras_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nplinker.strain.utils import extract_strain_metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "strain_genome=extract_strain_metadata(\"/Users/rosinatorres/Documents/PhD/WP3/nplinker_workshop/nplinker/tests/unit/data3/3strains_metadata_genome.txt\")\n",
+    "strain_spectra=extract_strain_metadata(\"/Users/rosinatorres/Documents/PhD/WP3/nplinker_workshop/nplinker/tests/unit/data3/3strains_metadata_extract.txt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Extracts the bgcs from antismash results, with the associated genome_id from the metadatafile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nplinker.strain.utils import extract_bgcs_genome_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bgcs_path = \"/Users/rosinatorres/Documents/PhD/WP3/nplinker_workshop/nplinker/tests/unit/data3/antismash\" # Replace with the path to your antiSMASH results\n",
+    "bgc_dict,strain_bgcs = extract_bgcs_genome_id(strain_genome, bgcs_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Extracts the features from gnps results, with the associated spectra from the metadatafile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nplinker.strain.utils import extract_features_metabolome_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "features_path =\"/Users/rosinatorres/Documents/PhD/WP3/nplinker_workshop/nplinker/tests/unit/data3/gnps/file_mappings.csv\"\n",
+    "strain_features = extract_features_metabolome_id(strain_spectra, features_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Strain_mapping creation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nplinker.strain.utils import create_strain_mappings\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "JSON file 'strain_mappings_2.json' has been created successfully.\n"
+     ]
+    }
+   ],
+   "source": [
+    "create_strain_mappings(strain_genome, bgc_dict, strain_features)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "npl_dev_2",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/nplinker/genomics/antismash/antismash_loader.py
+++ b/src/nplinker/genomics/antismash/antismash_loader.py
@@ -57,6 +57,17 @@ class AntismashBGCLoader(BGCLoaderBase):
             bid: os.path.basename(os.path.dirname(bpath)) for bid, bpath in self._file_dict.items()
         }
 
+    def get_genome_bgcs_mapping(self) -> dict[str, list]:
+        """Get the mapping from genome to BGCs.
+
+        Returns:
+            The key is genome id and value is a list of BGC names (gbk file names
+        """
+        genome_to_bgcs = {}
+        for bgc, genome in self.get_bgc_genome_mapping().items():
+            genome_to_bgcs.setdefault(genome, []).append(bgc)
+        return genome_to_bgcs
+
     def get_files(self) -> dict[str, str]:
         """Get BGC gbk files.
 


### PR DESCRIPTION
This is a new feature for generating the file needed for running NPLinker called **strain_mappings in local mode.** 

The src and test were modified in:

- nplinker 
-> antismash_loader.py -> creating a dict for genome --> bgcs
-> strain -> utils.py -> four new functions:
1. extract_strain_metadata (for the creation of the json file)
2. extract features metabolite id -> for making a strain --> features dictionary
3. extract bgcs genome id -> for making a strain --> bgcs dictionary
4. merge features and bgcs
5. build a nice dictionary with the info needed for running NPLinker in local mode

I also added the testing functions:
- test for each function

There is a notebook for running all the functions step by step: ~/nplinker/tests/unit/local_strain_mapping.ipynb
I would strongly suggest that the test/data information is updated with the correct information as antismash results generates. The current strain_mapping is incorrect as well as the folder generated in test/unit/data/antismash. I generated another folder where the data is correct, but I was not sure if adding that to the pull request yet.
