### PR TITLE
change bigscape version setting from int to str

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -182,7 +182,7 @@ Here are some example values for the `nplinker.toml` file:
     version = "3.1"
 
     [bigscape]
-    version = 1
+    version = "1"
     cutoff = "0.30"
 
     [scoring]
@@ -208,7 +208,7 @@ Here are some example values for the `nplinker.toml` file:
     version = "3.1"
 
     [bigscape]
-    version = 2
+    version = "2"
     cutoff = "0.30"
     parameters = "--mibig_version 3.1 --include_singletons --gcf_cutoffs 0.30"
 

--- a/src/nplinker/arranger.py
+++ b/src/nplinker/arranger.py
@@ -319,7 +319,7 @@ class DatasetArranger:
             version,
         )
 
-        if version == 1:
+        if version == "1":
             for f in glob(
                 str(
                     self.bigscape_running_output_dir
@@ -330,7 +330,7 @@ class DatasetArranger:
                 )
             ):
                 shutil.copy(f, self.bigscape_dir)
-        elif version == 2:
+        elif version == "2":
             shutil.copy(
                 self.bigscape_running_output_dir / "data_sqlite.db",
                 self.bigscape_dir,

--- a/src/nplinker/config.py
+++ b/src/nplinker/config.py
@@ -69,7 +69,7 @@ CONFIG_VALIDATORS = [
     # BigScape
     Validator("bigscape.parameters", is_type_of=str),
     Validator("bigscape.cutoff", required=True, is_type_of=str),
-    Validator("bigscape.version", required=True, is_type_of=int, is_in=[1, 2]),
+    Validator("bigscape.version", required=True, is_type_of=str, is_in=["1", "2"]),
     # Scoring
     ## `scoring.methods` must be a list of strings and must contain at least one of the
     ## supported scoring methods.

--- a/src/nplinker/data/nplinker.toml
+++ b/src/nplinker/data/nplinker.toml
@@ -53,8 +53,8 @@ version = "3.1"
 [bigscape]
 # Settings for BiG-SCAPE.
 
-version = 1
-# [REQUIRED] Available values are 1 and 2. 1 for version 1.x series and 2 for version 2.x series.
+version = "1"
+# [REQUIRED] Available values are "1" and "2". "1" for version 1.x series and "2" for version 2.x series.
 # The version of BiG-SCAPE to use.
 
 cutoff = "0.30"

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -206,7 +206,7 @@ class DatasetLoader:
         all_bgcs_with_strain = antismash_bgcs_with_strain + self.mibig_bgcs
 
         # Step 4: load all GCF objects
-        if self.config.bigscape.version == 1:
+        if self.config.bigscape.version == "1":
             bigscape_cluster_file = (
                 self.config.root_dir
                 / defaults.BIGSCAPE_DIRNAME
@@ -214,7 +214,7 @@ class DatasetLoader:
             )
             loader = BigscapeGCFLoader(bigscape_cluster_file)
             logger.info(f"Loading BigSCAPE cluster file {bigscape_cluster_file}")
-        elif self.config.bigscape.version == 2:
+        elif self.config.bigscape.version == "2":
             bigscape_db_file = self.config.root_dir / defaults.BIGSCAPE_DIRNAME / "data_sqlite.db"
             loader = BigscapeV2GCFLoader(bigscape_db_file)
             logger.info(f"Loading BigSCAPE database file {bigscape_db_file}")

--- a/src/nplinker/utils.py
+++ b/src/nplinker/utils.py
@@ -249,7 +249,7 @@ def _extract_tar(
     members: Sequence[tarfile.TarInfo] | None,
     compression: str | None,
 ) -> None:
-    with tarfile.open(from_path, f"r:{compression[1:]}" if compression else "r") as tar:
+    with tarfile.open(from_path, f"r:{compression[1:]}" if compression else "r") as tar:  # type: ignore
         tar.extractall(to_path, members)
 
 

--- a/tests/integration/data/nplinker_local_mode.toml
+++ b/tests/integration/data/nplinker_local_mode.toml
@@ -10,7 +10,7 @@ to_use = true
 version = "3.1"
 
 [bigscape]
-version = 1
+version = "1"
 cutoff = "0.30"
 
 [scoring]

--- a/tests/unit/data/nplinker_local_mode.toml
+++ b/tests/unit/data/nplinker_local_mode.toml
@@ -10,7 +10,7 @@ to_use = true
 version = "3.1"
 
 [bigscape]
-version = 1
+version = "1"
 cutoff = "0.30"
 
 [scoring]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -20,6 +20,6 @@ def test_config(tmp_path):
     assert config.mibig.version == "3.1"
 
     assert config.bigscape.cutoff == "0.30"
-    assert config.bigscape.version == 1
+    assert config.bigscape.version == "1"
 
     assert config.scoring.methods == ["metcalf"]


### PR DESCRIPTION
This change will make the type of `version` settings in config file consistent.