### PR TITLE
Fix inconsistent Bigscape version handling

### DIFF
--- a/src/nplinker/genomics/bigscape/runbigscape.py
+++ b/src/nplinker/genomics/bigscape/runbigscape.py
@@ -16,7 +16,7 @@ def run_bigscape(
     antismash_path: str | PathLike,
     output_path: str | PathLike,
     extra_params: str,
-    version: Literal[1, 2] = 1,
+    version: Literal["1", "2"] = "1",
 ) -> bool:
     """Runs BiG-SCAPE to cluster BGCs.
 
@@ -48,7 +48,7 @@ def run_bigscape(
         antismash_path: Path to the antismash output directory.
         output_path: Path to the output directory where BiG-SCAPE will write its results.
         extra_params: Additional parameters to pass to BiG-SCAPE.
-        version: The version of BiG-SCAPE to run. Must be 1 or 2.
+        version: The version of BiG-SCAPE to run. Must be "1" or "2".
 
     Returns:
         True if BiG-SCAPE ran successfully, False otherwise.
@@ -62,15 +62,15 @@ def run_bigscape(
     Examples:
         >>>  from nplinker.genomics.bigscape import run_bigscape
         >>> run_bigscape(antismash_path="./antismash", output_path="./output",
-        ... extra_params="--help", version=1)
+        ... extra_params="--help", version="1")
     """
     # switch to correct version of BiG-SCAPE
-    if version == 1:
+    if version == "1":
         bigscape_py_path = "bigscape.py"
-    elif version == 2:
+    elif version == "2":
         bigscape_py_path = "bigscape-v2.py"
     else:
-        raise ValueError("Invalid BiG-SCAPE version number. Expected: 1 or 2.")
+        raise ValueError("Invalid BiG-SCAPE version number. Expected: '1' or '2'.")
 
     try:
         subprocess.run([bigscape_py_path, "-h"], capture_output=True, check=True)
@@ -92,9 +92,9 @@ def run_bigscape(
 
     # version 2 points to specific Pfam file, version 1 points to directory
     # version 2 also requires the cluster subcommand
-    if version == 1:
+    if version == "1":
         args.extend(["--pfam_dir", PFAM_PATH])
-    elif version == 2:
+    elif version == "2":
         args.extend(["cluster", "--pfam_path", os.path.join(PFAM_PATH, "Pfam-A.hmm")])
 
     # add input and output paths. these are unchanged

--- a/tests/unit/genomics/test_runbigscape.py
+++ b/tests/unit/genomics/test_runbigscape.py
@@ -4,7 +4,7 @@ from nplinker.genomics import bigscape
 from .. import DATA_DIR
 
 
-@pytest.mark.parametrize("version", [1, 2])
+@pytest.mark.parametrize("version", ["1", "2"])
 def test_run_bigscape(tmp_path, version):
     """Test whether BiG-SCAPE runs at all using the --help command"""
     result = bigscape.run_bigscape(
@@ -17,8 +17,10 @@ def test_run_bigscape(tmp_path, version):
     assert result is True
 
 
-@pytest.mark.skipif(os.getenv('GITHUB_ACTIONS') == 'true', reason="The test is time-consuming on CI")
-@pytest.mark.parametrize("version", [1, 2])
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") == "true", reason="The test is time-consuming on CI"
+)
+@pytest.mark.parametrize("version", ["1", "2"])
 def test_run_bigscape_small_dataset(tmp_path, version):
     result = bigscape.run_bigscape(
         antismash_path=DATA_DIR / "bigscape" / "minimal_dataset",
@@ -36,13 +38,13 @@ def test_run_bigscape_wrong_version(tmp_path):
             antismash_path=DATA_DIR,
             output_path=tmp_path,
             extra_params="--help",
-            version=3,
+            version="3",
         )
 
     assert "version" in e.value.args[0]
 
 
-@pytest.mark.parametrize("version", [1, 2])
+@pytest.mark.parametrize("version", ["1", "2"])
 def test_input_path_not_exist(tmp_path, version):
     with pytest.raises(FileNotFoundError) as e:
         bigscape.run_bigscape(
@@ -55,7 +57,7 @@ def test_input_path_not_exist(tmp_path, version):
     assert "antismash_path" in e.value.args[0]
 
 
-@pytest.mark.parametrize("version", [1, 2])
+@pytest.mark.parametrize("version", ["1", "2"])
 def test_bad_parameters(tmp_path, version):
     with pytest.raises(RuntimeError) as e:
         bigscape.run_bigscape(


### PR DESCRIPTION
Fixes issue #305

Standardizes the handling of the BiG-SCAPE version number to be a string throughout the codebase.

**Changes Made**

- Updated `nplinker/genomics/bigscape/runbigscape.py` to expect the BiG-SCAPE version as a string instead of an integer.
- Adjusted relevant tests to ensure compatibility with the updated version format.