### PR TITLE
Fix: fix updated BiG-SCAPE v2 database paths

### DIFF
--- a/src/nplinker/arranger.py
+++ b/src/nplinker/arranger.py
@@ -334,8 +334,8 @@ class DatasetArranger:
                 shutil.copy(f, self.bigscape_dir)
         elif version == "2":
             shutil.copy(
-                self.bigscape_running_output_dir / "data_sqlite.db",
-                self.bigscape_dir,
+                self.bigscape_running_output_dir / f"{self.bigscape_running_output_dir.name}.db",
+                self.bigscape_dir / f"{self.bigscape_dir.name}.db",
             )
         else:
             raise ValueError(f"Invalid BiG-SCAPE version: {version}")
@@ -525,6 +525,6 @@ def validate_bigscape(bigscape_dir: str | PathLike, cutoff: str) -> None:
         raise FileNotFoundError(f"BiG-SCAPE data directory not found at {bigscape_dir}")
 
     clustering_file = bigscape_dir / f"mix_clustering_c{cutoff}.tsv"
-    database_file = bigscape_dir / "data_sqlite.db"
+    database_file = bigscape_dir / f"{bigscape_dir.name}.db"
     if not clustering_file.exists() and not database_file.exists():
         raise FileNotFoundError(f"BiG-SCAPE data not found in {clustering_file} or {database_file}")

--- a/src/nplinker/loader.py
+++ b/src/nplinker/loader.py
@@ -200,7 +200,11 @@ class DatasetLoader:
             loader = BigscapeGCFLoader(bigscape_cluster_file)
             logger.info(f"Loading BigSCAPE cluster file {bigscape_cluster_file}")
         elif self.config.bigscape.version == "2":
-            bigscape_db_file = self.config.root_dir / defaults.BIGSCAPE_DIRNAME / "data_sqlite.db"
+            bigscape_db_file = (
+                self.config.root_dir
+                / defaults.BIGSCAPE_DIRNAME
+                / f"{defaults.BIGSCAPE_DIRNAME}.db"
+            )
             loader = BigscapeV2GCFLoader(bigscape_db_file)
             logger.info(f"Loading BigSCAPE database file {bigscape_db_file}")
         else:


### PR DESCRIPTION
Fixes the BiG-SCAPE paths to reflect the modern ways in which BiG-SCAPE dbs are saved.

Current configuration (and one that will likely remain from now on) is to name the db the same as the parent folder + .db.

Fixes the BiG-SCAPE part of #332 