### PR TITLE
fix mkdocs warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,6 @@ jobs:
           python3 --version
       - name: Upgrade pip and install dependencies
         run: |
-          python3 -m pip install --upgrade pip setuptools
           pip install build pytest wheel pytest-xdist
       - name: Build the package
         run: 	python -m build
@@ -79,7 +78,6 @@ jobs:
           python3 --version
       - name: Upgrade pip and install dependencies
         run: |
-          python3 -m pip install --upgrade pip setuptools
           pip install build pytest wheel pytest-xdist
       - name: Build the package
         run: 	python -m build

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 	@echo "update - update pip, build, twine packages"
 	@echo "update-version - update NPLinker version. Usage: make update-version CURRENT_VERSION=0.1.0 NEW_VERSION=0.2.0"
 
-clean: clean-build clean-pyc clean-test
+clean: clean-build clean-pyc clean-test clean-doc
 
 clean-build:
 	rm -fr build/
@@ -29,6 +29,9 @@ clean-pyc:
 clean-test:
 	rm -f .coverage*
 	rm -f coverage.xml
+
+clean-doc:
+	rm -rf site
 
 build: clean
 	python -m build

--- a/docs/concepts/bigscape.md
+++ b/docs/concepts/bigscape.md
@@ -2,5 +2,3 @@ NPLinker can run BigScape automatically if the `bigscape` directory does not exi
 Both version 1 and version 2 of BigScape are supported.
 
 See the [configuration template][configuration-template] for how to set parameters for running BigScape.
-
-See the [default configurations][default-configurations] for the default parameters used in NPLinker.

--- a/docs/concepts/gnps_data.md
+++ b/docs/concepts/gnps_data.md
@@ -1,4 +1,4 @@
-# GNPS data 
+# GNPS
 
 NPLinker requires GNPS molecular networking data as input. It currently accepts data from both GNPS1
 (https://gnps.ucsd.edu) and GNPS2 (https://gnps2.org) workflows.

--- a/src/nplinker/metabolomics/gnps/gnps_downloader.py
+++ b/src/nplinker/metabolomics/gnps/gnps_downloader.py
@@ -45,7 +45,11 @@ class GNPSDownloader:
             ValueError: If the given GNPS version is not valid.
 
         Examples:
-            >>> GNPSDownloader("c22f44b14a3d450eb836d607cb9521bb", "~/downloads")
+            Download GNPS1 job
+            >>> GNPSDownloader("c22f44b14a3d450eb836d607cb9521bb", "~/downloads", "1")
+
+            Download GNPS2 job
+            >>> GNPSDownloader("2014f321d72542afb5216c932e0d5079", "~/downloads", "2")
         """
         if gnps_version == "1":
             gnps_format = gnps_format_from_gnps1_task_id(task_id)


### PR DESCRIPTION
This PR contains several minor miscellaneous changes.

The mkdocs warnings are:

```
WARNING -  mkdocs_autorefs: Multiple primary URLs found for 'gnps-data': ['quickstart/#gnps-data', 'concepts/gnps_data/#gnps-data']. Make sure to use unique headings, identifiers, or Markdown anchors (see our
           docs).
WARNING -  mkdocs_autorefs: concepts/bigscape.md: Could not find cross-reference target 'default-configurations'
``` 