### PR TITLE
Fix: Handle invalid GenBank accessions or missing RefSeq accessions in _resolve_genbank_accession()

### DIFF
--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -274,37 +274,37 @@ def _resolve_genbank_accession(genbank_id: str) -> str:
     # For schema, see https://www.ncbi.nlm.nih.gov/datasets/docs/v2/api/rest-api/#get-/genome/accession/-accession-/revision_history
     url = f"https://api.ncbi.nlm.nih.gov/datasets/v2/genome/accession/{genbank_id}/revision_history"
 
+    refseq_id = ""
     try:
         resp = httpx.get(
             url, headers={"User-Agent": USER_AGENT}, timeout=10.0, follow_redirects=True
         )
         resp.raise_for_status()
+
+        data = resp.json()
+        if not data:
+            raise ValueError("No Assembly Revision data found")
+
+        assembly_entries = [
+            entry for entry in data["assembly_revisions"] if "refseq_accession" in entry
+        ]
+        if not assembly_entries:
+            raise ValueError("No RefSeq assembly accession found")
+
+        latest_entry = max(assembly_entries, key=lambda x: x["release_date"])
+        refseq_id: str = latest_entry["refseq_accession"]
+
     except httpx.RequestError as exc:
         logger.warning(f"An error occurred while requesting {exc.request.url!r}: {exc}")
-        return ""
     except httpx.HTTPStatusError as exc:
         logger.warning(
             f"Error response {exc.response.status_code} while requesting {exc.request.url!r}"
         )
-        return ""
     except httpx.ReadTimeout:
         logger.warning("Timed out waiting for result of GenBank assembly lookup")
-        return ""
+    except ValueError as exc:
+        logger.warning(f"Error while resolving GenBank assembly accession {genbank_id}: {exc}")
 
-    data = resp.json()
-    if not data:
-        logger.warning(f"Invalid GenBank accession {genbank_id}: no data found")
-        return ""
-
-    assembly_entries = [
-        entry for entry in data["assembly_revisions"] if "refseq_accession" in entry
-    ]
-    if not assembly_entries:
-        logger.warning(f"No RefSeq accession found for GenBank accession {genbank_id}")
-        return ""
-
-    latest_entry = max(assembly_entries, key=lambda x: x["release_date"])
-    refseq_id: str = latest_entry["refseq_accession"]
     return refseq_id
 
 

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -287,6 +287,8 @@ def _resolve_genbank_accession(genbank_id: str) -> str:
             if assembly_entries:
                 latest_entry = max(assembly_entries, key=lambda x: x["release_date"])
                 refseq_id = latest_entry["refseq_accession"]
+            else:
+                logger.warning(f"No RefSeq accession found for GenBank accession {genbank_id}")
     except httpx.ReadTimeout:
         logger.warning("Timed out waiting for result of GenBank assembly lookup")
 

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -292,7 +292,7 @@ def _resolve_genbank_accession(genbank_id: str) -> str:
             raise ValueError("No RefSeq assembly accession found")
 
         latest_entry = max(assembly_entries, key=lambda x: x["release_date"])
-        refseq_id: str = latest_entry["refseq_accession"]
+        refseq_id = latest_entry["refseq_accession"]
 
     except httpx.RequestError as exc:
         logger.warning(f"An error occurred while requesting {exc.request.url!r}: {exc}")

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -304,7 +304,8 @@ def _resolve_genbank_accession(genbank_id: str) -> str:
         return ""
 
     latest_entry = max(assembly_entries, key=lambda x: x["release_date"])
-    return latest_entry["refseq_accession"]
+    refseq_id: str = latest_entry["refseq_accession"]
+    return refseq_id
 
 
 def _resolve_jgi_accession(jgi_id: str) -> str:

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -281,11 +281,12 @@ def _resolve_genbank_accession(genbank_id: str) -> str:
         )
         if resp.status_code == httpx.codes.OK:
             data = resp.json()
-            latest_entry = max(
-                (entry for entry in data["assembly_revisions"] if "refseq_accession" in entry),
-                key=lambda x: x["release_date"],
-            )
-            refseq_id = latest_entry["refseq_accession"]
+            assembly_entries = [
+                entry for entry in data["assembly_revisions"] if "refseq_accession" in entry
+            ]
+            if assembly_entries:
+                latest_entry = max(assembly_entries, key=lambda x: x["release_date"])
+                refseq_id = latest_entry["refseq_accession"]
     except httpx.ReadTimeout:
         logger.warning("Timed out waiting for result of GenBank assembly lookup")
 

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -274,30 +274,37 @@ def _resolve_genbank_accession(genbank_id: str) -> str:
     # For schema, see https://www.ncbi.nlm.nih.gov/datasets/docs/v2/api/rest-api/#get-/genome/accession/-accession-/revision_history
     url = f"https://api.ncbi.nlm.nih.gov/datasets/v2/genome/accession/{genbank_id}/revision_history"
 
-    refseq_id = ""
     try:
         resp = httpx.get(
             url, headers={"User-Agent": USER_AGENT}, timeout=10.0, follow_redirects=True
         )
-        if resp.status_code == httpx.codes.OK:
-            data = resp.json()
-            if not data.get("assembly_revisions"):
-                logger.warning(
-                    f"Invalid GenBank accession {genbank_id}: no assembly revisions found"
-                )
-                return ""
-            assembly_entries = [
-                entry for entry in data["assembly_revisions"] if "refseq_accession" in entry
-            ]
-            if assembly_entries:
-                latest_entry = max(assembly_entries, key=lambda x: x["release_date"])
-                refseq_id = latest_entry["refseq_accession"]
-            else:
-                logger.warning(f"No RefSeq accession found for GenBank accession {genbank_id}")
+        resp.raise_for_status()
+    except httpx.RequestError as exc:
+        logger.warning(f"An error occurred while requesting {exc.request.url!r}: {exc}")
+        return ""
+    except httpx.HTTPStatusError as exc:
+        logger.warning(
+            f"Error response {exc.response.status_code} while requesting {exc.request.url!r}"
+        )
+        return ""
     except httpx.ReadTimeout:
         logger.warning("Timed out waiting for result of GenBank assembly lookup")
+        return ""
 
-    return refseq_id
+    data = resp.json()
+    if not data:
+        logger.warning(f"Invalid GenBank accession {genbank_id}: no data found")
+        return ""
+
+    assembly_entries = [
+        entry for entry in data["assembly_revisions"] if "refseq_accession" in entry
+    ]
+    if not assembly_entries:
+        logger.warning(f"No RefSeq accession found for GenBank accession {genbank_id}")
+        return ""
+
+    latest_entry = max(assembly_entries, key=lambda x: x["release_date"])
+    return latest_entry["refseq_accession"]
 
 
 def _resolve_jgi_accession(jgi_id: str) -> str:

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -281,6 +281,11 @@ def _resolve_genbank_accession(genbank_id: str) -> str:
         )
         if resp.status_code == httpx.codes.OK:
             data = resp.json()
+            if not data.get("assembly_revisions"):
+                logger.warning(
+                    f"Invalid GenBank accession {genbank_id}: no assembly revisions found"
+                )
+                return ""
             assembly_entries = [
                 entry for entry in data["assembly_revisions"] if "refseq_accession" in entry
             ]


### PR DESCRIPTION
**Fixes issue #307 + additional issue**

This PR addresses two different bugs in the `_resolve_genbank_accession()` function when resolving GenBank accession numbers to RefSeq accessions:  

1. The function previously failed when a valid GenBank accession existed in NCBI but had no corresponding RefSeq accession.  
2. It also broke when the provided GenBank accession was invalid (not found in NCBI).  

### Changes & Improvements:  
- Instead of causing an error, the function now returns an empty string (`""`) when no RefSeq accession is available.  
- Additional error handling cases have been added to improve robustness.  
- The function has been refactored for better readability and maintainability.  