### PR TITLE
Feature/antismash_api_jobs

### DIFF
--- a/.github/workflows/format-typing-check.yml
+++ b/.github/workflows/format-typing-check.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Install ruff and mypy
         run: |
           pip install ruff mypy typing_extensions \
-            types-Deprecated types-beautifulsoup4 types-jsonschema \
-            types-networkx types-tabulate types-PyYAML pandas-stubs
+            types-Deprecated types-beautifulsoup4 types-jsonschema types-requests \
+            types-networkx types-tabulate types-PyYAML pandas-stubs 
       - name: Get all changed python files
         id: changed-python-files
         uses: tj-actions/changed-files@v44

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "mypy",
     "typing_extensions",
     # stub packages. Update the `format-typing-check.yml` too if you add more.
+    "types-requests",
     "types-beautifulsoup4",
     "types-jsonschema",
     "types-networkx",

--- a/src/nplinker/genomics/antismash/__init__.py
+++ b/src/nplinker/genomics/antismash/__init__.py
@@ -1,16 +1,24 @@
-from .antismash_downloader import download_and_extract_antismash_data
+from .antismash_api_client import antismash_job_is_done
+from .antismash_api_client import submit_antismash_job
+from .antismash_downloader import download_and_extract_from_antismash_api
+from .antismash_downloader import download_and_extract_from_antismash_db
 from .antismash_loader import AntismashBGCLoader
 from .antismash_loader import parse_bgc_genbank
+from .ncbi_downloader import download_and_extract_ncbi_genome
 from .podp_antismash_downloader import GenomeStatus
 from .podp_antismash_downloader import get_best_available_genome_id
 from .podp_antismash_downloader import podp_download_and_extract_antismash_data
 
 
 __all__ = [
-    "download_and_extract_antismash_data",
+    "download_and_extract_from_antismash_api",
+    "download_and_extract_from_antismash_db",
     "AntismashBGCLoader",
     "parse_bgc_genbank",
     "GenomeStatus",
     "get_best_available_genome_id",
     "podp_download_and_extract_antismash_data",
+    "download_and_extract_ncbi_genome",
+    "submit_antismash_job",
+    "antismash_job_is_done",
 ]

--- a/src/nplinker/genomics/antismash/__init__.py
+++ b/src/nplinker/genomics/antismash/__init__.py
@@ -2,6 +2,7 @@ from .antismash_api_client import antismash_job_is_done
 from .antismash_api_client import submit_antismash_job
 from .antismash_downloader import download_and_extract_from_antismash_api
 from .antismash_downloader import download_and_extract_from_antismash_db
+from .antismash_downloader import extract_antismash_data
 from .antismash_loader import AntismashBGCLoader
 from .antismash_loader import parse_bgc_genbank
 from .ncbi_downloader import download_and_extract_ncbi_genome
@@ -11,6 +12,7 @@ from .podp_antismash_downloader import podp_download_and_extract_antismash_data
 
 
 __all__ = [
+    "extract_antismash_data",
     "download_and_extract_from_antismash_api",
     "download_and_extract_from_antismash_db",
     "AntismashBGCLoader",

--- a/src/nplinker/genomics/antismash/antismash_api_client.py
+++ b/src/nplinker/genomics/antismash/antismash_api_client.py
@@ -18,7 +18,7 @@ def submit_antismash_job(genbank_filepath: str | PathLike) -> str:
         genbank_filepath (str | PathLike): The path to the GenBank file to be submitted.
 
     Returns:
-        str: The job ID if the submission.
+        str: The job ID of the submitted antiSMASH job.
 
     Raises:
         requests.exceptions.RequestException: If there is an issue with the HTTP request.

--- a/src/nplinker/genomics/antismash/antismash_api_client.py
+++ b/src/nplinker/genomics/antismash/antismash_api_client.py
@@ -9,7 +9,7 @@ import requests
 logger = logging.getLogger(__name__)
 
 
-def submit_antismash_job(genbank_filepath: str | PathLike) -> Optional[str]:
+def submit_antismash_job(genbank_filepath: str | PathLike) -> str:
     """Submits an antiSMASH job using the provided GenBank file.
 
     This function sends a GenBank file to the antiSMASH API
@@ -19,11 +19,11 @@ def submit_antismash_job(genbank_filepath: str | PathLike) -> Optional[str]:
         genbank_filepath (str | PathLike): The path to the GenBank file to be submitted.
 
     Returns:
-        Optional[str]: The job ID if the submission is successful, or None if it fails.
+        str: The job ID if the submission.
 
     Raises:
         requests.exceptions.RequestException: If there is an issue with the HTTP request.
-         RuntimeError: If the API response does not contain a job ID.
+        RuntimeError: If the API response does not contain a job ID.
     """
     url = "https://antismash.secondarymetabolites.org/api/v1.0/submit"
     genbank_filepath = Path(genbank_filepath)

--- a/src/nplinker/genomics/antismash/antismash_api_client.py
+++ b/src/nplinker/genomics/antismash/antismash_api_client.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+import logging
+from os import PathLike
+from pathlib import Path
+from typing import Optional
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+
+def submit_antismash_job(genbank_filepath: str | PathLike) -> Optional[str]:
+    """Submits an antiSMASH job using the provided GenBank file.
+
+    This function sends a GenBank file to the antiSMASH API
+    and retrieves the job ID if the submission is successful.
+
+    Args:
+        genbank_filepath (str | PathLike): The path to the GenBank file to be submitted.
+
+    Returns:
+        Optional[str]: The job ID if the submission is successful, or None if it fails.
+
+    Raises:
+        requests.exceptions.RequestException: If there is an issue with the HTTP request.
+         RuntimeError: If the API response does not contain a job ID.
+    """
+    url = "https://antismash.secondarymetabolites.org/api/v1.0/submit"
+    genbank_filepath = Path(genbank_filepath)
+
+    with open(genbank_filepath, "rb") as file:
+        files = {"seq": file}
+        response = requests.post(url, files=files)
+        response.raise_for_status()  # Raise an exception for HTTP errors
+
+    data = response.json()
+    if "id" not in data:
+        raise RuntimeError("No antiSMASH job ID returned")
+    return data["id"]
+
+
+def query_antismash_job(job_id: str) -> Optional[dict]:
+    """Gets the status of an antiSMASH job.
+
+    Args:
+        job_id (str): The job ID to query.
+
+    Returns:
+        dict: The response JSON if successful, otherwise None.
+    """
+    url = f"https://antismash.secondarymetabolites.org/api/v1.0/status/{job_id}"
+
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()  # Raise an exception for HTTP errors
+        return response.json()
+
+    except requests.exceptions.RequestException as req_err:
+        logger.error(f"Request failed for job_id {job_id}: {req_err}")
+    except ValueError as json_err:  # Handles JSON decoding errors
+        logger.error(f"Invalid JSON response for job_id {job_id}: {json_err}")
+    except Exception as err:
+        logger.error(f"Unexpected error while getting job state for job_id {job_id}: {err}")
+
+
+def antismash_job_is_done(job_id: str) -> bool:
+    """Checks if the antiSMASH job is complete by polling the job status.
+
+    Args:
+        job_id (str): The job ID to query.
+
+    Returns:
+        bool: True if the job is done, False if the job is still running.
+
+    Raises:
+        RuntimeError: If the job status could not be retrieved or if the job failed.
+        ValueError: If the job state is missing or unexpected in the response.
+    """
+    response = query_antismash_job(job_id)
+
+    if response is None:
+        raise RuntimeError(f"Failed to retrieve job status for job_id {job_id}")
+    if "state" not in response:
+        raise ValueError(f"Job state missing in response for job_id: {job_id}")
+
+    job_state = response["state"]
+    if job_state in ("running", "queued"):
+        return False
+    if job_state == "done":
+        return True
+    if job_state == "failed":
+        job_status = response.get("status", "No error message provided")
+        raise RuntimeError(f"AntiSMASH job {job_id} failed with an error: {job_status}")
+    else:
+        raise ValueError(
+            f"Unexpected job state for antismash job ID {job_id}. Job state: {job_state}"
+        )

--- a/src/nplinker/genomics/antismash/antismash_api_client.py
+++ b/src/nplinker/genomics/antismash/antismash_api_client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 import logging
 from os import PathLike
 from pathlib import Path
-from typing import Optional
 import requests
 
 
@@ -36,60 +35,45 @@ def submit_antismash_job(genbank_filepath: str | PathLike) -> str:
     data = response.json()
     if "id" not in data:
         raise RuntimeError("No antiSMASH job ID returned")
-    return data["id"]
-
-
-def query_antismash_job(job_id: str) -> Optional[dict]:
-    """Gets the status of an antiSMASH job.
-
-    Args:
-        job_id (str): The job ID to query.
-
-    Returns:
-        dict: The response JSON if successful, otherwise None.
-    """
-    url = f"https://antismash.secondarymetabolites.org/api/v1.0/status/{job_id}"
-
-    try:
-        response = requests.get(url, timeout=10)
-        response.raise_for_status()  # Raise an exception for HTTP errors
-        return response.json()
-
-    except requests.exceptions.RequestException as req_err:
-        logger.error(f"Request failed for job_id {job_id}: {req_err}")
-    except ValueError as json_err:  # Handles JSON decoding errors
-        logger.error(f"Invalid JSON response for job_id {job_id}: {json_err}")
-    except Exception as err:
-        logger.error(f"Unexpected error while getting job state for job_id {job_id}: {err}")
+    return str(data["id"])
 
 
 def antismash_job_is_done(job_id: str) -> bool:
-    """Checks if the antiSMASH job is complete by polling the job status.
+    """Determines if the antiSMASH job has completed by checking its status.
+
+    This function queries the antiSMASH API to retrieve the current state
+    of the job and determines whether it has finished successfully, is still
+    in progress, or has encountered an error.
 
     Args:
-        job_id (str): The job ID to query.
+        job_id (str): The unique identifier of the antiSMASH job.
 
     Returns:
-        bool: True if the job is done, False if the job is still running.
+        bool: True if the job is completed successfully, False if it is still
+            running or queued.
 
     Raises:
-        RuntimeError: If the job status could not be retrieved or if the job failed.
-        ValueError: If the job state is missing or unexpected in the response.
+        RuntimeError: If the job has failed or if the API response indicates an error.
+        ValueError: If the job state is missing or an unexpected state is encountered
+            in the API response.
+        requests.exceptions.HTTPError: If an HTTP error occurs during the API request.
     """
-    response = query_antismash_job(job_id)
+    url = f"https://antismash.secondarymetabolites.org/api/v1.0/status/{job_id}"
 
-    if response is None:
-        raise RuntimeError(f"Failed to retrieve job status for job_id {job_id}")
-    if "state" not in response:
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()  # Raise exception for HTTP errors
+    respose_data = response.json()
+
+    if "state" not in respose_data:
         raise ValueError(f"Job state missing in response for job_id: {job_id}")
 
-    job_state = response["state"]
+    job_state = respose_data["state"]
     if job_state in ("running", "queued"):
         return False
     if job_state == "done":
         return True
     if job_state == "failed":
-        job_status = response.get("status", "No error message provided")
+        job_status = respose_data.get("status", "No error message provided")
         raise RuntimeError(f"AntiSMASH job {job_id} failed with an error: {job_status}")
     else:
         raise ValueError(

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -172,6 +172,7 @@ def _cleanup_extracted_files(extract_path: str | PathLike) -> None:
 
 
 def _prepare_extract_path(extract_path: str | PathLike) -> None:
+    extract_path = Path(extract_path)
     if extract_path.exists():
         _check_extract_path(extract_path)
     else:

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from os import PathLike
 from pathlib import Path
+import requests
 from nplinker.utils import download_and_extract_archive
 from nplinker.utils import list_dirs
 from nplinker.utils import list_files
@@ -15,10 +16,75 @@ logger = logging.getLogger(__name__)
 ANTISMASH_DB_DOWNLOAD_URL = "https://antismash-db.secondarymetabolites.org/output/{}/{}"
 # The antiSMASH DBV2 is for the availability of the old version, better to keep it.
 ANTISMASH_DBV2_DOWNLOAD_URL = "https://antismash-dbv2.secondarymetabolites.org/output/{}/{}"
+# antismash api to download results from submitted jobs
+ANTISMASH_API_DOWNLOAD_URL = "https://antismash.secondarymetabolites.org/upload/{}/{}"
 
 
 def download_and_extract_antismash_data(
-    antismash_id: str, download_root: str | PathLike, extract_root: str | PathLike
+    url: str, antismash_id: str, download_root: str | PathLike, extract_root: str | PathLike
+) -> None:
+    """Download and extract antiSMASH BGC archive for a specified genome.
+
+    This function downloads a BGC archive from the specified URL, extracts its contents,
+    and organizes the extracted files into a structured directory under the given `extract_root`.
+
+    Args:
+        url (str): The URL to download the BGC archive from.
+        antismash_id (str): The identifier for the antiSMASH genome, used to name the extraction directory.
+        download_root: Path to the directory where the downloaded archive will be stored.
+        extract_root: Path to the directory where the data files will be extracted.
+            Note that an `antismash` directory will be created in the specified `extract_root` if
+            it doesn't exist. The files will be extracted to `<extract_root>/antismash/<antismash_id>` directory.
+
+    Raises:
+        ValueError: if `<extract_root>/antismash/<antismash_id>` dir is not empty.
+        Exception: If any error occurs during the download or extraction process, the partially extracted
+            directory will be cleaned up, and the exception will be re-raised.
+
+    Examples:
+         >>> download_and_extract_antismash_data(
+                 "https://antismash-db.secondarymetabolites.org/output/GCF_001.1/GCF_001.1.zip",
+                 "GCF_001.1",
+                 "/data/download",
+                 "/data/extracted"
+             )
+    """
+    extract_path = Path(extract_root) / "antismash" / antismash_id
+
+    _prepare_extract_path(extract_path)
+    try:
+        download_and_extract_archive(url, download_root, extract_path, f"{antismash_id}.zip")
+        _cleanup_extracted_files(extract_path)
+    except Exception as e:
+        shutil.rmtree(extract_path)
+        raise e
+
+
+def download_and_extract_from_antismash_api(
+    job_id: str, antismash_id: str, download_root: str | PathLike, extract_root: str | PathLike
+) -> None:
+    """Downloads and extracts results from an antiSMASH API job.
+
+    This function constructs the download URL using the provided job ID then
+    downloads the results as a ZIP file and extracts its contents to the specified directories.
+
+    Args:
+        antismash_id (str): The unique identifier for the antiSMASH dataset.
+        job_id (str): The job ID for the antiSMASH API job.
+        download_root (str or PathLike): The root directory where the ZIP file will be downloaded.
+        extract_root (str or PathLike): The root directory where the contents of the ZIP file will be extracted.
+
+    Raises:
+        requests.exceptions.RequestException: If there is an issue with the HTTP request.
+        zipfile.BadZipFile: If the downloaded file is not a valid ZIP file.
+        OSError: If there is an issue with file operations such as writing or extracting.
+    """
+    url = ANTISMASH_API_DOWNLOAD_URL.format(job_id, antismash_id + ".zip")
+    download_and_extract_antismash_data(url, antismash_id, download_root, extract_root)
+
+
+def download_and_extract_from_antismash_db(
+    refseq_acc: str, download_root: str | PathLike, extract_root: str | PathLike
 ) -> None:
     """Download and extract antiSMASH BGC archive for a specified genome.
 
@@ -27,7 +93,7 @@ def download_and_extract_antismash_data(
     of a genome as the id of the archive.
 
     Args:
-        antismash_id: The id used to download BGC archive from antiSMASH database.
+        refseq_acc: The id used to download BGC archive from antiSMASH database.
             If the id is versioned (e.g., "GCF_004339725.1") please be sure to
             specify the version as well.
         download_root: Path to the directory to place downloaded archive in.
@@ -36,27 +102,20 @@ def download_and_extract_antismash_data(
             it doesn't exist. The files will be extracted to `<extract_root>/antismash/<antismash_id>` directory.
 
     Raises:
-        ValueError: if `<extract_root>/antismash/<refseq_assembly_id>` dir is not empty.
+        ValueError: if `<extract_root>/antismash/<refseq_acc>` dir is not empty.
 
     Examples:
-        >>> download_and_extract_antismash_metadata("GCF_004339725.1", "/data/download", "/data/extracted")
+        >>> download_and_extract_from_antismash_db("GCF_004339725.1", "/data/download", "/data/extracted")
     """
-    download_root = Path(download_root)
-    extract_path = Path(extract_root) / "antismash" / antismash_id
+    for base_url in [ANTISMASH_DB_DOWNLOAD_URL, ANTISMASH_DBV2_DOWNLOAD_URL]:
+        url = base_url.format(refseq_acc, f"{refseq_acc}.zip")
+        if requests.head(url).status_code == 404:  # not found
+            continue
+        download_and_extract_antismash_data(url, refseq_acc, download_root, extract_root)
+        return  # Exit the loop once a valid URL is processed
 
-    _prepare_extract_path(extract_path)
-
-    try:
-        for base_url in [ANTISMASH_DB_DOWNLOAD_URL, ANTISMASH_DBV2_DOWNLOAD_URL]:
-            url = base_url.format(antismash_id, antismash_id + ".zip")
-            download_and_extract_archive(url, download_root, extract_path, antismash_id + ".zip")
-            break
-
-        _cleanup_extracted_files(extract_path)
-
-    except Exception as e:
-        shutil.rmtree(extract_path)
-        raise e
+    # if both urls give 404 not found
+    raise RuntimeError(f"No results in antiSMASH DB for {refseq_acc}")
 
 
 def _check_extract_path(extract_path: Path):

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -44,10 +44,7 @@ def download_and_extract_antismash_data(
     download_root = Path(download_root)
     extract_path = Path(extract_root) / "antismash" / antismash_id
 
-    if extract_path.exists():
-        _check_extract_path(extract_path)
-    else:
-        extract_path.mkdir(parents=True, exist_ok=True)
+    _prepare_extract_path(extract_path)
 
     try:
         for base_url in [ANTISMASH_DB_DOWNLOAD_URL, ANTISMASH_DBV2_DOWNLOAD_URL]:
@@ -81,3 +78,10 @@ def _cleanup_extracted_files(extract_path: str | PathLike) -> None:
     for file in list_files(extract_path):
         if file not in files_to_keep:
             os.remove(file)
+
+
+def _prepare_extract_path(extract_path: str | PathLike) -> None:
+    if extract_path.exists():
+        _check_extract_path(extract_path)
+    else:
+        extract_path.mkdir(parents=True, exist_ok=True)

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -6,6 +6,7 @@ from os import PathLike
 from pathlib import Path
 import requests
 from nplinker.utils import download_and_extract_archive
+from nplinker.utils import extract_archive
 from nplinker.utils import list_dirs
 from nplinker.utils import list_files
 
@@ -116,6 +117,40 @@ def download_and_extract_from_antismash_db(
 
     # if both urls give 404 not found
     raise RuntimeError(f"No results in antiSMASH DB for {refseq_acc}")
+
+
+def extract_antismash_data(
+    archive: str | PathLike, extract_root: str | PathLike, antimash_id: str
+) -> None:
+    """Extracts antiSMASH results from a given archive into a specified directory.
+
+    This function handles the extraction of antiSMASH results by preparing the
+    extraction path, extracting the archive, and performing cleanup of
+    unnecessary files. If an error occurs during the process, the partially
+    extracted files are removed, and the exception is re-raised.
+
+    Args:
+        archive (str | PathLike): The path to the archive file containing antiSMASH results.
+        extract_root (str | PathLike): The root directory where the data should
+            be extracted.
+        antimash_id (str): A unique identifier for the antiSMASH data, used to
+            create a subdirectory for the extracted files.
+
+    Raises:
+        Exception: If any error occurs during the extraction process, the
+            exception is re-raised after cleaning up the extraction directory.
+    """
+    extract_path = Path(extract_root) / "antismash" / antimash_id
+
+    _prepare_extract_path(extract_path)
+
+    try:
+        extract_archive(archive, extract_path, remove_finished=False)
+        _cleanup_extracted_files(extract_path)
+
+    except Exception as e:
+        shutil.rmtree(extract_path)
+        raise e
 
 
 def _check_extract_path(extract_path: Path):

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -55,15 +55,7 @@ def download_and_extract_antismash_data(
             download_and_extract_archive(url, download_root, extract_path, antismash_id + ".zip")
             break
 
-        # delete subdirs
-        for subdir_path in list_dirs(extract_path):
-            shutil.rmtree(subdir_path)
-
-        # delete unnecessary files
-        files_to_keep = list_files(extract_path, suffix=(".json", ".gbk"))
-        for file in list_files(extract_path):
-            if file not in files_to_keep:
-                os.remove(file)
+        _cleanup_extracted_files(extract_path)
 
         logger.info("antiSMASH BGC data of %s is downloaded and extracted.", antismash_id)
 
@@ -77,3 +69,15 @@ def _check_extract_path(extract_path: Path):
     # check if extract_path is empty
     if any(extract_path.iterdir()):
         raise ValueError(f'Nonempty directory: "{extract_path}"')
+
+
+def _cleanup_extracted_files(extract_path: str | PathLike) -> None:
+    # delete subdirs
+    for subdir_path in list_dirs(extract_path):
+        shutil.rmtree(subdir_path)
+
+    # delete unnecessary files
+    files_to_keep = list_files(extract_path, suffix=(".json", ".gbk"))
+    for file in list_files(extract_path):
+        if file not in files_to_keep:
+            os.remove(file)

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -54,11 +54,8 @@ def download_and_extract_antismash_data(
 
         _cleanup_extracted_files(extract_path)
 
-        logger.info("antiSMASH BGC data of %s is downloaded and extracted.", antismash_id)
-
     except Exception as e:
         shutil.rmtree(extract_path)
-        logger.warning(e)
         raise e
 
 

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -42,8 +42,7 @@ def download_and_extract_antismash_data(
         >>> download_and_extract_antismash_metadata("GCF_004339725.1", "/data/download", "/data/extracted")
     """
     download_root = Path(download_root)
-    extract_root = Path(extract_root)
-    extract_path = extract_root / "antismash" / antismash_id
+    extract_path = Path(extract_root) / "antismash" / antismash_id
 
     try:
         if extract_path.exists():

--- a/src/nplinker/genomics/antismash/antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/antismash_downloader.py
@@ -44,12 +44,12 @@ def download_and_extract_antismash_data(
     download_root = Path(download_root)
     extract_path = Path(extract_root) / "antismash" / antismash_id
 
-    try:
-        if extract_path.exists():
-            _check_extract_path(extract_path)
-        else:
-            extract_path.mkdir(parents=True, exist_ok=True)
+    if extract_path.exists():
+        _check_extract_path(extract_path)
+    else:
+        extract_path.mkdir(parents=True, exist_ok=True)
 
+    try:
         for base_url in [ANTISMASH_DB_DOWNLOAD_URL, ANTISMASH_DBV2_DOWNLOAD_URL]:
             url = base_url.format(antismash_id, antismash_id + ".zip")
             download_and_extract_archive(url, download_root, extract_path, antismash_id + ".zip")

--- a/src/nplinker/genomics/antismash/ncbi_downloader.py
+++ b/src/nplinker/genomics/antismash/ncbi_downloader.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 import os
 import shutil

--- a/src/nplinker/genomics/antismash/ncbi_downloader.py
+++ b/src/nplinker/genomics/antismash/ncbi_downloader.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def download_and_extract_ncbi_genome(
-    refseq_id: str,
+    genome_assembly_acc: str,
     download_root: str | PathLike,
     extract_root: str | PathLike,
     max_attempts: int = 10,
@@ -29,7 +29,7 @@ def download_and_extract_ncbi_genome(
     processing.
 
     Args:
-        refseq_id (str): The RefSeq ID for the dataset to be downloaded.
+        genome_assembly_acc (str): The NCBI accession of the genome assembly to be downloaded.
         download_root (str | PathLike): The directory where the dataset will be downloaded.
         extract_root (str | PathLike): The directory where the dataset will be extracted.
         max_attempts (int): The maximum number of download attempts. Defaults to 10.
@@ -43,12 +43,12 @@ def download_and_extract_ncbi_genome(
     """
     url = (
         "https://api.ncbi.nlm.nih.gov/datasets/v2/genome/accession/"
-        f"{refseq_id}/download?include_annotation_type=GENOME_GB"
+        f"{genome_assembly_acc}/download?include_annotation_type=GENOME_GB"
     )
 
     download_root = Path(download_root)
     extract_path = Path(extract_root) / "ncbi_genomes"
-    filename = f"ncbi_{refseq_id}.zip"
+    filename = f"ncbi_{genome_assembly_acc}.zip"
 
     extract_path.mkdir(parents=True, exist_ok=True)
 
@@ -70,8 +70,8 @@ def download_and_extract_ncbi_genome(
     verify_ncbi_dataset_md5_sums(extract_path)
 
     # Move and rename GenBank file
-    genbank_path = extract_path / "ncbi_dataset" / "data" / refseq_id / "genomic.gbff"
-    new_genbank_path = extract_path / f"{refseq_id}.gbff"
+    genbank_path = extract_path / "ncbi_dataset" / "data" / genome_assembly_acc / "genomic.gbff"
+    new_genbank_path = extract_path / f"{genome_assembly_acc}.gbff"
     genbank_path.rename(new_genbank_path)
 
     # Delete unnecessary files

--- a/src/nplinker/genomics/antismash/ncbi_downloader.py
+++ b/src/nplinker/genomics/antismash/ncbi_downloader.py
@@ -108,7 +108,7 @@ def _download_genome(genome_assembly_acc, download_root, max_attempts):
         )
 
 
-def _verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> bool:
+def _verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> None:
     """Verify the integrity of files in a specified directory using MD5 checksums.
 
     This function reads an "md5sum.txt" file located in the given extraction path,
@@ -119,9 +119,6 @@ def _verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> bool:
     Args:
         extract_path (PathLike): Path to the directory containing the files and
             the "md5sum.txt" file.
-
-    Returns:
-        bool: True if all files pass the MD5 checksum verification.
 
     Raises:
         ValueError: If the MD5 checksum of any file does not match the expected value.

--- a/src/nplinker/genomics/antismash/ncbi_downloader.py
+++ b/src/nplinker/genomics/antismash/ncbi_downloader.py
@@ -5,6 +5,8 @@ import time
 from os import PathLike
 from pathlib import Path
 from typing import Optional
+import httpx
+import requests
 from nplinker.utils import check_md5
 from nplinker.utils import download_url
 from nplinker.utils import extract_archive
@@ -41,31 +43,11 @@ def download_and_extract_ncbi_genome(
         RuntimeError: If the maximum number of retries is reached and the dataset
             could not be successfully downloaded and extracted.
     """
-    url = (
-        "https://api.ncbi.nlm.nih.gov/datasets/v2/genome/accession/"
-        f"{genome_assembly_acc}/download?include_annotation_type=GENOME_GB"
-    )
-
-    download_root = Path(download_root)
     extract_path = Path(extract_root) / "ncbi_genomes"
-    filename = f"ncbi_{genome_assembly_acc}.zip"
-
     extract_path.mkdir(parents=True, exist_ok=True)
 
-    for attempt in range(1, max_attempts + 1):
-        try:
-            download_url(url, download_root, filename)
-            archive = download_root / filename
-            break
-        except Exception as e:
-            logger.warning(f"Attempt {attempt}/{max_attempts} failed to download {url}. Error: {e}")
-            if attempt < max_attempts:
-                time.sleep(2)
-    else:
-        raise RuntimeError(
-            f"Maximum download retries ({max_attempts}) reached for {url}. Download failed."
-        )
-
+    _check_genome_accession_validity(genome_assembly_acc)
+    archive = _download_genome(genome_assembly_acc, download_root, max_attempts)
     extract_archive(archive, extract_path)
     verify_ncbi_dataset_md5_sums(extract_path)
 
@@ -106,3 +88,48 @@ def verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> bool:
             file_path = extract_path / file_name
             if not check_md5(file_path, md5sum):
                 raise ValueError(f"MD5 checksum mismatch for {file_path}")
+
+
+def _check_genome_accession_validity(genome_assembly_acc, max_attempts=10):
+    """Check the validity of genome accessio."""
+    url = f"https://api.ncbi.nlm.nih.gov/datasets/v2/genome/accession/{genome_assembly_acc}/check"
+
+    # Retry multiple times because NCBI has currently issues (500 Internal Server Error)
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+            break
+        except Exception:
+            if attempt < max_attempts:
+                time.sleep(1)
+
+    # Raise if no attempt was successful
+    response.raise_for_status()
+    # Raise if genome assembly is not successful
+    if "valid_assemblies" not in response.json():
+        raise ValueError(f"Not a valid genome assembly accession: {genome_assembly_acc}")
+
+
+def _download_genome(genome_assembly_acc, download_root, max_attempts):
+    url = (
+        "https://api.ncbi.nlm.nih.gov/datasets/v2/genome/accession/"
+        f"{genome_assembly_acc}/download?include_annotation_type=GENOME_GB"
+    )
+    download_root = Path(download_root)
+    filename = f"ncbi_{genome_assembly_acc}.zip"
+
+    # Retry multiple times because NCBI has issues currently
+    for attempt in range(1, max_attempts + 1):
+        try:
+            download_url(url, download_root, filename)
+            return download_root / filename
+        except httpx.ReadTimeout as e:
+            logger.warning(f"Attempt {attempt}/{max_attempts} failed to download {url}. Error: {e}")
+            if attempt < max_attempts:
+                time.sleep(1)
+    else:
+        raise httpx.ReadTimeout(
+            f"Failed to download the genome {genome_assembly_acc} from NCBI. "
+            f"Maximum download retries ({max_attempts}) reached for {url}."
+        )

--- a/src/nplinker/genomics/antismash/ncbi_downloader.py
+++ b/src/nplinker/genomics/antismash/ncbi_downloader.py
@@ -19,26 +19,27 @@ def download_and_extract_ncbi_genome(
     extract_root: str | PathLike,
     max_attempts: int = 10,
 ) -> Optional[Path]:
-    """Downloads and extracts an NCBI dataset for a given genome refseq ID.
+    """Downloads and extracts an NCBI dataset for a given genome RefSeq ID.
 
-    This function attempts to download a dataset from the NCBI database using
-    the provided refseq ID. It retries the download process up to a maximum
-    number of times if any errors occur. The function verifies the integrity
-    of the downloaded files using MD5 checksums and moves and renames the
-    GenBank files upon successful verification.
+    This function retrieves a dataset from the NCBI database using the provided
+    RefSeq ID. It retries the download process up to a specified maximum number
+    of attempts in case of errors. The function verifies the integrity of the
+    downloaded files using MD5 checksums, extracts the dataset, and renames the
+    GenBank file for easier access. Unnecessary files are removed after successful
+    processing.
 
     Args:
-        refseq_id (str): The refseq ID for the dataset to be downloaded.
-        download_root (str or Path): The root directory where the dataset will be downloaded.
-        extract_root (str or Path): The root directory where the dataset will be extracted.
-        max_attempts (int): The maximum number of times to attempt downloading.
+        refseq_id (str): The RefSeq ID for the dataset to be downloaded.
+        download_root (str | PathLike): The directory where the dataset will be downloaded.
+        extract_root (str | PathLike): The directory where the dataset will be extracted.
+        max_attempts (int): The maximum number of download attempts. Defaults to 10.
 
     Returns:
-        Path: The path to the extracted dataset if successful, otherwise None.
+        Optional[Path]: The path to the extracted GenBank file if successful, otherwise None.
 
     Raises:
-        Exception: If the maximum number of retries is reached and the dataset could
-        not be successfully downloaded and extracted.
+        RuntimeError: If the maximum number of retries is reached and the dataset
+            could not be successfully downloaded and extracted.
     """
     url = (
         "https://api.ncbi.nlm.nih.gov/datasets/v2/genome/accession/"

--- a/src/nplinker/genomics/antismash/ncbi_downloader.py
+++ b/src/nplinker/genomics/antismash/ncbi_downloader.py
@@ -1,0 +1,107 @@
+import logging
+import os
+import shutil
+import time
+from os import PathLike
+from pathlib import Path
+from typing import Optional
+from nplinker.utils import check_md5
+from nplinker.utils import download_url
+from nplinker.utils import extract_archive
+
+
+logger = logging.getLogger(__name__)
+
+
+def download_and_extract_ncbi_genome(
+    refseq_id: str,
+    download_root: str | PathLike,
+    extract_root: str | PathLike,
+    max_attempts: int = 10,
+) -> Optional[Path]:
+    """Downloads and extracts an NCBI dataset for a given genome refseq ID.
+
+    This function attempts to download a dataset from the NCBI database using
+    the provided refseq ID. It retries the download process up to a maximum
+    number of times if any errors occur. The function verifies the integrity
+    of the downloaded files using MD5 checksums and moves and renames the
+    GenBank files upon successful verification.
+
+    Args:
+        refseq_id (str): The refseq ID for the dataset to be downloaded.
+        download_root (str or Path): The root directory where the dataset will be downloaded.
+        extract_root (str or Path): The root directory where the dataset will be extracted.
+        max_attempts (int): The maximum number of times to attempt downloading.
+
+    Returns:
+        Path: The path to the extracted dataset if successful, otherwise None.
+
+    Raises:
+        Exception: If the maximum number of retries is reached and the dataset could
+        not be successfully downloaded and extracted.
+    """
+    url = (
+        "https://api.ncbi.nlm.nih.gov/datasets/v2/genome/accession/"
+        f"{refseq_id}/download?include_annotation_type=GENOME_GB"
+    )
+
+    download_root = Path(download_root)
+    extract_path = Path(extract_root) / "ncbi_genomes"
+    filename = f"ncbi_{refseq_id}.zip"
+
+    extract_path.mkdir(parents=True, exist_ok=True)
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            download_url(url, download_root, filename)
+            archive = download_root / filename
+            break
+        except Exception as e:
+            logger.warning(f"Attempt {attempt}/{max_attempts} failed to download {url}. Error: {e}")
+            if attempt < max_attempts:
+                time.sleep(2)
+    else:
+        raise RuntimeError(
+            f"Maximum download retries ({max_attempts}) reached for {url}. Download failed."
+        )
+
+    extract_archive(archive, extract_path)
+    verify_ncbi_dataset_md5_sums(extract_path)
+
+    # Move and rename GenBank file
+    genbank_path = extract_path / "ncbi_dataset" / "data" / refseq_id / "genomic.gbff"
+    new_genbank_path = extract_path / f"{refseq_id}.gbff"
+    genbank_path.rename(new_genbank_path)
+
+    # Delete unnecessary files
+    shutil.rmtree(extract_path / "ncbi_dataset")
+    os.remove(extract_path / "md5sum.txt")
+    os.remove(extract_path / "README.md")
+
+    return new_genbank_path
+
+
+def verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> bool:
+    """Verify the integrity of files in a specified directory using MD5 checksums.
+
+    This function reads an "md5sum.txt" file located in the given extraction path,
+    which contains MD5 checksums and corresponding file names. It then computes
+    the MD5 checksum for each file and compares it with the expected value. If any
+    file's checksum does not match, a `ValueError` is raised.
+
+    Args:
+        extract_path (PathLike): Path to the directory containing the files and
+            the "md5sum.txt" file.
+
+    Returns:
+        bool: True if all files pass the MD5 checksum verification.
+
+    Raises:
+        ValueError: If the MD5 checksum of any file does not match the expected value.
+    """
+    with open(extract_path / "md5sum.txt", "r") as f:
+        for line in f:
+            md5sum, file_name = line.strip().split()
+            file_path = extract_path / file_name
+            if not check_md5(file_path, md5sum):
+                raise ValueError(f"MD5 checksum mismatch for {file_path}")

--- a/src/nplinker/genomics/antismash/ncbi_downloader.py
+++ b/src/nplinker/genomics/antismash/ncbi_downloader.py
@@ -64,32 +64,6 @@ def download_and_extract_ncbi_genome(
     return new_genbank_path
 
 
-def _verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> bool:
-    """Verify the integrity of files in a specified directory using MD5 checksums.
-
-    This function reads an "md5sum.txt" file located in the given extraction path,
-    which contains MD5 checksums and corresponding file names. It then computes
-    the MD5 checksum for each file and compares it with the expected value. If any
-    file's checksum does not match, a `ValueError` is raised.
-
-    Args:
-        extract_path (PathLike): Path to the directory containing the files and
-            the "md5sum.txt" file.
-
-    Returns:
-        bool: True if all files pass the MD5 checksum verification.
-
-    Raises:
-        ValueError: If the MD5 checksum of any file does not match the expected value.
-    """
-    with open(extract_path / "md5sum.txt", "r") as f:
-        for line in f:
-            md5sum, file_name = line.strip().split()
-            file_path = extract_path / file_name
-            if not check_md5(file_path, md5sum):
-                raise ValueError(f"MD5 checksum mismatch for {file_path}")
-
-
 def _check_genome_accession_validity(genome_assembly_acc, max_attempts=10):
     """Check the validity of genome accessio."""
     url = f"https://api.ncbi.nlm.nih.gov/datasets/v2/genome/accession/{genome_assembly_acc}/check"
@@ -133,3 +107,29 @@ def _download_genome(genome_assembly_acc, download_root, max_attempts):
             f"Failed to download the genome {genome_assembly_acc} from NCBI. "
             f"Maximum download retries ({max_attempts}) reached for {url}."
         )
+
+
+def _verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> bool:
+    """Verify the integrity of files in a specified directory using MD5 checksums.
+
+    This function reads an "md5sum.txt" file located in the given extraction path,
+    which contains MD5 checksums and corresponding file names. It then computes
+    the MD5 checksum for each file and compares it with the expected value. If any
+    file's checksum does not match, a `ValueError` is raised.
+
+    Args:
+        extract_path (PathLike): Path to the directory containing the files and
+            the "md5sum.txt" file.
+
+    Returns:
+        bool: True if all files pass the MD5 checksum verification.
+
+    Raises:
+        ValueError: If the MD5 checksum of any file does not match the expected value.
+    """
+    with open(extract_path / "md5sum.txt", "r") as f:
+        for line in f:
+            md5sum, file_name = line.strip().split()
+            file_path = extract_path / file_name
+            if not check_md5(file_path, md5sum):
+                raise ValueError(f"MD5 checksum mismatch for {file_path}")

--- a/src/nplinker/genomics/antismash/ncbi_downloader.py
+++ b/src/nplinker/genomics/antismash/ncbi_downloader.py
@@ -108,7 +108,7 @@ def _download_genome(genome_assembly_acc, download_root, max_attempts):
         )
 
 
-def _verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> None:
+def _verify_ncbi_dataset_md5_sums(extract_path: str | PathLike) -> None:
     """Verify the integrity of files in a specified directory using MD5 checksums.
 
     This function reads an "md5sum.txt" file located in the given extraction path,
@@ -123,6 +123,7 @@ def _verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> None:
     Raises:
         ValueError: If the MD5 checksum of any file does not match the expected value.
     """
+    extract_path = Path(extract_path)
     with open(extract_path / "md5sum.txt", "r") as f:
         for line in f:
             md5sum, file_name = line.strip().split()

--- a/src/nplinker/genomics/antismash/ncbi_downloader.py
+++ b/src/nplinker/genomics/antismash/ncbi_downloader.py
@@ -49,7 +49,7 @@ def download_and_extract_ncbi_genome(
     _check_genome_accession_validity(genome_assembly_acc)
     archive = _download_genome(genome_assembly_acc, download_root, max_attempts)
     extract_archive(archive, extract_path)
-    verify_ncbi_dataset_md5_sums(extract_path)
+    _verify_ncbi_dataset_md5_sums(extract_path)
 
     # Move and rename GenBank file
     genbank_path = extract_path / "ncbi_dataset" / "data" / genome_assembly_acc / "genomic.gbff"
@@ -64,7 +64,7 @@ def download_and_extract_ncbi_genome(
     return new_genbank_path
 
 
-def verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> bool:
+def _verify_ncbi_dataset_md5_sums(extract_path: PathLike) -> bool:
     """Verify the integrity of files in a specified directory using MD5 checksums.
 
     This function reads an "md5sum.txt" file located in the given extraction path,

--- a/src/nplinker/genomics/antismash/ncbi_downloader.py
+++ b/src/nplinker/genomics/antismash/ncbi_downloader.py
@@ -4,7 +4,6 @@ import shutil
 import time
 from os import PathLike
 from pathlib import Path
-from typing import Optional
 import httpx
 import requests
 from nplinker.utils import check_md5
@@ -20,7 +19,7 @@ def download_and_extract_ncbi_genome(
     download_root: str | PathLike,
     extract_root: str | PathLike,
     max_attempts: int = 10,
-) -> Optional[Path]:
+) -> Path:
     """Downloads and extracts an NCBI dataset for a given genome RefSeq ID.
 
     This function retrieves a dataset from the NCBI database using the provided
@@ -37,7 +36,7 @@ def download_and_extract_ncbi_genome(
         max_attempts (int): The maximum number of download attempts. Defaults to 10.
 
     Returns:
-        Optional[Path]: The path to the extracted GenBank file if successful, otherwise None.
+        Path: The path to the extracted GenBank file.
 
     Raises:
         RuntimeError: If the maximum number of retries is reached and the dataset

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -179,33 +179,18 @@ def podp_download_and_extract_antismash_data(
             logger.info(f"Genome ID {raw_genome_id} skipped due to previous failed attempt")
             continue
 
-        # if not downloaded or lookup attempted, then try to resolve the ID
-        # and download
-        logger.info(f"Start lookup process for genome ID {raw_genome_id}")
-        gs_obj.resolved_refseq_id = _resolve_refseq_id(genome_id_data)
-        gs_obj.resolve_attempted = True
-
-        if gs_obj.resolved_refseq_id == "":
-            # give up on this one
-            logger.warning(f"Failed lookup for genome ID {raw_genome_id}")
+        # resolve genome ID
+        try:
+            get_genome_assembly_accession(gs, genome_record["genome_ID"])
+        except Exception as e:
+            logger.warning(f"Failed to resolve genome ID {gs.original_id}. Error: {e}")
             continue
 
-        # if resolved id is valid, try to download and extract antismash data
+        # retrieve antismash BGC data from antiSMASH-DB
         try:
-            download_and_extract_antismash_data(
-                gs_obj.resolved_refseq_id, project_download_root, project_extract_root
-            )
-
-            gs_obj.bgc_path = str(
-                Path(project_download_root, gs_obj.resolved_refseq_id + ".zip").absolute()
-            )
-
-            output_path = Path(project_extract_root, "antismash", gs_obj.resolved_refseq_id)
-            if output_path.exists():
-                Path.touch(output_path / "completed", exist_ok=True)
-
+            retrieve_antismash_db_data(gs, project_download_root, project_extract_root)
         except Exception:
-            gs_obj.bgc_path = ""
+            continue
 
     # raise and log warning for failed downloads
     failed_ids = [gs.original_id for gs in gs_dict.values() if not gs.bgc_path]
@@ -245,6 +230,67 @@ def get_best_available_genome_id(genome_id_data: Mapping[str, str]) -> str | Non
         logger.warning(f"Failed to get valid genome ID in genome data: {genome_id_data}")
         return None
     return best_id
+
+
+def get_genome_assembly_accession(
+    genome_status: GenomeStatus, genome_id_data: Mapping[str, str]
+) -> None:
+    """Resolve and update the genome assembly accession for a given genome status.
+
+    This function attempts to resolve the RefSeq ID for the provided genome record
+    and updates the `genome_status` object with the resolved ID. It also sets the
+    `resolve_attempted` flag to `True` to indicate that an attempt to resolve the
+    RefSeq ID has been made. If the resolution fails, raises a RuntimeError and leaves
+    the `resolved_refseq_id` empty.
+
+    Args:
+        genome_status (GenomeStatus): An object representing the status of the genome,
+            which will be updated with the resolved RefSeq ID.
+        genome_id_data (Mapping[str, str]): A dictionary containing genome
+            information, where keys like "RefSeq_accession", "GenBank_accession",
+            or "JGI_Genome_ID" are used to resolve the RefSeq ID.
+
+    Warnings:
+        Logs a warning if the RefSeq ID cannot be resolved.
+    """
+    genome_status.resolved_refseq_id = _resolve_refseq_id(genome_id_data)
+    genome_status.resolve_attempted = True
+
+    if genome_status.resolved_refseq_id == "":
+        raise RuntimeError("Failed to get genome assembly accession")
+
+
+def retrieve_antismash_db_data(
+    genome_status: GenomeStatus, download_root: str | PathLike, extract_root: str | PathLike
+) -> None:
+    """Retrieve antiSMASH database data for a given genome and update its status.
+
+    This function downloads and extracts antiSMASH data for a genome identified
+    by its resolved RefSeq ID. It updates the `genome_status` object with the
+    path to the downloaded data or sets it to an empty string if an error occurs.
+
+    Args:
+        genome_status (GenomeStatus): An object representing the genome's status,
+            including its resolved RefSeq ID and BGC path.
+        download_root (str | PathLike): The root directory where the antiSMASH
+            data will be downloaded.
+        extract_root (str | PathLike): The root directory where the antiSMASH
+            data will be extracted.
+
+    Raises:
+        Exception: If an error occurs during the download or extraction process.
+    """
+    antismash_id = genome_status.resolved_refseq_id
+    extract_path = Path(extract_root, "antismash", antismash_id)
+    download_path = Path(download_root, f"{antismash_id}.zip").absolute()
+
+    try:
+        download_and_extract_antismash_data(antismash_id, download_root, extract_root)
+        Path.touch(extract_path / "completed", exist_ok=True)
+        genome_status.bgc_path = str(download_path)
+    except Exception as e:
+        genome_status.bgc_path = ""
+        raise e
 
 
 def _resolve_genbank_accession(genbank_id: str) -> str:

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -16,6 +16,7 @@ from nplinker.genomics.antismash import antismash_job_is_done
 from nplinker.genomics.antismash import download_and_extract_from_antismash_api
 from nplinker.genomics.antismash import download_and_extract_from_antismash_db
 from nplinker.genomics.antismash import download_and_extract_ncbi_genome
+from nplinker.genomics.antismash import extract_antismash_data
 from nplinker.genomics.antismash import submit_antismash_job
 from nplinker.schemas import GENOME_STATUS_SCHEMA
 
@@ -170,13 +171,23 @@ def podp_download_and_extract_antismash_data(
         # Retrieve or initialize the GenomeStatus object for the genome ID
         gs = gs_dict.setdefault(original_genome_id, GenomeStatus(original_genome_id))
 
-        # Skip genomes
+        # Check if genomes already have antiSMASH BGC data
         if gs.bgc_path and Path(gs.bgc_path).exists():
             logger.info(
                 f"antiSMASH BGC data for genome ID {original_genome_id} already downloaded to "
                 f"{gs.bgc_path}"
             )
-            continue
+            try:
+                process_existing_antismash_data(gs, project_extract_root)
+                continue
+            except Exception as e:
+                logger.warning(
+                    "Failed to process existing antiSMASH BGC data for genome ID "
+                    f"{original_genome_id}. Error: {e}"
+                )
+        gs.bgc_path = ""  # Reset bgc path
+
+        # Check if a previous attempt to get bgc data has failed
         if gs.resolve_attempted:
             logger.info(f"Genome ID {original_genome_id} skipped due to previous failed attempt")
             continue
@@ -294,6 +305,37 @@ def get_genome_assembly_accession(
 
     if genome_status.resolved_refseq_id == "":
         raise RuntimeError("Failed to get genome assembly accession")
+
+
+def process_existing_antismash_data(gs_obj: GenomeStatus, extract_root: str | PathLike) -> None:
+    """Processes already downloaded antiSMASH BGC data archive.
+
+    This function ensures that the antiSMASH data archive associated with a given genomic sequence
+    object is properly extracted into a specified directory. If the data has already been extracted,
+    the function skips the extraction process.
+
+    Args:
+        gs_obj: An object representing a genomic sequence, which contains the path
+                to the antiSMASH BGC data (accessible via `gs_obj.bgc_path`) and
+                an original identifier (`gs_obj.original_id`).
+        extract_root: The root directory where the antiSMASH data should be extracted.
+
+    Raises:
+        Any exceptions raised by the `extract_antismash_data` function if the extraction fails.
+    """
+    antismash_id = Path(gs_obj.bgc_path).stem
+    extract_path = Path(extract_root, "antismash", antismash_id)
+    completed_marker = extract_path / "completed"
+
+    # Check if archive is already successfully extracted
+    if completed_marker.exists():
+        logger.info(
+            f"antiSMASH BGC data for {gs_obj.original_id} already extracted at {extract_path}."
+        )
+        return
+
+    extract_antismash_data(gs_obj.bgc_path, extract_root, antismash_id)
+    completed_marker.touch(exist_ok=True)
 
 
 def retrieve_antismash_db_data(

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import time
 import warnings
 from collections.abc import Mapping
 from collections.abc import Sequence
@@ -11,7 +12,11 @@ import httpx
 from bs4 import BeautifulSoup
 from jsonschema import validate
 from nplinker.defaults import GENOME_STATUS_FILENAME
-from nplinker.genomics.antismash import download_and_extract_antismash_data
+from nplinker.genomics.antismash import antismash_job_is_done
+from nplinker.genomics.antismash import download_and_extract_from_antismash_api
+from nplinker.genomics.antismash import download_and_extract_from_antismash_db
+from nplinker.genomics.antismash import download_and_extract_ncbi_genome
+from nplinker.genomics.antismash import submit_antismash_job
 from nplinker.schemas import GENOME_STATUS_SCHEMA
 
 
@@ -189,9 +194,31 @@ def podp_download_and_extract_antismash_data(
             logger.info(
                 f"antiSMASH BGC data for genome ID {gs.original_id} is downloaded and extracted"
             )
+            continue
         except Exception as e:
             logger.warning(
                 f"Failed to retrieve BGC data from antiSMASH-DB for {gs.original_id}. Error: {e}"
+            )
+
+        # retrieve antismash BGC by submitting antismash job via API
+        try:
+            logger.info(
+                f"Downloading genome and submitting antiSMASH job for genome ID {gs.original_id}."
+            )
+            genome_path = download_and_extract_ncbi_genome(
+                gs.resolved_refseq_id, project_download_root, project_extract_root
+            )
+            job_id = submit_antismash_job(genome_path)
+            while antismash_job_is_done(job_id) is False:
+                time.sleep(15)
+            retrieve_antismash_job_data(job_id, gs, project_download_root, project_extract_root)
+            logger.info(
+                f"antiSMASH BGC data for genome ID {gs.original_id} is downloaded and extracted"
+            )
+            continue
+        except Exception as e:
+            logger.warning(
+                f"Failed to retrieve BGC data by submitting a antiSMASH job for genome ID {gs.original_id}. Error: {e}"
             )
 
     # raise and log warning for failed downloads
@@ -286,13 +313,42 @@ def retrieve_antismash_db_data(
     extract_path = Path(extract_root, "antismash", antismash_id)
     download_path = Path(download_root, f"{antismash_id}.zip").absolute()
 
-    try:
-        download_and_extract_antismash_data(antismash_id, download_root, extract_root)
-        Path.touch(extract_path / "completed", exist_ok=True)
-        genome_status.bgc_path = str(download_path)
-    except Exception as e:
-        genome_status.bgc_path = ""
-        raise e
+    download_and_extract_from_antismash_db(antismash_id, download_root, extract_root)
+    Path.touch(extract_path / "completed", exist_ok=True)
+    genome_status.bgc_path = str(download_path)
+
+
+def retrieve_antismash_job_data(
+    job_id: str,
+    genome_status: GenomeStatus,
+    download_root: str | PathLike,
+    extract_root: str | PathLike,
+) -> None:
+    """Retrieve antiSMASH API data for a given genome and update its status.
+
+    This function downloads and extracts antiSMASH data for a genome identified
+    by its resolved RefSeq ID. It updates the `genome_status` object with the
+    path to the downloaded data or sets it to an empty string if an error occurs.
+
+    Args:
+        job_id (str): The job ID for the antiSMASH API job.
+        genome_status (GenomeStatus): An object representing the genome's status,
+            including its resolved RefSeq ID and BGC path.
+        download_root (str | PathLike): The root directory where the antiSMASH
+            data will be downloaded.
+        extract_root (str | PathLike): The root directory where the antiSMASH
+            data will be extracted.
+
+    Raises:
+        Exception: If an error occurs during the download or extraction process.
+    """
+    antismash_id = genome_status.resolved_refseq_id
+    extract_path = Path(extract_root, "antismash", antismash_id)
+    download_path = Path(download_root, f"{antismash_id}.zip").absolute()
+
+    download_and_extract_from_antismash_api(job_id, antismash_id, download_root, extract_root)
+    Path.touch(extract_path / "completed", exist_ok=True)
+    genome_status.bgc_path = str(download_path)
 
 
 def _resolve_genbank_accession(genbank_id: str) -> str:

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -211,6 +211,7 @@ def podp_download_and_extract_antismash_data(
                 gs.resolved_refseq_id, project_download_root, project_extract_root
             )
             job_id = submit_antismash_job(genome_path)
+            logger.info(f"Waiting for antiSMASH job {job_id} to complete.")
             while antismash_job_is_done(job_id) is False:
                 time.sleep(15)
             retrieve_antismash_job_data(job_id, gs, project_download_root, project_extract_root)

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -203,7 +203,8 @@ def podp_download_and_extract_antismash_data(
         # retrieve antismash BGC by submitting antismash job via API
         try:
             logger.info(
-                f"Downloading genome and submitting antiSMASH job for genome ID {gs.original_id}."
+                "Downloading genome assembly from NCBI and submitting antiSMASH job for "
+                f"genome ID {gs.original_id}."
             )
             genome_path = download_and_extract_ncbi_genome(
                 gs.resolved_refseq_id, project_download_root, project_extract_root

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -297,8 +297,8 @@ def get_genome_assembly_accession(
             information, where keys like "RefSeq_accession", "GenBank_accession",
             or "JGI_Genome_ID" are used to resolve the RefSeq ID.
 
-    Warnings:
-        Logs a warning if the RefSeq ID cannot be resolved.
+    Raises:
+        RuntimeError: If the RefSeq ID cannot be resolved.
     """
     genome_status.resolved_refseq_id = _resolve_refseq_id(genome_id_data)
     genome_status.resolve_attempted = True

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -153,30 +153,26 @@ def podp_download_and_extract_antismash_data(
     gs_dict = GenomeStatus.read_json(gs_file)
 
     for i, genome_record in enumerate(genome_records):
-        # get the best available ID from the dict
-        genome_id_data = genome_record["genome_ID"]
-        raw_genome_id = get_best_available_genome_id(genome_id_data)
-        if raw_genome_id is None or len(raw_genome_id) == 0:
-            logger.warning(f'Invalid input genome record "{genome_record}"')
-            continue
-
-        # check if genome ID exist in the genome status file
-        if raw_genome_id not in gs_dict:
-            gs_dict[raw_genome_id] = GenomeStatus(raw_genome_id)
-
-        gs_obj = gs_dict[raw_genome_id]
-
         logger.info(
-            f"Checking for antismash data {i + 1}/{len(genome_records)}, "
-            f"current genome ID={raw_genome_id}"
+            f"Getting antismash BGC data for genome record {i + 1} of {len(genome_records)}."
         )
-        # first, check if BGC data is downloaded
-        if gs_obj.bgc_path and Path(gs_obj.bgc_path).exists():
-            logger.info(f"Genome ID {raw_genome_id} already downloaded to {gs_obj.bgc_path}")
+
+        # get the best available genome ID from the dict
+        original_genome_id = get_best_available_genome_id(genome_record["genome_ID"])
+        if not original_genome_id:
+            logger.warning(f"Skipping invalid genome record: {genome_record}")
             continue
-        # second, check if lookup attempted previously
-        if gs_obj.resolve_attempted:
-            logger.info(f"Genome ID {raw_genome_id} skipped due to previous failed attempt")
+
+        # Retrieve or initialize the GenomeStatus object for the genome ID
+        gs = gs_dict.setdefault(original_genome_id, GenomeStatus(original_genome_id))
+
+        # Skip genome if BGC data is downloaded
+        if gs.bgc_path and Path(gs.bgc_path).exists():
+            logger.info(f"Genome ID {original_genome_id} already downloaded to {gs.bgc_path}")
+            continue
+        # Skip genome if lookup attempted previously
+        if gs.resolve_attempted:
+            logger.info(f"Genome ID {original_genome_id} skipped due to previous failed attempt")
             continue
 
         # resolve genome ID

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -162,13 +162,15 @@ def podp_download_and_extract_antismash_data(
         if not original_genome_id:
             logger.warning(f"Skipping invalid genome record: {genome_record}")
             continue
-
         # Retrieve or initialize the GenomeStatus object for the genome ID
         gs = gs_dict.setdefault(original_genome_id, GenomeStatus(original_genome_id))
 
         # Skip genomes
         if gs.bgc_path and Path(gs.bgc_path).exists():
-            logger.info(f"Genome ID {original_genome_id} already downloaded to {gs.bgc_path}")
+            logger.info(
+                f"antiSMASH BGC data for genome ID {original_genome_id} already downloaded to "
+                f"{gs.bgc_path}"
+            )
             continue
         if gs.resolve_attempted:
             logger.info(f"Genome ID {original_genome_id} skipped due to previous failed attempt")
@@ -184,7 +186,9 @@ def podp_download_and_extract_antismash_data(
         # retrieve antismash BGC data from antiSMASH-DB
         try:
             retrieve_antismash_db_data(gs, project_download_root, project_extract_root)
-            logger.info(f"antiSMASH BGC data for {gs.original_id} is downloaded and extracted")
+            logger.info(
+                f"antiSMASH BGC data for genome ID {gs.original_id} is downloaded and extracted"
+            )
         except Exception as e:
             logger.warning(
                 f"Failed to retrieve BGC data from antiSMASH-DB for {gs.original_id}. Error: {e}"

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -185,8 +185,11 @@ def podp_download_and_extract_antismash_data(
         # retrieve antismash BGC data from antiSMASH-DB
         try:
             retrieve_antismash_db_data(gs, project_download_root, project_extract_root)
-        except Exception:
-            continue
+            logger.info(f"antiSMASH BGC data for {gs.original_id} is downloaded and extracted")
+        except Exception as e:
+            logger.warning(
+                f"Failed to retrieve BGC data from antiSMASH-DB for {gs.original_id}. Error: {e}"
+            )
 
     # raise and log warning for failed downloads
     failed_ids = [gs.original_id for gs in gs_dict.values() if not gs.bgc_path]

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -196,8 +196,9 @@ def podp_download_and_extract_antismash_data(
             )
             continue
         except Exception as e:
-            logger.warning(
-                f"Failed to retrieve BGC data from antiSMASH-DB for {gs.original_id}. Error: {e}"
+            logger.info(
+                f"Unable to retrieve BGC data from antiSMASH-DB for genome ID {gs.original_id}. "
+                f"Error: {e}"
             )
 
         # retrieve antismash BGC by submitting antismash job via API
@@ -218,9 +219,13 @@ def podp_download_and_extract_antismash_data(
             )
             continue
         except Exception as e:
-            logger.warning(
-                f"Failed to retrieve BGC data by submitting a antiSMASH job for genome ID {gs.original_id}. Error: {e}"
+            logger.info(
+                f"Unable to retrieve BGC data via antiSMASH API for genome ID {gs.original_id}. "
+                f"Error: {e}"
             )
+
+        if gs.bgc_path == "":
+            logger.warning(f"Failed to retrieve BGC data for genome ID {gs.original_id}.")
 
     # raise and log warning for failed downloads
     failed_ids = [gs.original_id for gs in gs_dict.values() if not gs.bgc_path]

--- a/src/nplinker/genomics/antismash/podp_antismash_downloader.py
+++ b/src/nplinker/genomics/antismash/podp_antismash_downloader.py
@@ -166,11 +166,10 @@ def podp_download_and_extract_antismash_data(
         # Retrieve or initialize the GenomeStatus object for the genome ID
         gs = gs_dict.setdefault(original_genome_id, GenomeStatus(original_genome_id))
 
-        # Skip genome if BGC data is downloaded
+        # Skip genomes
         if gs.bgc_path and Path(gs.bgc_path).exists():
             logger.info(f"Genome ID {original_genome_id} already downloaded to {gs.bgc_path}")
             continue
-        # Skip genome if lookup attempted previously
         if gs.resolve_attempted:
             logger.info(f"Genome ID {original_genome_id} skipped due to previous failed attempt")
             continue

--- a/tests/unit/genomics/test_antismash_downloader.py
+++ b/tests/unit/genomics/test_antismash_downloader.py
@@ -1,5 +1,5 @@
 import pytest
-from nplinker.genomics.antismash import download_and_extract_antismash_data
+from nplinker.genomics.antismash import download_and_extract_from_antismash_db
 from nplinker.utils import extract_archive
 from nplinker.utils import list_files
 
@@ -14,7 +14,7 @@ class TestDownloadAndExtractAntismashData:
         extract_root.mkdir()
         original_extract_root = tmp_path / "original"
         original_extract_root.mkdir()
-        download_and_extract_antismash_data(self.antismash_id, download_root, extract_root)
+        download_and_extract_from_antismash_db(self.antismash_id, download_root, extract_root)
         archive = download_root / "GCF_004339725.1.zip"
         extracted_folder = extract_root / "antismash" / "GCF_004339725.1"
         extracted_files = list_files(extracted_folder, keep_parent=False)
@@ -32,7 +32,9 @@ class TestDownloadAndExtractAntismashData:
         nonempty_path = tmp_path / "extracted" / "antismash" / f"{self.antismash_id}" / "subdir"
         nonempty_path.mkdir(parents=True)
         with pytest.raises(ValueError, match="Nonempty directory"):
-            download_and_extract_antismash_data(self.antismash_id, tmp_path, tmp_path / "extracted")
+            download_and_extract_from_antismash_db(
+                self.antismash_id, tmp_path, tmp_path / "extracted"
+            )
 
     # test a non-existent ID, which can be either a fake ID, non-existent in NCBI
     # or a valid NCBI genome ID but it does not have BGC data in antismash database
@@ -44,6 +46,6 @@ class TestDownloadAndExtractAntismashData:
         extract_root.mkdir()
         for test_id in nonexisting_ids:
             with pytest.raises(RuntimeError):
-                download_and_extract_antismash_data(test_id, download_root, extract_root)
+                download_and_extract_from_antismash_db(test_id, download_root, extract_root)
             extracted_folder = extract_root / "antismash" / test_id
             assert not extracted_folder.exists()

--- a/tests/unit/genomics/test_ncbi_downloader.py
+++ b/tests/unit/genomics/test_ncbi_downloader.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+import httpx
+import pytest
+from nplinker.genomics.antismash.ncbi_downloader import download_and_extract_ncbi_genome
+
+
+@pytest.fixture
+def download_root(tmp_path):
+    return tmp_path / "download"
+
+
+@pytest.fixture
+def extract_root(tmp_path):
+    return tmp_path / "extracted"
+
+
+def test_download_and_extract_ncbi_genome_success(download_root, extract_root):
+    refseq_id = "GCF_000514775.1"
+
+    genome_path = download_and_extract_ncbi_genome(refseq_id, download_root, extract_root)
+
+    assert genome_path == extract_root / "ncbi_genomes" / f"{refseq_id}.gbff"
+    assert not (extract_root / "ncbi_genomes" / "md5sum.txt").exists()
+    assert not (extract_root / "ncbi_genomes" / "README.md").exists()
+    assert not (extract_root / "ncbi_genomes" / "ncbi_dataset").exists()
+
+
+def test_download_and_extract_ncbi_genome_max_retries(download_root, extract_root):
+    refseq_id = "GCF_000514775.1"
+
+    with patch(
+        "nplinker.genomics.antismash.ncbi_downloader.download_url",
+        side_effect=httpx.ReadTimeout("Download failed"),
+    ):
+        with pytest.raises(httpx.ReadTimeout, match="Maximum download retries"):
+            download_and_extract_ncbi_genome(refseq_id, download_root, extract_root, max_attempts=1)
+
+
+def test_download_and_extract_ncbi_genome_invalid_refseq_id(download_root, extract_root):
+    refseq_id = "invalid_ref_seq_id"
+
+    with pytest.raises(ValueError, match="Not a valid genome assembly accession"):
+        download_and_extract_ncbi_genome(refseq_id, download_root, extract_root)

--- a/tests/unit/genomics/test_podp_antismash_downloader.py
+++ b/tests/unit/genomics/test_podp_antismash_downloader.py
@@ -218,7 +218,7 @@ def test_caching(download_root, extract_root, genome_status_file, caplog):
     assert genome_obj.resolve_attempted
     podp_download_and_extract_antismash_data(genome_records, download_root, extract_root)
     assert (
-        f"Genome ID {genome_obj.original_id} already downloaded to {genome_obj.bgc_path}"
+        f"antiSMASH BGC data for genome ID {genome_obj.original_id} already downloaded to {genome_obj.bgc_path}"
         in caplog.text
     )
     assert (


### PR DESCRIPTION
This pull request improves antiSMASH BGC data acquisition in PODP mode by adding new features for handling previously downloaded data and for automating job submissions via the antiSMASH API

Features:

1. processing of previously downloaded antiSMASH data
  - checks if existing BGC data archives are extracted in the antismash directory  
  - extracts unprocessed archives to ensure they are ready for use  

2. antiSMASH job submission and download of results
  - if BGC data for a genome is unavailable and cannot be downloaded from antiSMASH-DB, the corresponding refseq genome is retrieved from NCBI  
  - the downloaded genome is submitted to the antiSMASH API  
  - waits for the job to complete
  - downloads and extracts the results  
