### PR TITLE
add gnps version as a new setting in config file

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -185,6 +185,9 @@ Here are some example values for the `nplinker.toml` file:
     version = "1"
     cutoff = "0.30"
 
+    [gnps]
+    version = "1"
+
     [scoring]
     methods = ["metcalf"]
     ```
@@ -211,6 +214,9 @@ Here are some example values for the `nplinker.toml` file:
     version = "2"
     cutoff = "0.30"
     parameters = "--mibig_version 3.1 --include_singletons --gcf_cutoffs 0.30"
+
+    [gnps]
+    version = "1"
 
     [scoring]
     methods = ["metcalf"]

--- a/src/nplinker/config.py
+++ b/src/nplinker/config.py
@@ -70,6 +70,8 @@ CONFIG_VALIDATORS = [
     Validator("bigscape.parameters", is_type_of=str),
     Validator("bigscape.cutoff", required=True, is_type_of=str),
     Validator("bigscape.version", required=True, is_type_of=str, is_in=["1", "2"]),
+    # GNPS
+    Validator("gnps.version", required=True, is_type_of=str, is_in=["1", "2"]),
     # Scoring
     ## `scoring.methods` must be a list of strings and must contain at least one of the
     ## supported scoring methods.

--- a/src/nplinker/data/nplinker.toml
+++ b/src/nplinker/data/nplinker.toml
@@ -80,6 +80,14 @@ parameters = "version1_parameters_or_version2_parameters"
 # BiG-SCPAPE v2 also runs a `--mix` analysis by default, so you don't need to set this parameter here.
 # An example value could be: "--mibig_version 3.1 --include_singletons --gcf_cutoffs 0.30"
 
+[gnps]
+# Settings for GNPS.
+
+version = "1"
+# [REQUIRED] Available values are "1" and "2".
+# The version of GNPS platform you have used to run the analysis.
+# Set the version to "1" if you have used https://gnps.ucsd.edu/;
+# Set the version to "2" if you have used https://gnps2.org/.
 
 [scoring]
 # Settings for scoring.

--- a/tests/integration/data/nplinker_local_mode.toml
+++ b/tests/integration/data/nplinker_local_mode.toml
@@ -13,5 +13,8 @@ version = "3.1"
 version = "1"
 cutoff = "0.30"
 
+[gnps]
+version = "1"
+
 [scoring]
 methods = ["metcalf"]

--- a/tests/unit/data/nplinker_local_mode.toml
+++ b/tests/unit/data/nplinker_local_mode.toml
@@ -13,5 +13,8 @@ version = "3.1"
 version = "1"
 cutoff = "0.30"
 
+[gnps]
+version = "1"
+
 [scoring]
 methods = ["metcalf"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,4 +22,6 @@ def test_config(tmp_path):
     assert config.bigscape.cutoff == "0.30"
     assert config.bigscape.version == "1"
 
+    assert config.gnps.version == "1"
+
     assert config.scoring.methods == ["metcalf"]


### PR DESCRIPTION
To support GNPS2 (https://gnps2.org/) data in NPLinker, we have to add a new setting `gnps.version` in the config file `nplinker.toml`.