### PR TITLE
fix: Validate unique antismash BGC/region file names

### DIFF
--- a/src/nplinker/genomics/antismash/antismash_loader.py
+++ b/src/nplinker/genomics/antismash/antismash_loader.py
@@ -97,6 +97,12 @@ class AntismashBGCLoader(BGCLoaderBase):
             for f in files:
                 fname = os.path.splitext(f)[0]
                 fpath = os.path.join(subdir, f)
+                if fname in bgc_files.keys():
+                    raise ValueError(
+                        f"Duplicated BGC gbk file name {fname} in {fpath} and "
+                        f"{bgc_files[fname]}. All BGC gbk file names must be "
+                        f"unique across all directories."
+                    )
                 bgc_files[fname] = fpath
 
         return bgc_files

--- a/tests/unit/data/antismash_duplicated_bgc_ids/GCF_000514515.1/contig_1.region001.gbk
+++ b/tests/unit/data/antismash_duplicated_bgc_ids/GCF_000514515.1/contig_1.region001.gbk
@@ -1,0 +1,3633 @@
+LOCUS       NZ_AZWB01000005        66716 bp    DNA     linear   CON 29-NOV-2019
+DEFINITION  Salinispora pacifica CNT029 B170DRAFT_scaffold_1.2_C, whole genome
+            shotgun sequence.
+ACCESSION   NZ_AZWB01000005
+VERSION     NZ_AZWB01000005
+KEYWORDS    .
+SOURCE      Salinispora pacifica CNT029
+  ORGANISM  Salinispora pacifica CNT029
+            Bacteria; Actinobacteria; Micromonosporales; Micromonosporaceae;
+            Salinispora.
+COMMENT     REFSEQ INFORMATION: The reference sequence was derived from
+            AZWB01000005.
+            The annotation was added by the NCBI Prokaryotic Genome Annotation
+            Pipeline (PGAP). Information about PGAP can be found here:
+            https://www.ncbi.nlm.nih.gov/genome/annotation_prok/
+            COMPLETENESS: not full length.
+            ##antiSMASH-Data-START##
+            Version      :: 5.2.0-8ecc354
+            Run date     :: 2020-09-21 13:16:59
+            NOTE: This is a single cluster extracted from a larger record!
+            Orig. start  :: 246431
+            Orig. end    :: 313147
+            ##antiSMASH-Data-END##
+FEATURES             Location/Qualifiers
+     protocluster    1..66716
+                     /aStool="rule-based-clusters"
+                     /contig_edge="False"
+                     /core_location="[266431:293147]"
+                     /cutoff="20000"
+                     /detection_rule="(cds(Condensation and (AMP-binding or
+                     A-OX)) or (Condensation and AMP-binding))"
+                     /neighbourhood="20000"
+                     /product="NRPS"
+                     /protocluster_number="1"
+                     /tool="antismash"
+     proto_core      20001..46716
+                     /aStool="rule-based-clusters"
+                     /tool="antismash"
+                     /cutoff="20000"
+                     /detection_rule="(cds(Condensation and (AMP-binding or
+                     A-OX)) or (Condensation and AMP-binding))"
+                     /neighbourhood="20000"
+                     /product="NRPS"
+                     /protocluster_number="1"
+     cand_cluster    1..66716
+                     /SMILES="NC([*])C(=O)NC([*])C(=O)NC(CO)C(=O)NC(Cc1ccccc1)C(
+                     =O)NCC(=O)O"
+                     /candidate_cluster_number="1"
+                     /contig_edge="False"
+                     /detection_rules="(cds(Condensation and (AMP-binding or
+                     A-OX)) or (Condensation and AMP-binding))"
+                     /detection_rules="((LANC_like and (Lant_dehydr_N or
+                     Lant_dehydr_C) or cds(LANC_like and (Pkinase or DUF4135)))
+                     and not (YcaO or TIGR03882))"
+                     /kind="interleaved"
+                     /product="NRPS"
+                     /product="lanthipeptide"
+                     /protoclusters="1"
+                     /protoclusters="2"
+                     /tool="antismash"
+     region          1..66716
+                     /candidate_cluster_numbers="1"
+                     /contig_edge="False"
+                     /product="NRPS"
+                     /product="lanthipeptide"
+                     /region_number="1"
+                     /rules="(cds(Condensation and (AMP-binding or A-OX)) or
+                     (Condensation and AMP-binding))"
+                     /rules="((LANC_like and (Lant_dehydr_N or Lant_dehydr_C) or
+                     cds(LANC_like and (Pkinase or DUF4135))) and not (YcaO or
+                     TIGR03882))"
+                     /tool="antismash"
+     gene            complement(75..962)
+                     /locus_tag="B170_RS0101195"
+     CDS             complement(75..962)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_011904239.1"
+                     /locus_tag="B170_RS0101195"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="alpha/beta hydrolase"
+                     /protein_id="WP_027654901.1"
+                     /transl_table=11
+                     /translation="MRGFRWPPPPDGGPRTWGPGPSAPRTGRPALPEPETELVATPHGV
+                     HLEQLVTGAGDPVTVFAHGLGSGIATTRPFGSGVTGRRLFFQFRGHGRSAAPTGPWTYR
+                     DLARDLRSVADRGRATRAFGASLGAGALCRLLADNPTRFDRLVFYLPAVLDQPRGDAAR
+                     RRLTALLDALGSGDVGQLAEVVQLELPPAIRNTPAGWAYLRQRLDQLMRDGLASGLVGL
+                     PESVPVRDAAELAEVTAPALVIGCVGDELHPVAVAERLAAALPQATLHVYDRPGVLWAK
+                     RADLRERISAFLNE"
+     gene            complement(959..1273)
+                     /locus_tag="B170_RS0101200"
+     CDS             complement(959..1273)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018254623.1"
+                     /locus_tag="B170_RS0101200"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="DUF2516 family protein"
+                     /protein_id="WP_026271676.1"
+                     /transl_table=11
+                     /translation="MAIAAPFAFEVRYVIELILLVFALIVQGVALVHVITQRSDAFAAV
+                     GTLPKGAWAAILAVCLVLTLLGFGPISLFGLVGIAAGLIYLLDVRTGLRDLRGGRGNSW
+                     "
+     gene            complement(1365..1943)
+                     /locus_tag="B170_RS0101205"
+     CDS             complement(1365..1943)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_011904237.1"
+                     /locus_tag="B170_RS0101205"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_019870483.1"
+                     /transl_table=11
+                     /translation="MTSQPKTSRIPAPLYAAAGAGDLAYQQLRKLPAAVTELRNRVAAD
+                     LGTVNGAELRQKATETLRTATATAENLRRRAASDLDLSRLRETATRNAAVVVASAQAAQ
+                     ERAVTTYGALVGHGERVVGAGVLEAADTVNTDIETTEQPPAPTPAQLAEAAEVKPAAVT
+                     KRATKAAGKPASSATKSPRATKRTPPARD"
+     gene            complement(2049..2645)
+                     /locus_tag="B170_RS0101210"
+     CDS             complement(2049..2645)
+                     /codon_start=1
+                     /gene_functions="other (smcogs) SMCOG1148:hypothetical
+                     protein (Score: 87.4; E-value: 2.3e-26)"
+                     /gene_kind="other"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_011904236.1"
+                     /locus_tag="B170_RS0101210"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="helix-turn-helix transcriptional regulator"
+                     /protein_id="WP_019870482.1"
+                     /transl_table=11
+                     /translation="MASGKDLPNIGGFIRDLRRSAKISLRQLSEQAGVSNPYLSQIERG
+                     LRKPSAEVLQQLASALRVSTPAMYLRAGLLDDREGQGVLAAIAVDPDLTMAQKQSLTQI
+                     YETFRRENARLAEATAAADAASAEAATGPVTTESVAAPSTTEVTTGTVTTESVAGSPTT
+                     EPEPGPAQPSGTSADLANIAVTGPTTTGGTPTGGA"
+     gene            complement(2785..3798)
+                     /locus_tag="B170_RS0101215"
+     CDS             complement(2785..3798)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018584331.1"
+                     /locus_tag="B170_RS0101215"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="asparaginase"
+                     /protein_id="WP_050588275.1"
+                     /transl_table=11
+                     /translation="MPWSPLGWTFPKGGNVHAVGKTYEGGVPLAEVVRSGFVEGVHRGS
+                     VVALDATGAAVAKAGDVTSPIFPRSSNKPLQTVGMIRAGLRLADSADLALVSASHEGEE
+                     FHRARVGGLLARAGLDESALHCPPDLPADEEARAAVLRAGGGPTRIQMNCSGKHTGMLL
+                     TCQAAGWPGEGYWRSEHPLQERLRAAVEEFTDEPAAAVGIDGCGAPVLAVSLSGLALAY
+                     LRLVQAEPGSPERAVADSMRAHPEIVGGTRADDSRMMRAVPGLLAKIGVEGVIAAAVPG
+                     VGAIALKIDDGAGRARMPVLVSALRRLGVTAPALAVFAEVPLLGGGRPVGAIRSLW"
+     gene            complement(3838..4680)
+                     /locus_tag="B170_RS0101220"
+     CDS             complement(3838..4680)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018218117.1"
+                     /locus_tag="B170_RS0101220"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="3-keto-5-aminohexanoate cleavage protein"
+                     /protein_id="WP_027654903.1"
+                     /transl_table=11
+                     /translation="MTTGTLITVAPTGAESAKVEVPALPVTLDELLLTAKECEALGAAV
+                     VHVHIRDGAAQPTLDQRRLRETVAALRESTDLVVQLSSGGAVSDPEADRLAVLDAAPDM
+                     ASCTMGTVNFGTDVFLNRWEFIVELHTRMQERGIVPEYEIFDLGHLTALQRLLGKYGLP
+                     AGGHVHVDLVMGVPGGMPGTPAALVAAEQMLRDLPAGTTFSATGVGRSTIPVLLASLSA
+                     GGHLRVGMEDTVTYAKGQPVESNMQLVARAVGFAQLAQRPPLTTAEARELLGVPAPRR"
+     gene            complement(4792..5901)
+                     /locus_tag="B170_RS0101225"
+     CDS             complement(4792..5901)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019870479.1"
+                     /locus_tag="B170_RS0101225"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="folate-binding protein YgfZ"
+                     /protein_id="WP_027654904.1"
+                     /transl_table=11
+                     /translation="MIDIAGAVSVESIDEGSRDQPEPAHAAAGVRSVAAHYGDPLREQR
+                     TLETGVGLVDRSHRGVIAVPGEDRLGWLHTLTTQHLADLPAGQGTELLVLSPHGHVEQH
+                     AMVAEEGGTTWLDTEPGDTAGLLGYLERMRFFSKVEPRDVTPDHALLSLVGPAAVDAVA
+                     TLGVSGLAEPDLLEVPGPKFRAGSVPPRSTVRYDVRALPVGGWARRGPLGVDLLVAREA
+                     MGRVVAELSDAGVPVAGLWAYEAVRVAARRPRVGLDTDHRSIPAEVGLVGPAVHLEKGC
+                     YRGQETVARVHNMGRPPRRLVLLHLDGVTTDQPPSAGTPVTRDGRAVGFVGTAVHHHEL
+                     GQVALAVVKRNVPDDARLLVGETAAMIDS"
+     gene            complement(5898..6326)
+                     /locus_tag="B170_RS0101230"
+     CDS             complement(5898..6326)
+                     /codon_start=1
+                     /gene_functions="regulatory (smcogs) SMCOG1266:hydrogen
+                     peroxide sensitive repressor (Score: 114.4; E-value:
+                     6.2e-35)"
+                     /gene_kind="regulatory"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018736279.1"
+                     /locus_tag="B170_RS0101230"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="transcriptional repressor"
+                     /protein_id="WP_018730254.1"
+                     /transl_table=11
+                     /translation="MSESSLAELLRARGLRLTAQRQLVLQAVLELGHATPEQVHTAVRE
+                     VAAGVNITTIYRTLELLERLGLVTHTHLSHGSPTFHAAGEDQHVHLVCRECGAIDEIDP
+                     ALLRPLADQLAEQRGFRVDVGHVSLFGRCDRCENGAQE"
+     gene            6460..7326
+                     /locus_tag="B170_RS0101235"
+     CDS             6460..7326
+                     /NRPS_PKS="Domain: Aminotran_4 (47-275). E-value: 5.6e-34.
+                     Score: 109.6. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101235_Aminotran_4.1"
+                     /NRPS_PKS="type: other"
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018736280.1"
+                     /locus_tag="B170_RS0101235"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="aminotransferase IV"
+                     /protein_id="WP_027654905.1"
+                     /transl_table=11
+                     /translation="MTTARIAVLGRGRVPVTEPVLRGDDLGVLHGDGLFETMHLRAGRP
+                     WLREAHLERMTRAAPVLGLTLPPADALVALLEEICADWPTEVEGALRLVCTRGVADGEA
+                     PTAYATLAPVPPSARAARRDGITVATLPLGVPANGRAGLDWLPTGSKTTSYAVHNAARR
+                     WASRNGVNDALWTSTDGYVLEGPTANVLWLTGGALRTVPAAAGILPGTTAAWLLANAEQ
+                     VGLAAYEQLAAPAELHAADAVWFSSSVRGLVEVRVLDGIGRPRSTYTRRLQALLGFPVP
+                     PDDDQSD"
+     aSDomain        6601..7284
+                     /aSDomain="Aminotran_4"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101235_Aminotran_4.1"
+                     /evalue="5.60E-34"
+                     /label="B170_RS0101235_Aminotran_4.1"
+                     /locus_tag="B170_RS0101235"
+                     /protein_end="275"
+                     /protein_start="47"
+                     /score="109.6"
+                     /tool="antismash"
+                     /translation="REAHLERMTRAAPVLGLTLPPADALVALLEEICADWPTEVEGALR
+                     LVCTRGVADGEAPTAYATLAPVPPSARAARRDGITVATLPLGVPANGRAGLDWLPTGSK
+                     TTSYAVHNAARRWASRNGVNDALWTSTDGYVLEGPTANVLWLTGGALRTVPAAAGILPG
+                     TTAAWLLANAEQVGLAAYEQLAAPAELHAADAVWFSSSVRGLVEVRVLDGIGRPRSTYT
+                     RRLQAL"
+     gene            complement(7393..7986)
+                     /locus_tag="B170_RS0101240"
+     CDS             complement(7393..7986)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_007465734.1"
+                     /locus_tag="B170_RS0101240"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="FABP family protein"
+                     /protein_id="WP_018730256.1"
+                     /transl_table=11
+                     /translation="MSDENPLQPPWLNAPPVDPYPYEESHDLRTGPKLHPTLDGLLPYI
+                     GVWRGRGRGGYPTIEDFDYAQEIRISHDGRPFLCYESRAWLLDEQSRPVRPAGREMGWW
+                     RPVLDGDDRATNEWEALMSTPTGVMELHLGKRTGTQLEFATDAVVRTPTAKEVTAGHRL
+                     FGIVEGALLYAQEMAAVGHGLTPHLSARLIRVGG"
+     gene            8101..8475
+                     /locus_tag="B170_RS0101250"
+     CDS             8101..8475
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_007073224.1"
+                     /locus_tag="B170_RS0101250"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="DsrE family protein"
+                     /protein_id="WP_018739966.1"
+                     /transl_table=11
+                     /translation="MLALVGRNLVVKVTAGADSPERCAQAFTVAATAAAAGVDVSLWLT
+                     GEATWFALPGRAQEFELPHSAPLGELLHVILTTGRVTACTQCAARRDIGTGDVLPGVRI
+                     AGSAVFVEEVMAEESRALVY"
+     gene            complement(8557..9327)
+                     /locus_tag="B170_RS0101255"
+     CDS             complement(8557..9327)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_011904228.1"
+                     /locus_tag="B170_RS0101255"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="MBL fold metallo-hydrolase"
+                     /protein_id="WP_027654906.1"
+                     /transl_table=11
+                     /translation="MTSEKLQFTVLGCATPYPSVDNPCSGYLVSGGGARVWVDAGSGTL
+                     AQLQRHVRLDELDAIWISHLHADHSADLLTAYYGALYADIQLAAPIPLYGPPGIADRLA
+                     HFLTNTATRSPIESAFAVGELHDGDRVAVGALTLTSRSVAHGIPAFALRVDIGGRSLVY
+                     SGDTAPCSGLTSLAEGSDVLLCEAESAQVPSAGERVHHTPEDAGETARAAGVGRLIVTH
+                     IGRFLTPEQAVARASTRFDGPIDHAVPGATHSVD"
+     gene            complement(9379..10227)
+                     /locus_tag="B170_RS0101260"
+     CDS             complement(9379..10227)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018586895.1"
+                     /locus_tag="B170_RS0101260"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027654907.1"
+                     /transl_table=11
+                     /translation="MSAVHPGYAPPSGPDRPPSRPWARRLLIAGTMAWAVLLAGLAWWS
+                     ARTDEPTVREQRTIEQAAPVVSAAVGQLVAALDGTAWAMTPSRVERGCRVTPVSTGAEL
+                     TRGIDVLVAEGGERELLSQVTEALPARWRAGVRDAAEGPLLRADAGEFVLVEGESTSPG
+                     RVRLEVLTGCRPTDAGSGDRLLGNPPEPALRAALQALGRPVPEHSDEVVAPCPGGAKAW
+                     TQRVAAGAGPASLSALAPLAAGAVVVDTPEAYAYRRGADLIVADATGDQLHLAFSTGCA
+                     D"
+     gene            complement(10282..10737)
+                     /locus_tag="B170_RS0101265"
+     CDS             complement(10282..10737)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018743155.1"
+                     /locus_tag="B170_RS0101265"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="winged helix-turn-helix transcriptional
+                     regulator"
+                     /protein_id="WP_019870472.1"
+                     /transl_table=11
+                     /translation="MAVRERVLRRLDGVGPVLSCADLAELRAMLFPEPSVTEERGTGPP
+                     NAPVRYGELVVDPPGHLVTWRGHPLALTRTERRLLTRLVTPPVRLWSYERLFAAVWGGA
+                     YLGDTAILHSAIKRLRRKLRLLSGGPRVLTVRGVGYRLVLGSDDAGG"
+     gene            10994..15346
+                     /locus_tag="B170_RS0101270"
+     CDS             10994..15346
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional
+                     (rule-based-clusters) Peptidase_S8"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018586893.1"
+                     /locus_tag="B170_RS0101270"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="S8 family serine peptidase"
+                     /protein_id="WP_027654908.1"
+                     /sec_met_domain="Peptidase_S8 (E-value: 2.1e-40, bitscore:
+                     133.4, seeds: 43, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MFVRPSARSRLGRLAVAFGALVLGLSAQPALAASPPGASERATVA
+                     SELLETSDSTSFLVYLRETAPLASTATLQAPDDRARAVHQLLTNTADRTQADLLRLLEA
+                     RKAEHTSYWIANAIQVHGDRALIDEIANRPEVERIEPIRSRQLIEPTPAEAEARTDAIE
+                     WGVAEIGAPQVWDEFGDRGEGIVIANIDTGVQYDHPALVNSYRGNLGGGSFDHAYNWFD
+                     PTGICSDSEPCDNNDHGTHTMGTMVGDDGADNQIGVAPGARWIAAKGCEVSTCSDAALL
+                     ASGQWILAPTDANGENPRPELRPDIVNNSWGGGGNDPWYQQTVDAWRAAGILPVFSNGN
+                     SGPGCGTAGSPGDYESSYAVGAYGSNGAIAGFSSRGSGTDLIKPNIAAPGVAVRSSVPG
+                     GGYAAFNGTSMAAPHVAATAALIWSVAPSLRGDLPATEALLDRTARDVDDTTCGGTAAD
+                     NNVFGEGRLDAYAAVNEAPRGPVGRVTGTVTAAEDGEPLAGVTIDDGTRDTTTGADGRY
+                     SLTVPSGETTVTATLYGYESQSDTFTVDEGGAVTRDFALVESPMVTVSGQVTDGSGQGW
+                     PLYAKINIAGKPGDPVFTDPVTGEWSATVAGDNTYSITATPQYPDYRTVTREVPVGSDA
+                     TTVDMAVQIAESCTAAGYNASYDDPLLTEDFADSTTPEGWSVVNRTDEGGWTFEDLGGR
+                     GNLTGGSGGFAIIDSDDLGLGNSQDTDLVSPTVDLSGTPAPVLRFNTDWRAIGVTDSAD
+                     IDVTTDGGATWTNVWHQTSSLRGPRVEEVPLTPAAGASEVQVRFRFAGSFDWWWQVDDV
+                     MLANRNCTPAPGGLVVGTTSDQNTDAALNGVAVTSVDQPEDNAVSAGTDDPAESKGFYW
+                     LFSSLTGTHPFTAERAPYPVATQDVTVVANDVRRADFALAAGKLTVTPTEVESHQPYGS
+                     TRSTQVTVKNTGTAPADVEVLERSGAFDLLAAPGAPLREVTMKGISTARTGTTFGGAPA
+                     EAEESTDNSWTRVADLPSNAFDNSAAILDGKVYSIGGGSATGNERATWAYDPGTDSWSE
+                     LPPLPTSRSKPGVAAVGGKIYVTGGWGNEIDPDATVNVFDPASETWSTLDGVTNPAPTA
+                     APGTAVVDGKIYLVGGCANSSCTATDDTVVFDPRAATFATVAPYPQQVSWMSCGGVGTQ
+                     MYCAGGSGADTAAHKYDPATDTWTPIADMPLDLWGSSSAAAGGMLVLAGGITNGSTTVT
+                     NQTIAYDPAAGTWQDLPNAEFARYRGAGACGAYRIGGSFDPFLGTAEVEQLSGLELCVQ
+                     ETELPWLSTAPASFTLEPGESRKVQLTLTATAEAGVEQPGRYSGELAFAADVPYPTTPV
+                     KVEMNVSPPKSWGKLQGTVTGVTCGGETVGVPATVRVNATGSGAGYTLTADNSGTYTVW
+                     LPKGRYDVIVAKDGWVPEFDRTKVEAGFVATLDFSLEPSSDCTKASGI"
+     gene            complement(15481..16482)
+                     /gene="sbnB"
+                     /locus_tag="B170_RS0101275"
+     CDS             complement(15481..16482)
+                     /codon_start=1
+                     /gene="sbnB"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1158:ornithine cyclodeaminase (Score: 355.7; E-value:
+                     2.9e-108)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_020215520.1"
+                     /locus_tag="B170_RS0101275"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="2,3-diaminopropionate biosynthesis protein SbnB"
+                     /protein_id="WP_027654909.1"
+                     /transl_table=11
+                     /translation="MLMLGKSEVNLVLDGAESDVLAAVREAYELHALGRTAVPHSVFLR
+                     FPADLQNRIIALPAYLGTRTPVAGVKWVASFPGNLRLGQDRASASMILNCPRTGFPEVF
+                     MEAAAISAQRTAASAALAAVTLGSSHPESGVSQIGCGPIGFEVLRYLQLVKPELDQITL
+                     YDLDRARAESFAARVNARWPRLKVEVAARVEEALAAHPLVTLATTASVPHLAGEHLRPG
+                     ALVLHLSLRDLSAETIQTSINIVDDADHVCRAATSLHLAEQQSGGRDFIAASLGELLVA
+                     GDRYSRDDSSLTVFSPFGLGCLDLAVAAMVRRKAEERGLGTTLPGFMSVGEA"
+     gene            complement(16476..17498)
+                     /gene="sbnA"
+                     /locus_tag="B170_RS0101280"
+     CDS             complement(16476..17498)
+                     /codon_start=1
+                     /gene="sbnA"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1081:cysteine synthase (Score: 377.3; E-value:
+                     7.7e-115)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018800097.1"
+                     /locus_tag="B170_RS0101280"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="2,3-diaminopropionate biosynthesis protein SbnA"
+                     /protein_id="WP_027654910.1"
+                     /transl_table=11
+                     /translation="MIGPVDQGGSSVSGVLSTIGATPIVELTKLDPNSSVRIFAKLESH
+                     NPGGSIKDRSALEMLQERIRDGRLVPGKSTVIESSSGNLGIGLAQICAYHGIRFICVVD
+                     PRTNRQNIAIMRAYGAEVEVVTDVDPVSGEYLPVRIRRVRELVESITHAYCPNQYANPL
+                     NPRAHHSTVREILDALPTLDFVFCATSSCGTLRGCAEYLRRHQLPAQVVAVDALGSAIF
+                     GPPVGGRLIPGHGASVRPSLYADGLADQVIRVHDLDAIVGCRRLAAREAILAGGSSGAV
+                     VSALDVVRDRIPPGSTCALVFPDRGERYLDTIYNDDWVAMHFGDVAHLWKEPEMEAMSC
+                     "
+     gene            complement(17495..18778)
+                     /locus_tag="B170_RS0101285"
+     CDS             complement(17495..18778)
+                     /codon_start=1
+                     /gene_functions="transport (smcogs) SMCOG1020:major
+                     facilitator transporter (Score: 341.3; E-value: 1.2e-103)"
+                     /gene_kind="transport"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018824930.1"
+                     /locus_tag="B170_RS0101285"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="MFS transporter"
+                     /protein_id="WP_027654911.1"
+                     /transl_table=11
+                     /translation="MTTTAQPRPGAPVSKLRHNRDFLLLWSGTAVSLVGLTVSTVAYPL
+                     LILAATGSKAAAGVVGFFSLLPALLFQLPAGVLVDRWDRRRLMIWCDVVRAAGAASVVL
+                     ALALDELTVAHVVVVGFVEGTMSVFFNLAAHAAVPNIVHPDHLSAALSRNEARSRAATM
+                     LGTTLGGVLFGLSRIMPFLLHAVTHVISLVTLLFIRADFQRRQPARTRTTGLLAEVGEG
+                     MRWLWRQPFLRTAALLVAGSNLLFRALFLVVVVMATDVGASPAAVGVLLGVAGAGGVLG
+                     SLAAGWCQRWVPLPALVVGANWIWALLMGAIVVADNLYLLTAAYAGMWFVGPLWNVAVA
+                     THQLRITPDRLRGRVLGAMGLLASGALPIGALIGGLLLEWFDARAAALVLAGWMGLLAL
+                     VATFAPALRRPVVPVETPTVPDAEPTVR"
+     gene            18991..19971
+                     /locus_tag="B170_RS0101290"
+     CDS             18991..19971
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1046:Dioxygenase TauD/TfdA (Score: 416.3; E-value:
+                     1e-126)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018791342.1"
+                     /locus_tag="B170_RS0101290"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="TauD/TfdA family dioxygenase"
+                     /protein_id="WP_027654912.1"
+                     /transl_table=11
+                     /translation="MKTSPLPQPLRTPSDAEPALPYVVTAPAPETTATSFLATSRDQVR
+                     QRLREHGAVLLRGFDVDGVDGFDQIVRSVSGTPLSYAERSSPRSTIKGRVYTSTDYPPG
+                     EEIFLHNENSYQATWPMTLFFYCITPPETLGATPLADTRQVLRSIDPAVRDEFARRGWT
+                     VVRNFSDGLGVPWQQAFNTDKPAEVEAYCAGNGVEVEWVGRNGLRTTGRRQAVHRHPAT
+                     GAEVWFNHLTFFHVTTLAEEMCAGLREMFDEVDLPTNTYYGDGERVPDEVVAHLRDCYR
+                     AAQRRFDWQRDDVLLVDNMLAAHGREPFTGPRKIAVAMAEPFRTA"
+     gene            20001..26378
+                     /locus_tag="B170_RS0101295"
+     CDS             20001..26378
+                     /NRPS_PKS="Domain: Condensation_LCL (7-305). E-value:
+                     4.5e-97. Score: 316.4. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_Condensation_LCL.1"
+                     /NRPS_PKS="Domain: AMP-binding (469-866). E-value: 1e-107.
+                     Score: 352.0. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_AMP-binding.1"
+                     /NRPS_PKS="Domain: PCP (976-1043). E-value: 1.6e-21. Score:
+                     68.1. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_PCP.1"
+                     /NRPS_PKS="Domain: Condensation_LCL (1059-1351). E-value:
+                     1.6e-111. Score: 363.9. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_Condensation_LCL.2"
+                     /NRPS_PKS="Domain: AMP-binding (1525-1924). E-value:
+                     1.8e-112. Score: 367.7. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_AMP-binding.2"
+                     /NRPS_PKS="Domain: PCP (2032-2096). E-value: 3.8e-28.
+                     Score: 89.3. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_PCP.2"
+                     /NRPS_PKS="type: NRPS"
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     AMP-binding"
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     Condensation"
+                     /gene_functions="biosynthetic-additional
+                     (rule-based-clusters) PP-binding"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1127:condensation domain-containing protein (Score:
+                     433.3; E-value: 2e-131)"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019030251.1"
+                     /locus_tag="B170_RS0101295"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="non-ribosomal peptide synthetase"
+                     /protein_id="WP_027654913.1"
+                     /sec_met_domain="Condensation (E-value: 1e-75, bitscore:
+                     249.1, seeds: 42, tool: rule-based-clusters)"
+                     /sec_met_domain="AMP-binding (E-value: 2.7e-119, bitscore:
+                     393.0, seeds: 400, tool: rule-based-clusters)"
+                     /sec_met_domain="PP-binding (E-value: 1.1e-16, bitscore:
+                     55.7, seeds: 164, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MATGDGGISLSFTQEQLWFLDQLRSGAATEYLLHEAFQVRGPVDV
+                     DALATAFTRVSERHEVLRTRYETVDDTALQVVDDPVAVPVEVIDLTAVADADTELQRIR
+                     LDQRTPIDLRTEPPWRVTLVRLDRSDSVLLITVHHIAFDGWSWGVLARELGELYGELTG
+                     GTAAGLAEPPVQYGDYADWQREWWASAEEVRSKQLGYWRNTLAGLAPLDLPTDRPRPSH
+                     WNSAGDNFDFTVPVAVANEVTLLARAAGATPFMVYLSAFQLLLGRYAGQRDVAVGVSLA
+                     GRNDVQLEPLIGAFVNTIVLRTNLAGAPSFAELLARVRETTLDAYGHQDVPFDRVVHDL
+                     APDRDPSRNPVFQVGFAMHNAERVRLSLPGLEVTKLPAAWTNSAFDLSLHLSERPDGTV
+                     HARLMYVTALFDRARIERMAANYLRLLSRALAEPTRPVTRLSLVAEPELHQLHEWNHTN
+                     APTSRLLLPELFLAQARRTPDAVAVAGADGDLTYAELAARVTALTSYLLSRGVTTERPV
+                     GVSLHPGADLVTTLLAVLAAGGVYVPLPPEHPAERLAMMVADAGVELIVTNSALRDQLP
+                     TAQLIALDSDQALIASAPTAVPPVIHPGNAAYVMYTSGSTGRPKGVTITHGGIRNRVLW
+                     SVHRYGMAPGDRVLQKTTIGFDASVWEFLSPLVSGGAVVTPPAGVHRDPAAMVEAVATH
+                     GVTVLQLVPSVLRLLVEVPHLAGCSALRLLCSAGEPLPVALCERLLDTLDVEIMNTYGP
+                     TECAIDSTAAWFRRGEQGETVPIGTPLQNMRAYVVDASDELVPLGVPGELCVSGVGLAR
+                     GYVGRGDLTAERFRPNPYARVPGERWYRTGDLVRWRDDGVLEFIGRVDEQVKIRGVRVE
+                     PAEVEAAVRTHPDVGEAVVTARRGELGDLELVAYTVPANGTPVSLETLAAHLAEVLPAP
+                     MIPSNHVGLDVLPLTSNGKVDRAALPEPGTLPASPTDEHVSPRTPTERAVAALMEEVLG
+                     IERVGAEDDFFTYGHSLLAIRFVLRLRRTFDIELTVGDLFAARTVAALAAHIDVAAADG
+                     PVIPPVPRDGVLPLSFAQQRMWFLDQLEPGSVEYLVPLALRLRGPLDTEALRRAMDAVA
+                     ARHEMLRTRYVSAGDSPVQVIDPPGPVWFEVVDLTGASDAAVQALVDRSCSQPFDLSQE
+                     RPLRVTVVRRGAEDHLVAVSLHHVAFDAWSMDLFMRDLRTAYAAIRGGADVPLAPPTVQ
+                     YADFAAWQRSREAELGDQLDYWRERLTGLDPVELPTDRPRPAVRDPRGGTVSVDVPDEL
+                     AAGLHELAGRHGATLFMTLLAGFQVLLARYTGRTDLAVGTPVAGRTRPETEELLGFFVN
+                     TLVLRHDLSGNPTFVELLDQVRRSSLDAFANQDVPFEHLVDALAANRDMSRNPLFQIMF
+                     ELAHLDQFPTTLGEAAIEPVHAGVPVAKFDLTLTVKQRSRGRLRCTFEYATGLFDRSTV
+                     ERLAGHYLNLLTAIVGSPTARLNSLPVLSDGERDVLVREWPDPASTRLPLLDPVDERHR
+                     TVPELFERQAKRTPDAVAMVFGEQEVTYRELNERANQLAHHLRSLGVGPEVVVASCLER
+                     GPDAVVVLLAALKSGGVYVPFDPDHPTERLDFMLTDAAAHLVVTTRAAAQRLAGHRVVT
+                     VDDDQLATAPATDLESPPRPHNLAYVIYTSGSTGRPKGVMIEHRSYVHHCRVISDAYGI
+                     GPDDRVVLLSALTFDVAMDQIAATLLAGATVVVSDPVFWTPSELPARLAEHGVTIMEIT
+                     PAYYRELLEADVDRLSALRLMNVGSDVVTVADARRWAATGLPARFLCNYGPTEATVTCV
+                     LHPVAGLDADERDEAAMPIGRPVAGTRGYVLDAGLMPVPVGVPGELCLGGIRLARGYLN
+                     RPELTADRFVPDPHSGDPGARLYRTGDLVRWRPDGTIEFIGRIDQQVKVRGFRIELGEI
+                     EAALAEHPAVHASVVTVREVGPGEKQLVGYVVPRDRSRPDIAELRAHLRDRVPEYMVPA
+                     RWVTLDALPLTPSKKVDRKALPAPSAPDGERTLTSPRDETEAALAGIWAEVLDVEQVGI
+                     HDNFFELGGHSLLATRVLARIRTAFAVDLPLRRLFEATTVAELAIEVGAAVEADVALLT
+                     DTEIEALLAEEEGAR"
+     aSDomain        20022..20915
+                     /aSDomain="Condensation"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_Condensation_LCL.
+                     1"
+                     /domain_subtype="Condensation_LCL"
+                     /evalue="4.50E-97"
+                     /label="B170_RS0101295_Condensation_LCL.1"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="305"
+                     /protein_start="7"
+                     /score="316.4"
+                     /tool="antismash"
+                     /translation="ISLSFTQEQLWFLDQLRSGAATEYLLHEAFQVRGPVDVDALATAF
+                     TRVSERHEVLRTRYETVDDTALQVVDDPVAVPVEVIDLTAVADADTELQRIRLDQRTPI
+                     DLRTEPPWRVTLVRLDRSDSVLLITVHHIAFDGWSWGVLARELGELYGELTGGTAAGLA
+                     EPPVQYGDYADWQREWWASAEEVRSKQLGYWRNTLAGLAPLDLPTDRPRPSHWNSAGDN
+                     FDFTVPVAVANEVTLLARAAGATPFMVYLSAFQLLLGRYAGQRDVAVGVSLAGRNDVQL
+                     EPLIGAFVNTIVLRTNL"
+     aSModule        20022..23129
+                     /complete
+                     /domains="nrpspksdomains_B170_RS0101295_Condensation_LCL.1"
+                     /domains="nrpspksdomains_B170_RS0101295_AMP-binding.1"
+                     /domains="nrpspksdomains_B170_RS0101295_PCP.1"
+                     /locus_tags="B170_RS0101295"
+                     /monomer_pairings="X -> X"
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       20031..20063
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0001"
+                     /evalue="1.40E-01"
+                     /label="C1_LCL_004-017"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="21"
+                     /protein_start="10"
+                     /score="5.5"
+                     /tool="antismash"
+                     /translation="SFTQEQLWFLD"
+     CDS_motif       20091..20198
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0002"
+                     /evalue="4.20E-12"
+                     /label="C2_LCL_024-062"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="66"
+                     /protein_start="30"
+                     /score="38.5"
+                     /tool="antismash"
+                     /translation="YLLHEAFQVRGPVDVDALATAFTRVSERHEVLRTRY"
+     CDS_motif       20409..20474
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0003"
+                     /evalue="2.20E-11"
+                     /label="C3_LCL_132-143"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="158"
+                     /protein_start="136"
+                     /score="36.1"
+                     /tool="antismash"
+                     /translation="VHHIAFDGWSWGVLARELGELY"
+     CDS_motif       20523..20558
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0004"
+                     /evalue="2.90E-03"
+                     /label="C4_LCL_164-176"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="186"
+                     /protein_start="174"
+                     /score="10.5"
+                     /tool="antismash"
+                     /translation="QYGDYADWQREW"
+     CDS_motif       20817..20906
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0005"
+                     /evalue="8.50E-11"
+                     /label="C5_LCL_267-296"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="302"
+                     /protein_start="272"
+                     /score="34.3"
+                     /tool="antismash"
+                     /translation="DVAVGVSLAGRNDVQLEPLIGAFVNTIVLR"
+     CDS_motif       20955..21074
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0006"
+                     /evalue="9.20E-22"
+                     /label="C67_LCL_14fromHMM"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="358"
+                     /protein_start="318"
+                     /score="69.5"
+                     /tool="antismash"
+                     /translation="RETTLDAYGHQDVPFDRVVHDLAPDRDPSRNPVFQVGFAM"
+     aSDomain        21408..22598
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_AMP-binding.1"
+                     /evalue="1.00E-107"
+                     /label="B170_RS0101295_AMP-binding.1"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="866"
+                     /protein_start="469"
+                     /score="352.0"
+                     /specificity="consensus: X"
+                     /tool="antismash"
+                     /translation="FLAQARRTPDAVAVAGADGDLTYAELAARVTALTSYLLSRGVTTE
+                     RPVGVSLHPGADLVTTLLAVLAAGGVYVPLPPEHPAERLAMMVADAGVELIVTNSALRD
+                     QLPTAQLIALDSDQALIASAPTAVPPVIHPGNAAYVMYTSGSTGRPKGVTITHGGIRNR
+                     VLWSVHRYGMAPGDRVLQKTTIGFDASVWEFLSPLVSGGAVVTPPAGVHRDPAAMVEAV
+                     ATHGVTVLQLVPSVLRLLVEVPHLAGCSALRLLCSAGEPLPVALCERLLDTLDVEIMNT
+                     YGPTECAIDSTAAWFRRGEQGETVPIGTPLQNMRAYVVDASDELVPLGVPGELCVSGVG
+                     LARGYVGRGDLTAERFRPNPYARVPGERWYRTGDLVRWRDDGVLEFIGRVDEQVKIR"
+     CDS_motif       21594..21632
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0007"
+                     /evalue="3.60E-03"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="544"
+                     /protein_start="531"
+                     /score="11.0"
+                     /tool="antismash"
+                     /translation="LAVLAAGGVYVPL"
+     CDS_motif       21819..21878
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0008"
+                     /evalue="7.00E-10"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="626"
+                     /protein_start="606"
+                     /score="30.8"
+                     /tool="antismash"
+                     /translation="AYVMYTSGSTGRPKGVTITH"
+     CDS_motif       22251..22274
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0009"
+                     /evalue="6.90E-02"
+                     /label="NRPS-A_a5"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="758"
+                     /protein_start="750"
+                     /score="6.4"
+                     /tool="antismash"
+                     /translation="YGPTECAI"
+     CDS_motif       22386..22475
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0010"
+                     /evalue="2.80E-15"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="825"
+                     /protein_start="795"
+                     /score="48.4"
+                     /tool="antismash"
+                     /translation="PLGVPGELCVSGVGLARGYVGRGDLTAERF"
+     CDS_motif       22563..22628
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0011"
+                     /evalue="3.40E-10"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="876"
+                     /protein_start="854"
+                     /score="32.0"
+                     /tool="antismash"
+                     /translation="FIGRVDEQVKIRGVRVEPAEVE"
+     aSDomain        22929..23129
+                     /aSDomain="PCP"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_PCP.1"
+                     /evalue="1.60E-21"
+                     /label="B170_RS0101295_PCP.1"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1043"
+                     /protein_start="976"
+                     /score="68.1"
+                     /tool="antismash"
+                     /translation="ERAVAALMEEVLGIERVGAEDDFFTYGHSLLAIRFVLRLRRTFDI
+                     ELTVGDLFAARTVAALAAHIDV"
+     aSDomain        23178..24053
+                     /aSDomain="Condensation"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_Condensation_LCL.
+                     2"
+                     /domain_subtype="Condensation_LCL"
+                     /evalue="1.60E-111"
+                     /label="B170_RS0101295_Condensation_LCL.2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1351"
+                     /protein_start="1059"
+                     /score="363.9"
+                     /tool="antismash"
+                     /translation="LPLSFAQQRMWFLDQLEPGSVEYLVPLALRLRGPLDTEALRRAMD
+                     AVAARHEMLRTRYVSAGDSPVQVIDPPGPVWFEVVDLTGASDAAVQALVDRSCSQPFDL
+                     SQERPLRVTVVRRGAEDHLVAVSLHHVAFDAWSMDLFMRDLRTAYAAIRGGADVPLAPP
+                     TVQYADFAAWQRSREAELGDQLDYWRERLTGLDPVELPTDRPRPAVRDPRGGTVSVDVP
+                     DELAAGLHELAGRHGATLFMTLLAGFQVLLARYTGRTDLAVGTPVAGRTRPETEELLGF
+                     FVNTLVLRHDL"
+     aSModule        23178..26288
+                     /complete
+                     /domains="nrpspksdomains_B170_RS0101295_Condensation_LCL.2"
+                     /domains="nrpspksdomains_B170_RS0101295_AMP-binding.2"
+                     /domains="nrpspksdomains_B170_RS0101295_PCP.2"
+                     /locus_tags="B170_RS0101295"
+                     /monomer_pairings="X -> X"
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       23187..23219
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0012"
+                     /evalue="2.40E-03"
+                     /label="C1_LCL_004-017"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1073"
+                     /protein_start="1062"
+                     /score="10.5"
+                     /tool="antismash"
+                     /translation="SFAQQRMWFLD"
+     CDS_motif       23244..23354
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0013"
+                     /evalue="1.40E-17"
+                     /label="C2_LCL_024-062"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1118"
+                     /protein_start="1081"
+                     /score="56.0"
+                     /tool="antismash"
+                     /translation="YLVPLALRLRGPLDTEALRRAMDAVAARHEMLRTRYV"
+     CDS_motif       23559..23624
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0014"
+                     /evalue="3.80E-09"
+                     /label="C3_LCL_132-143"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1208"
+                     /protein_start="1186"
+                     /score="29.1"
+                     /tool="antismash"
+                     /translation="LHHVAFDAWSMDLFMRDLRTAY"
+     CDS_motif       23673..23708
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0015"
+                     /evalue="2.70E-05"
+                     /label="C4_LCL_164-176"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1236"
+                     /protein_start="1224"
+                     /score="16.7"
+                     /tool="antismash"
+                     /translation="QYADFAAWQRSR"
+     CDS_motif       23955..24044
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0016"
+                     /evalue="6.20E-17"
+                     /label="C5_LCL_267-296"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1348"
+                     /protein_start="1318"
+                     /score="53.9"
+                     /tool="antismash"
+                     /translation="DLAVGTPVAGRTRPETEELLGFFVNTLVLR"
+     protocluster    24035..61782
+                     /aStool="rule-based-clusters"
+                     /contig_edge="False"
+                     /core_location="[280465:298213]"
+                     /cutoff="20000"
+                     /detection_rule="((LANC_like and (Lant_dehydr_N or
+                     Lant_dehydr_C) or cds(LANC_like and (Pkinase or DUF4135)))
+                     and not (YcaO or TIGR03882))"
+                     /neighbourhood="10000"
+                     /product="lanthipeptide"
+                     /protocluster_number="2"
+                     /tool="antismash"
+     proto_core      34035..51782
+                     /aStool="rule-based-clusters"
+                     /tool="antismash"
+                     /cutoff="20000"
+                     /detection_rule="((LANC_like and (Lant_dehydr_N or
+                     Lant_dehydr_C) or cds(LANC_like and (Pkinase or DUF4135)))
+                     and not (YcaO or TIGR03882))"
+                     /neighbourhood="10000"
+                     /product="lanthipeptide"
+                     /protocluster_number="2"
+     CDS_motif       24093..24206
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0017"
+                     /evalue="9.50E-21"
+                     /label="C67_LCL_14fromHMM"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1402"
+                     /protein_start="1364"
+                     /score="66.2"
+                     /tool="antismash"
+                     /translation="RRSSLDAFANQDVPFEHLVDALAANRDMSRNPLFQIMF"
+     aSDomain        24576..25772
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_AMP-binding.2"
+                     /evalue="1.80E-112"
+                     /label="B170_RS0101295_AMP-binding.2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1924"
+                     /protein_start="1525"
+                     /score="367.7"
+                     /specificity="consensus: X"
+                     /tool="antismash"
+                     /translation="FERQAKRTPDAVAMVFGEQEVTYRELNERANQLAHHLRSLGVGPE
+                     VVVASCLERGPDAVVVLLAALKSGGVYVPFDPDHPTERLDFMLTDAAAHLVVTTRAAAQ
+                     RLAGHRVVTVDDDQLATAPATDLESPPRPHNLAYVIYTSGSTGRPKGVMIEHRSYVHHC
+                     RVISDAYGIGPDDRVVLLSALTFDVAMDQIAATLLAGATVVVSDPVFWTPSELPARLAE
+                     HGVTIMEITPAYYRELLEADVDRLSALRLMNVGSDVVTVADARRWAATGLPARFLCNYG
+                     PTEATVTCVLHPVAGLDADERDEAAMPIGRPVAGTRGYVLDAGLMPVPVGVPGELCLGG
+                     IRLARGYLNRPELTADRFVPDPHSGDPGARLYRTGDLVRWRPDGTIEFIGRIDQQVKVR
+                     "
+     CDS_motif       24762..24803
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0018"
+                     /evalue="1.90E-03"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1601"
+                     /protein_start="1587"
+                     /score="11.8"
+                     /tool="antismash"
+                     /translation="LAALKSGGVYVPFD"
+     CDS_motif       24984..25043
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0019"
+                     /evalue="1.90E-11"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1681"
+                     /protein_start="1661"
+                     /score="35.6"
+                     /tool="antismash"
+                     /translation="AYVIYTSGSTGRPKGVMIEH"
+     CDS_motif       25158..25190
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0020"
+                     /evalue="4.20E+01"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1730"
+                     /protein_start="1719"
+                     /score="-1.2"
+                     /tool="antismash"
+                     /translation="ATLLAGATVVV"
+     misc_feature    25287..25289
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     CDS_motif       25410..25442
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0021"
+                     /evalue="3.80E-03"
+                     /label="NRPS-A_a5"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1814"
+                     /protein_start="1803"
+                     /score="9.9"
+                     /tool="antismash"
+                     /translation="NYGPTEATVTC"
+     CDS_motif       25560..25649
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0022"
+                     /evalue="2.20E-17"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1883"
+                     /protein_start="1853"
+                     /score="55.1"
+                     /tool="antismash"
+                     /translation="PVGVPGELCLGGIRLARGYLNRPELTADRF"
+     CDS_motif       25737..25802
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0023"
+                     /evalue="1.10E-11"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1934"
+                     /protein_start="1912"
+                     /score="36.7"
+                     /tool="antismash"
+                     /translation="FIGRIDQQVKVRGFRIELGEIE"
+     CDS_motif       25839..25895
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0024"
+                     /evalue="7.40E+00"
+                     /label="C5_LCL_267-296"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1965"
+                     /protein_start="1946"
+                     /score="-0.7"
+                     /tool="antismash"
+                     /translation="VVTVREVGPGEKQLVGYVV"
+     aSDomain        26097..26288
+                     /aSDomain="PCP"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_PCP.2"
+                     /evalue="3.80E-28"
+                     /label="B170_RS0101295_PCP.2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="2096"
+                     /protein_start="2032"
+                     /score="89.3"
+                     /tool="antismash"
+                     /translation="EAALAGIWAEVLDVEQVGIHDNFFELGGHSLLATRVLARIRTAFA
+                     VDLPLRRLFEATTVAELAI"
+     gene            26375..33427
+                     /locus_tag="B170_RS0101300"
+     CDS             26375..33427
+                     /NRPS_PKS="Domain: Condensation_LCL (37-328). E-value:
+                     1.5e-100. Score: 327.8. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_Condensation_LCL.1"
+                     /NRPS_PKS="Domain: AMP-binding (494-869). E-value:
+                     3.5e-117. Score: 383.2. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_AMP-binding.1"
+                     /NRPS_PKS="Domain: PCP (970-1034). E-value: 5e-18. Score:
+                     56.9. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_PCP.1"
+                     /NRPS_PKS="Domain: Condensation_DCL (1063-1362). E-value:
+                     3.4e-53. Score: 172.4. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_Condensation_DCL.1"
+                     /NRPS_PKS="Domain: AMP-binding (1513-1896). E-value:
+                     1.6e-105. Score: 344.8. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_AMP-binding.2"
+                     /NRPS_PKS="Domain: PCP (2005-2073). E-value: 9.5e-24.
+                     Score: 75.2. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_PCP.2"
+                     /NRPS_PKS="Domain: Thioesterase (2090-2332). E-value:
+                     3.2e-32. Score: 104.5. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_Thioesterase.1"
+                     /NRPS_PKS="type: NRPS"
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     AMP-binding"
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     Condensation"
+                     /gene_functions="biosynthetic-additional
+                     (rule-based-clusters) PP-binding"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1127:condensation domain-containing protein (Score:
+                     185; E-value: 4.7e-56)"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019532350.1"
+                     /locus_tag="B170_RS0101300"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="non-ribosomal peptide synthetase"
+                     /protein_id="WP_027654914.1"
+                     /sec_met_domain="Condensation (E-value: 2e-67, bitscore:
+                     222.0, seeds: 42, tool: rule-based-clusters)"
+                     /sec_met_domain="AMP-binding (E-value: 3.5e-116, bitscore:
+                     382.7, seeds: 400, tool: rule-based-clusters)"
+                     /sec_met_domain="PP-binding (E-value: 5.2e-15, bitscore:
+                     50.3, seeds: 164, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MTRTIDRAALRTALLRKRLSGQAGASPEGAPARVSRDGHLPLSSA
+                     QRRLWILDRLRPGSPEYLMTTALRIRGQLCRPALQTALDGLVARHEVLRTRYVDVNGEP
+                     AQVIDDPTPVTLHRRDGLDALDAVLSTELPNIDLAAGPVFRPTLVFLGEDDHALVLTLH
+                     HIAGDAWSEEVMVRELGERYTAASAGREPEFAELPVQYVDFAVWQRDRSSGQALAGDLA
+                     YWRERLAGLNPLELPTDRPRPPVRDGAGALVQVDVSAPIATRFGRLARDHGVTPFTAFL
+                     AAFKVLLARYTGQTDIAVGTPVAGRARPETQDLVGLFLNTLALRTDLSGSPSFRDVLDR
+                     VRETVLDGQSHQELPFEQIVDELAPVRDPSRSPLFSTMFLMTDRVTEAPSFGDLTVTAL
+                     PVGEVAAKFDLTLSVIERANGTLGVGVNYATALFEPETMSRLAGHYAHLLQSIVSDPDT
+                     PVRQLALLSAAERKQVVTSWNDTAVDQPSATLPGLIADQVRRTPQREAVRFDGSSLTYA
+                     ELAARSNQLAHHLRSLGVGPESIVGVCLPRSLDLVVALLAVQKAGGAYLPLDPDHPAER
+                     LRYLREDSGATAMIDTDTFAALAGYPTVDPGVAVRPEHPAYVIYTSGSTGRPKGVVVEH
+                     RGIVNRLRWMQHAYGLDATDRVLQKTPASFDVSVWELFWPLITGATLVVARPDGHRDPA
+                     YLARLIDSERITTLHFVPSMLRAFLTEPFAGLPSLRRVICSGEALTSDLVAAVHDRIGC
+                     ELHNLYGPTEASVDVTAARCRPGEPVTIGTPIANTRAYILDQDLQPVPVGVPGELMLAG
+                     VQLARGYLHRPVLTADRFVPDPFTPGGRLYRTGDLARHRPDGQIDYLGRLDHQVKINGI
+                     RVELGEVEHALTENPAVRAAAVTVDDGQLVAHLVGDVDLATLPDFLRAQLPEAMVPAHW
+                     LTYPALPLTTSGKVDRNALSAPDRNRTTTGGYVAPRTPLEHMIAGAIADALDIDNVGIE
+                     DRFFAIGGDSMRAIRVVGALRAAGVELAVHDLFTHQTVAGLAGLAGAATTEDTLVERFA
+                     QLSEADRQLLPNGLVDAYPLAETQAGMVYEMLAAPDRTVYLNVSCYRVHDELPFDLNTL
+                     RAATAILVGRHEILRTSFDLSTYSETMQLVHATAELPVAHTNLTGLASQAQRAAVDEWL
+                     VAERGRPFDIAQPPLLRYHVHEISADEWWLTHTECHAILDGWSHTSVVNELVSIYRRLR
+                     TGHQPDLAPPPEVRFADFVAAEKRALATSTDHGFWATAIGRYDKLELPDGWASERRDDK
+                     ATIIDVPWADLAPGLRRLAAAAGASMKSVLHAAHLKAISIVTGRRQFFGGLVCNGRPEE
+                     LRGDEVFGMYLNTVPFAADVTAATWRDFVADVFAGEAELWPHRRYPMPAMRREWSPGSP
+                     LIDVAFGYLDFHVLDWEADTVGMIDDFSPSELPLEVWTFPGLLRLGGRPSRIGRENLEL
+                     LGRTYRRVLEAMSLDPDASTDVTLAPVDHDHALHLGGDSTRDYPTEELVHQLVEHQATA
+                     APDAVAVRQADHTLTYAELDAAANRLAHRLRALGAGPGTLVGLFLTRGPDLVVGMLATL
+                     RAGAAFLPLDPAYPAERLRYLITDAEVGLLLTEPDLPLPTGVTATVEIVADYPDLPSAR
+                     PAVAPSLEDLAYVIYTSGSTGRPKGVGVPHRGALNLRHAQREHLDVRPGDRVLQFASPS
+                     FDASVWELLMSLTNGAELVLPPRGTDPGDLRQQAGLVTHMTLPPSLLERLSPEDFPHLR
+                     VLVSAGEACPVDQVARWSGQARFINAYGPTETSVCATLTEVAPTVTAPPSIGSTIGGVS
+                     AYVLDPDLRPLSVGVRGELYVGGAGLARGYLGRPGLTAERFVPNPYGPVGARMYRTGDV
+                     VSRNPDGTIQYHGRTDHQVKVRGHRIELGEIEAALSGHPAVASAVAAVHRSGTTDAALV
+                     AYTRAVDVPPTPAELREYLRACLPGHLLPTHWIAVEDFALTPAGKVDRAVLPGPDGSRP
+                     ELDSAYVAPSDETERALAAAWREALGVDRVGVHDDFFELGGHSLAMMRVIATLRARDGI
+                     ELTFRSFITHRTIAALATTVTDEPAGKAMMWLRRSGSATPLFCVHPGGGSAHWYLRLVP
+                     HLAPDIPVAAFEWPATHNEVPTAEQMAERYLAELRAAQPRGPYRLFSWCGGSSIATEMA
+                     RRLTDAGETVTFMLLDPGLDAHTRAEGWQELNYIRRLEALVEQIVADPRADTAERRAEI
+                     LALLEHLVDDVDPAVGITLPARGVGDVWPRSVRIWREVMELDLAYRHTPYSGQLHLIVS
+                     DELERGEHEVAAGQAFDGYVARWRELTAGGVTVHRVPGDHFGVMKPPHVADLGALLSRL
+                     TDRS"
+     aSDomain        26486..27358
+                     /aSDomain="Condensation"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_Condensation_LCL.
+                     1"
+                     /domain_subtype="Condensation_LCL"
+                     /evalue="1.50E-100"
+                     /label="B170_RS0101300_Condensation_LCL.1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="328"
+                     /protein_start="37"
+                     /score="327.8"
+                     /tool="antismash"
+                     /translation="GHLPLSSAQRRLWILDRLRPGSPEYLMTTALRIRGQLCRPALQTA
+                     LDGLVARHEVLRTRYVDVNGEPAQVIDDPTPVTLHRRDGLDALDAVLSTELPNIDLAAG
+                     PVFRPTLVFLGEDDHALVLTLHHIAGDAWSEEVMVRELGERYTAASAGREPEFAELPVQ
+                     YVDFAVWQRDRSSGQALAGDLAYWRERLAGLNPLELPTDRPRPPVRDGAGALVQVDVSA
+                     PIATRFGRLARDHGVTPFTAFLAAFKVLLARYTGQTDIAVGTPVAGRARPETQDLVGLF
+                     LNTLALRTDL"
+     aSModule        26486..29476
+                     /complete
+                     /domains="nrpspksdomains_B170_RS0101300_Condensation_LCL.1"
+                     /domains="nrpspksdomains_B170_RS0101300_AMP-binding.1"
+                     /domains="nrpspksdomains_B170_RS0101300_PCP.1"
+                     /locus_tags="B170_RS0101300"
+                     /monomer_pairings="ser -> ser"
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       26558..26668
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0001"
+                     /evalue="1.40E-15"
+                     /label="C2_LCL_024-062"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="98"
+                     /protein_start="61"
+                     /score="49.7"
+                     /tool="antismash"
+                     /translation="YLMTTALRIRGQLCRPALQTALDGLVARHEVLRTRYV"
+     CDS_motif       26858..26923
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0002"
+                     /evalue="1.20E-07"
+                     /label="C3_LCL_132-143"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="183"
+                     /protein_start="161"
+                     /score="24.3"
+                     /tool="antismash"
+                     /translation="LHHIAGDAWSEEVMVRELGERY"
+     CDS_motif       26972..27007
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0003"
+                     /evalue="1.30E-04"
+                     /label="C4_LCL_164-176"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="211"
+                     /protein_start="199"
+                     /score="14.6"
+                     /tool="antismash"
+                     /translation="QYVDFAVWQRDR"
+     CDS_motif       27260..27349
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0004"
+                     /evalue="2.80E-15"
+                     /label="C5_LCL_267-296"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="325"
+                     /protein_start="295"
+                     /score="48.6"
+                     /tool="antismash"
+                     /translation="DIAVGTPVAGRARPETQDLVGLFLNTLALR"
+     CDS_motif       27398..27514
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0005"
+                     /evalue="4.90E-20"
+                     /label="C67_LCL_14fromHMM"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="380"
+                     /protein_start="341"
+                     /score="63.9"
+                     /tool="antismash"
+                     /translation="RETVLDGQSHQELPFEQIVDELAPVRDPSRSPLFSTMFL"
+     aSDomain        27857..28981
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_AMP-binding.1"
+                     /evalue="3.50E-117"
+                     /label="B170_RS0101300_AMP-binding.1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="869"
+                     /protein_start="494"
+                     /score="383.2"
+                     /specificity="consensus: ser"
+                     /tool="antismash"
+                     /translation="ADQVRRTPQREAVRFDGSSLTYAELAARSNQLAHHLRSLGVGPES
+                     IVGVCLPRSLDLVVALLAVQKAGGAYLPLDPDHPAERLRYLREDSGATAMIDTDTFAAL
+                     AGYPTVDPGVAVRPEHPAYVIYTSGSTGRPKGVVVEHRGIVNRLRWMQHAYGLDATDRV
+                     LQKTPASFDVSVWELFWPLITGATLVVARPDGHRDPAYLARLIDSERITTLHFVPSMLR
+                     AFLTEPFAGLPSLRRVICSGEALTSDLVAAVHDRIGCELHNLYGPTEASVDVTAARCRP
+                     GEPVTIGTPIANTRAYILDQDLQPVPVGVPGELMLAGVQLARGYLHRPVLTADRFVPDP
+                     FTPGGRLYRTGDLARHRPDGQIDYLGRLDHQVKIN"
+     CDS_motif       28040..28081
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0006"
+                     /evalue="1.50E-04"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="569"
+                     /protein_start="555"
+                     /score="15.1"
+                     /tool="antismash"
+                     /translation="LAVQKAGGAYLPLD"
+     CDS_motif       28220..28279
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0007"
+                     /evalue="4.50E-11"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="635"
+                     /protein_start="615"
+                     /score="34.4"
+                     /tool="antismash"
+                     /translation="AYVIYTSGSTGRPKGVVVEH"
+     CDS_motif       28649..28672
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0008"
+                     /evalue="4.20E-01"
+                     /label="NRPS-A_a5"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="766"
+                     /protein_start="758"
+                     /score="4.2"
+                     /tool="antismash"
+                     /translation="YGPTEASV"
+     CDS_motif       28775..28864
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0009"
+                     /evalue="4.40E-15"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="830"
+                     /protein_start="800"
+                     /score="47.7"
+                     /tool="antismash"
+                     /translation="PVGVPGELMLAGVQLARGYLHRPVLTADRF"
+     CDS_motif       28946..29011
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0010"
+                     /evalue="2.20E-10"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="879"
+                     /protein_start="857"
+                     /score="32.6"
+                     /tool="antismash"
+                     /translation="YLGRLDHQVKINGIRVELGEVE"
+     misc_feature    29180..29182
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     aSDomain        29285..29476
+                     /aSDomain="PCP"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_PCP.1"
+                     /evalue="5.00E-18"
+                     /label="B170_RS0101300_PCP.1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1034"
+                     /protein_start="970"
+                     /score="56.9"
+                     /tool="antismash"
+                     /translation="HMIAGAIADALDIDNVGIEDRFFAIGGDSMRAIRVVGALRAAGVE
+                     LAVHDLFTHQTVAGLAGLA"
+     aSDomain        29564..30460
+                     /aSDomain="Condensation"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_Condensation_DCL.
+                     1"
+                     /domain_subtype="Condensation_DCL"
+                     /evalue="3.40E-53"
+                     /label="B170_RS0101300_Condensation_DCL.1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1362"
+                     /protein_start="1063"
+                     /score="172.4"
+                     /tool="antismash"
+                     /translation="DAYPLAETQAGMVYEMLAAPDRTVYLNVSCYRVHDELPFDLNTLR
+                     AATAILVGRHEILRTSFDLSTYSETMQLVHATAELPVAHTNLTGLASQAQRAAVDEWLV
+                     AERGRPFDIAQPPLLRYHVHEISADEWWLTHTECHAILDGWSHTSVVNELVSIYRRLRT
+                     GHQPDLAPPPEVRFADFVAAEKRALATSTDHGFWATAIGRYDKLELPDGWASERRDDKA
+                     TIIDVPWADLAPGLRRLAAAAGASMKSVLHAAHLKAISIVTGRRQFFGGLVCNGRPEEL
+                     RGDEVFGMYLNTVPFAAD"
+     aSModule        29564..33370
+                     /complete
+                     /domains="nrpspksdomains_B170_RS0101300_Condensation_DCL.1"
+                     /domains="nrpspksdomains_B170_RS0101300_AMP-binding.2"
+                     /domains="nrpspksdomains_B170_RS0101300_PCP.2"
+                     /domains="nrpspksdomains_B170_RS0101300_Thioesterase.1"
+                     /final_module
+                     /locus_tags="B170_RS0101300"
+                     /monomer_pairings="phe -> phe"
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       29675..29749
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0011"
+                     /evalue="8.10E-07"
+                     /label="C2_LCL_024-062"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1125"
+                     /protein_start="1100"
+                     /score="21.5"
+                     /tool="antismash"
+                     /translation="PFDLNTLRAATAILVGRHEILRTSF"
+     CDS_motif       29978..30037
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0012"
+                     /evalue="7.30E-05"
+                     /label="C3_DCL_135-156"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1221"
+                     /protein_start="1201"
+                     /score="15.4"
+                     /tool="antismash"
+                     /translation="HAILDGWSHTSVVNELVSIY"
+     CDS_motif       30374..30451
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0013"
+                     /evalue="1.50E-02"
+                     /label="C5_DCL_263-294"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1359"
+                     /protein_start="1333"
+                     /score="7.9"
+                     /tool="antismash"
+                     /translation="GLVCNGRPEELRGDEVFGMYLNTVPF"
+     aSDomain        30914..32062
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_AMP-binding.2"
+                     /evalue="1.60E-105"
+                     /label="B170_RS0101300_AMP-binding.2"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1896"
+                     /protein_start="1513"
+                     /score="344.8"
+                     /specificity="consensus: phe"
+                     /tool="antismash"
+                     /translation="VEHQATAAPDAVAVRQADHTLTYAELDAAANRLAHRLRALGAGPG
+                     TLVGLFLTRGPDLVVGMLATLRAGAAFLPLDPAYPAERLRYLITDAEVGLLLTEPDLPL
+                     PTGVTATVEIVADYPDLPSARPAVAPSLEDLAYVIYTSGSTGRPKGVGVPHRGALNLRH
+                     AQREHLDVRPGDRVLQFASPSFDASVWELLMSLTNGAELVLPPRGTDPGDLRQQAGLVT
+                     HMTLPPSLLERLSPEDFPHLRVLVSAGEACPVDQVARWSGQARFINAYGPTETSVCATL
+                     TEVAPTVTAPPSIGSTIGGVSAYVLDPDLRPLSVGVRGELYVGGAGLARGYLGRPGLTA
+                     ERFVPNPYGPVGARMYRTGDVVSRNPDGTIQYHGRTDHQVKVR"
+     CDS_motif       31100..31141
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0014"
+                     /evalue="8.70E-04"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1589"
+                     /protein_start="1575"
+                     /score="12.8"
+                     /tool="antismash"
+                     /translation="LATLRAGAAFLPLD"
+     CDS_motif       31319..31378
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0015"
+                     /evalue="1.60E-09"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1668"
+                     /protein_start="1648"
+                     /score="29.8"
+                     /tool="antismash"
+                     /translation="AYVIYTSGSTGRPKGVGVPH"
+     CDS_motif       31721..31747
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0016"
+                     /evalue="4.40E-02"
+                     /label="NRPS-A_a5"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1791"
+                     /protein_start="1782"
+                     /score="6.9"
+                     /tool="antismash"
+                     /translation="YGPTETSVC"
+     CDS_motif       31856..31942
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0017"
+                     /evalue="4.80E-16"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1856"
+                     /protein_start="1827"
+                     /score="50.8"
+                     /tool="antismash"
+                     /translation="VGVRGELYVGGAGLARGYLGRPGLTAERF"
+     CDS_motif       32027..32092
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0018"
+                     /evalue="1.30E-11"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1906"
+                     /protein_start="1884"
+                     /score="36.4"
+                     /tool="antismash"
+                     /translation="YHGRTDHQVKVRGHRIELGEIE"
+     aSDomain        32390..32593
+                     /aSDomain="PCP"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_PCP.2"
+                     /evalue="9.50E-24"
+                     /label="B170_RS0101300_PCP.2"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="2073"
+                     /protein_start="2005"
+                     /score="75.2"
+                     /tool="antismash"
+                     /translation="ERALAAAWREALGVDRVGVHDDFFELGGHSLAMMRVIATLRARDG
+                     IELTFRSFITHRTIAALATTVTD"
+     CDS_motif       32645..32674
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0019"
+                     /evalue="1.90E-03"
+                     /label="NRPS-beforete1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="2100"
+                     /protein_start="2090"
+                     /score="11.2"
+                     /tool="antismash"
+                     /translation="PLFCVHPGGG"
+     aSDomain        32645..33370
+                     /ASF="active site serine inconclusive"
+                     /aSDomain="Thioesterase"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_Thioesterase.1"
+                     /evalue="3.20E-32"
+                     /label="B170_RS0101300_Thioesterase.1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="2332"
+                     /protein_start="2090"
+                     /score="104.5"
+                     /tool="antismash"
+                     /translation="PLFCVHPGGGSAHWYLRLVPHLAPDIPVAAFEWPATHNEVPTAEQ
+                     MAERYLAELRAAQPRGPYRLFSWCGGSSIATEMARRLTDAGETVTFMLLDPGLDAHTRA
+                     EGWQELNYIRRLEALVEQIVADPRADTAERRAEILALLEHLVDDVDPAVGITLPARGVG
+                     DVWPRSVRIWREVMELDLAYRHTPYSGQLHLIVSDELERGEHEVAAGQAFDGYVARWRE
+                     LTAGGVTVHRVPGDHFGVMK"
+     CDS_motif       32816..32890
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0020"
+                     /evalue="5.40E-07"
+                     /label="NRPS-te1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="2172"
+                     /protein_start="2147"
+                     /score="22.1"
+                     /tool="antismash"
+                     /translation="QPRGPYRLFSWCGGSSIATEMARRL"
+     gene            33433..33948
+                     /locus_tag="B170_RS0101305"
+     CDS             33433..33948
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018730267.1"
+                     /locus_tag="B170_RS0101305"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027654915.1"
+                     /transl_table=11
+                     /translation="MERAVVWEVYTSHTESTVTVGGLSTCSAALARVFAAVARLGVEPT
+                     TVAGSGAGVTLVVPRPRGQAVAASLAAAGTRVQLSNAVARVGVRGIGLRADSAVAATFC
+                     QTVVAAGVTLSAVSVESTDISVMCPEHRAEAAAGALAKAFGTATHDIGRDLDPRRGPTL
+                     VVAGGGPL"
+     gene            complement(34035..36245)
+                     /locus_tag="B170_RS0101310"
+     CDS             complement(34035..36245)
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters)
+                     lanthipeptide: Lant_dehydr_N"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018792069.1"
+                     /locus_tag="B170_RS0101310"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="lantibiotic dehydratase"
+                     /protein_id="WP_027654916.1"
+                     /sec_met_domain="Lant_dehydr_N (E-value: 9.4e-18, bitscore:
+                     58.1, seeds: 73, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MDDTSVPLGANWRLWSQFALRGPGFPASGVLRLAPAGLGEAADKF
+                     SADEALSGAAWTAFEELYADAAVATASELQRVAALPAFQTAVAWQNRPLLNSGIAPFLA
+                     WTPSAAGRTSMPRQREELVAHYWQRFCVKNDTIGFFGPVGWGHWDTSTSGIAVTSGVGL
+                     VESSEVYFASWAVDAVARLVNADPELRPWIAPRLVPFVRVNHNSVLVPGRPPQVLPPEL
+                     IELLSRCDGVRPAREVGPAVQLEELVRRRIVLWRLDVPADARPEKWMRHWLESVGAPGG
+                     RAAELLEVLVHGRSRVAAAPGPEELKAALTDLESQFVALTDETAVREKNAKTAPCRTLV
+                     YSDARRSARVRLGADLLDALAPLNLLLTAGRWLTSTVAERVMARVREVFDGPMDLATFW
+                     FACMPVLHGEAAGIAVQVQEEFRRRWRSVLPPLTGSRIQVDAAEIAGAVREAFAAADAG
+                     WTAARYLSPDVLVSPGGELVLGELHVATNTLGASLFVNQHPDPESLLAQTARDHPEPRL
+                     LPLLPKEHRARLSARIRHTLVRPEDYYVALVDQTADPARPRTVRSADVTVRAQGDRLVA
+                     VLPDGAEFGIVDVFSHVLTTLVMDMFRLIPEADHTPRVTMDRMVVARESWRFPTAALPF
+                     IEEKSEAGRFVRARRWREQAELPRFVFVVSPTEPRPFFVDFDSPVYVNILAKSARRLHR
+                     QGDPEARLVITEMLPTPEQTWLMDDQGERYTAELRFVAVDNS"
+     misc_feature    complement(36153..36155)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(36257..36490)
+                     /locus_tag="B170_RS0101315"
+     CDS             complement(36257..36490)
+                     /NRPS_PKS="Domain: PP-binding (9-72). E-value: 1.3e-18.
+                     Score: 59.1. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101315_PP-binding.1"
+                     /NRPS_PKS="type: other"
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional
+                     (rule-based-clusters) PP-binding"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018800091.1"
+                     /locus_tag="B170_RS0101315"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="acyl carrier protein"
+                     /protein_id="WP_026323325.1"
+                     /sec_met_domain="PP-binding (E-value: 9.6e-18, bitscore:
+                     59.1, seeds: 164, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MTTTIDVSELIVSIYRETLHDETLDANSDFFEAGGDSLTAFQITA
+                     RLQATLDIEVPVALVFAYPSPADLAEVVAADF"
+     aSDomain        complement(36275..36463)
+                     /aSDomain="PP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101315_PP-binding.1"
+                     /evalue="1.30E-18"
+                     /label="B170_RS0101315_PP-binding.1"
+                     /locus_tag="B170_RS0101315"
+                     /protein_end="72"
+                     /protein_start="9"
+                     /score="59.1"
+                     /tool="antismash"
+                     /translation="LIVSIYRETLHDETLDANSDFFEAGGDSLTAFQITARLQATLDIE
+                     VPVALVFAYPSPADLAEV"
+     aSModule        36275..36463
+                     /domains="nrpspksdomains_B170_RS0101315_PP-binding.1"
+                     /incomplete
+                     /locus_tags="B170_RS0101315"
+                     /tool="antismash"
+                     /type="unknown"
+     CDS_motif       complement(36377..36406)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101315_0001"
+                     /evalue="2.20E-03"
+                     /label="PCP_mC"
+                     /locus_tag="B170_RS0101315"
+                     /protein_end="38"
+                     /protein_start="28"
+                     /score="11.3"
+                     /tool="antismash"
+                     /translation="DFFEAGGDSL"
+     gene            complement(36465..37442)
+                     /locus_tag="B170_RS0101320"
+     CDS             complement(36465..37442)
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1081:cysteine synthase (Score: 71.4; E-value:
+                     9.8e-22)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018730270.1"
+                     /locus_tag="B170_RS0101320"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="pyridoxal-phosphate dependent enzyme"
+                     /protein_id="WP_019870461.1"
+                     /transl_table=11
+                     /translation="MTTIGSATRSGLGIADVRVAAERISGLVRRTPLLALGSNLLVKGE
+                     HRQHGGSFKLRGAANAMVVLRPAAVVTGSSGNHGIAVATIGAACDIPVTVVMAAGTSEA
+                     KARAIRARGARVVHIEGGVAERERRARSIADRTGAVYLPSSDHELVVAGAGTVGLEVAE
+                     DAPDITTIFVPTGGGGLLAGVCLAVDAFDNPVRVVGVEPVHTRRYAISIAAGGPVELPP
+                     SSTIADGLRGQRPGAVPLPIIRRRVDELIGVTDDAIVHALGVLRVAGVAAEPSGAVALA
+                     GAMQAGCGGHAVAVVSGGNTSEVLSAAPWTFDERKHNDYNYRRV"
+     gene            complement(37442..38914)
+                     /locus_tag="B170_RS0101325"
+     CDS             complement(37442..38914)
+                     /NRPS_PKS="Domain: AMP-binding (10-398). E-value: 9e-87.
+                     Score: 283.0. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101325_AMP-binding.1"
+                     /NRPS_PKS="type: NRPS-like protein"
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     AMP-binding"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1002:AMP-dependent synthetase and ligase (Score:
+                     345.1; E-value: 8.9e-105)"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019870460.1"
+                     /locus_tag="B170_RS0101325"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="amino acid adenylation domain-containing protein"
+                     /protein_id="WP_027654917.1"
+                     /sec_met_domain="AMP-binding (E-value: 3.5e-94, bitscore:
+                     310.2, seeds: 400, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MTTFLDQLVAQGRDRPAAPAIVTPDTVVTYGELVARVDRLARVLV
+                     ARGVGPEQVCAIAVDRGPEAVIAMAAALRAGAAFLTLDVELPGPRLATMIRSGQARCLV
+                     TTSALAGQLDLAFGGLRVHTDEPDPGATVRLPPIATRSLAYVSHTSGSTGTPNAVLVEH
+                     RGLDNYLRCVVSDYDLGTETVVLQLAPLGYDASIRDTFAPLMAGSQLVMVARSALLRVD
+                     EFTATLRGFGVDTILSATPTFLTFVSGHDVPLLRLTVSSGESLRPFLTAGGRERLRGRL
+                     VNQYGPTEATMTSTRFVVPPDPDTTMDLVGTPIEGVTVYVLDDDLNPVPAGAVGQMWVG
+                     GIGVTRGYGGRPDLTAERFVPDPFNGPGNRMYRTGDLARLRGGVLEYLGRVDRQIKIRG
+                     YRVDPAEIEGALLNHPAVDGAAVTAATDDRGRVFLVAHVAGELAEVTDAALRAGLAATL
+                     PPYMLPRRFTRIARLPTTASGKVDHRALTAGP"
+     CDS_motif       complement(37691..37756)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101325_0004"
+                     /evalue="2.20E-11"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101325"
+                     /protein_end="408"
+                     /protein_start="386"
+                     /score="35.7"
+                     /tool="antismash"
+                     /translation="YLGRVDRQIKIRGYRVDPAEIE"
+     aSDomain        complement(37721..38884)
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101325_AMP-binding.1"
+                     /evalue="9.00E-87"
+                     /label="B170_RS0101325_AMP-binding.1"
+                     /locus_tag="B170_RS0101325"
+                     /protein_end="398"
+                     /protein_start="10"
+                     /score="283.0"
+                     /specificity="consensus: X"
+                     /tool="antismash"
+                     /translation="QGRDRPAAPAIVTPDTVVTYGELVARVDRLARVLVARGVGPEQVC
+                     AIAVDRGPEAVIAMAAALRAGAAFLTLDVELPGPRLATMIRSGQARCLVTTSALAGQLD
+                     LAFGGLRVHTDEPDPGATVRLPPIATRSLAYVSHTSGSTGTPNAVLVEHRGLDNYLRCV
+                     VSDYDLGTETVVLQLAPLGYDASIRDTFAPLMAGSQLVMVARSALLRVDEFTATLRGFG
+                     VDTILSATPTFLTFVSGHDVPLLRLTVSSGESLRPFLTAGGRERLRGRLVNQYGPTEAT
+                     MTSTRFVVPPDPDTTMDLVGTPIEGVTVYVLDDDLNPVPAGAVGQMWVGGIGVTRGYGG
+                     RPDLTAERFVPDPFNGPGNRMYRTGDLARLRGGVLEYLGRVDRQIKIR"
+     aSModule        37721..38884
+                     /domains="nrpspksdomains_B170_RS0101325_AMP-binding.1"
+                     /incomplete
+                     /locus_tags="B170_RS0101325"
+                     /starter_module
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       complement(37838..37927)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101325_0003"
+                     /evalue="1.90E-13"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101325"
+                     /protein_end="359"
+                     /protein_start="329"
+                     /score="42.5"
+                     /tool="antismash"
+                     /translation="PAGAVGQMWVGGIGVTRGYGGRPDLTAERF"
+     CDS_motif       complement(38036..38065)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101325_0002"
+                     /evalue="7.50E-03"
+                     /label="NRPS-A_a5"
+                     /locus_tag="B170_RS0101325"
+                     /protein_end="293"
+                     /protein_start="283"
+                     /score="9.1"
+                     /tool="antismash"
+                     /translation="QYGPTEATMT"
+     CDS_motif       complement(38426..38485)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101325_0001"
+                     /evalue="3.70E-07"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101325"
+                     /protein_end="163"
+                     /protein_start="143"
+                     /score="22.6"
+                     /tool="antismash"
+                     /translation="AYVSHTSGSTGTPNAVLVEH"
+     gene            complement(38911..41265)
+                     /locus_tag="B170_RS0101330"
+     CDS             complement(38911..41265)
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters)
+                     lanthipeptide: Lant_dehydr_N"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018733757.1"
+                     /locus_tag="B170_RS0101330"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="lantibiotic dehydratase"
+                     /protein_id="WP_027654918.1"
+                     /sec_met_domain="Lant_dehydr_N (E-value: 1.3e-48, bitscore:
+                     160.1, seeds: 73, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MSEHVELPVGGWRLWSQFALRGPGFPAAGVLALAPAGLAEHADKF
+                     DAGIVPSGAEWAAFEQDFDEAMVATAQELQRIAALPMFRAALAWQNRQLLDSGITPFLA
+                     WTPSAAGRTSMPRQREELVAHYWQRFCVKNDTIGFFGPVGWGRWDLSTSGIVVEPGTGL
+                     VDAARVYFSSWAIDHVARAIEADSAVRPWVPPRRLSFVRRVGHTVAMPGRPPQQILRFH
+                     GDVLDLCDGVRTAAEIAELLTVPVSAIEEALTELLRRRWIVRRLEVPTSAYPERWLRSA
+                     VERVTDDPVRARALAKLAVVERARDRVHAAGMDADALAGALADLETDFATVTEQAAARA
+                     KGARVAPCRSLLYGDARRSATATIGTAIRDELTPLGLFLTAARWMTNRFADRVGARIRA
+                     AYERLRDEHGSVDLGALWFACLPVPHPESAADVAAVQAELRARWAELVDAPAGTRRVQL
+                     RSADIAGRVYELFAEPGNGWNIARYVSPDLLVCAEDPEAVDRGEFELVLGELHVAMNTV
+                     GASLFVMQHPDVDSLLAETSRDFPGPRLMPMLPKEQPPRWSARSRPALVRPEDYVVALV
+                     DHTGDPSRPRNLLAADIRVEEHAGRLVLVLPDGAEFDVLDVFGNALTNRVMDRFTLRGD
+                     SPHAPRITIDRTVVARESWRVPAADVRFAHDKSEARRFVYARGWRAELGLPRFVFVVMP
+                     TEPRPFYVDFDSPVYVNILAKAIRRLGRKDPEARFTVTEMLPTPEQAWLTDDAGDRYTA
+                     ELRFVAVDQTVAATEGVAATDAVAATVGGSR"
+     gene            complement(41267..42217)
+                     /locus_tag="B170_RS0101335"
+     CDS             complement(41267..42217)
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1114:ornithine carbamoyltransferase (Score: 386.2;
+                     E-value: 1.5e-117)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019870458.1"
+                     /locus_tag="B170_RS0101335"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="ornithine carbamoyltransferase"
+                     /protein_id="WP_027654919.1"
+                     /transl_table=11
+                     /translation="MANRRHLISIDDLTDTDLREIVRRGTEFAAGAAEDARSLADLVVG
+                     VLFRKTSTRTRTAFSAGSLRLGARLITYGPGDLQENTGETAEDTAAVLSRMIDVLVART
+                     AGPEEELRAYAKQHRMAVVNAMSAAEHPTQALADLTTLTRHFGQVEGLRVLYLGEGNNT
+                     AAALALALARYTDTQLHLRTPPGYGVHPSVLERAQAAAKRSGAVVEQRHDPTDLPSVDV
+                     VYTTRWQTTGTTKPTPDWRREFTPYQVDEALMAACPGAVFMHDLPAHRGEEVTAAVLDG
+                     PTSITFAQAENKYHSARAVLEWCTGNTPNWRIAGG"
+     misc_feature    complement(41681..41683)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(42275..43567)
+                     /gene="ectB"
+                     /locus_tag="B170_RS0101340"
+     CDS             complement(42275..43567)
+                     /EC_number="2.6.1.76"
+                     /NRPS_PKS="Domain: Aminotran_3 (38-370). E-value: 2.9e-73.
+                     Score: 238.6. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101340_Aminotran_3.1"
+                     /NRPS_PKS="type: other"
+                     /codon_start=1
+                     /gene="ectB"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1013:aminotransferase class-III (Score: 386.6;
+                     E-value: 2.3e-117)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018736296.1"
+                     /locus_tag="B170_RS0101340"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="diaminobutyrate--2-oxoglutarate transaminase"
+                     /protein_id="WP_027654920.1"
+                     /transl_table=11
+                     /translation="MTITVDSTSVLEATTPFAAFESLESEVRSYCRKFPAVFHRARGAE
+                     LYSEDGKRFIDFFAGAGTLNYGHNNPFIKRRLLDYLNSDGVVHGLDMYTVAKREFLTAF
+                     NKTVLQPRGLDFKVQFCGPTGTDAVEAALKLARKATGRSGVIAFSGAYHGMSRGSLAVT
+                     GSRRARRAGGIGGGDVTFVPYEDGPQGPFDSIALIERMLDDPSSGMEIPAAVIVEPMQM
+                     EGGVYPASADWLRRLRTLTEQHGILLVVDEIQAGCGRTGTFFCFEHSGVVPDVVTVSKS
+                     IGGYGLPLSMSLFRRELDVWEPGEHTGTFRGNQLAFVAATAACELWGDPKFRTDIAVAS
+                     RRLERFRAELTSVDAGLVVRGRGMALGIDLGRVGGPDRAERLQRYAFDHGVIVERCGRH
+                     DEVIKVLPPIAIDIVRLDRGLEVLRDGLLAV"
+     aSDomain        complement(42458..43453)
+                     /aSDomain="Aminotran_3"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101340_Aminotran_3.1"
+                     /evalue="2.90E-73"
+                     /label="B170_RS0101340_Aminotran_3.1"
+                     /locus_tag="B170_RS0101340"
+                     /protein_end="370"
+                     /protein_start="38"
+                     /score="238.6"
+                     /tool="antismash"
+                     /translation="HRARGAELYSEDGKRFIDFFAGAGTLNYGHNNPFIKRRLLDYLNS
+                     DGVVHGLDMYTVAKREFLTAFNKTVLQPRGLDFKVQFCGPTGTDAVEAALKLARKATGR
+                     SGVIAFSGAYHGMSRGSLAVTGSRRARRAGGIGGGDVTFVPYEDGPQGPFDSIALIERM
+                     LDDPSSGMEIPAAVIVEPMQMEGGVYPASADWLRRLRTLTEQHGILLVVDEIQAGCGRT
+                     GTFFCFEHSGVVPDVVTVSKSIGGYGLPLSMSLFRRELDVWEPGEHTGTFRGNQLAFVA
+                     ATAACELWGDPKFRTDIAVASRRLERFRAELTSVDAGLVVRGRGMALGIDL"
+     gene            complement(43579..46716)
+                     /locus_tag="B170_RS0101345"
+     CDS             complement(43579..46716)
+                     /NRPS_PKS="Domain: Condensation_LCL (5-285). E-value:
+                     4e-96. Score: 313.3. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101345_Condensation_LCL.1"
+                     /NRPS_PKS="Domain: AMP-binding (455-847). E-value:
+                     1.9e-108. Score: 354.4. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101345_AMP-binding.1"
+                     /NRPS_PKS="Domain: PCP (954-1021). E-value: 3.5e-24. Score:
+                     76.6. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101345_PCP.1"
+                     /NRPS_PKS="type: NRPS"
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     AMP-binding"
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     Condensation"
+                     /gene_functions="biosynthetic-additional
+                     (rule-based-clusters) PP-binding"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1127:condensation domain-containing protein (Score:
+                     394.5; E-value: 1.2e-119)"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018584311.1"
+                     /locus_tag="B170_RS0101345"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="non-ribosomal peptide synthase"
+                     /protein_id="WP_027654921.1"
+                     /sec_met_domain="Condensation (E-value: 6.2e-68, bitscore:
+                     223.6, seeds: 42, tool: rule-based-clusters)"
+                     /sec_met_domain="AMP-binding (E-value: 4.7e-117, bitscore:
+                     385.6, seeds: 400, tool: rule-based-clusters)"
+                     /sec_met_domain="PP-binding (E-value: 2.9e-18, bitscore:
+                     60.7, seeds: 164, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MDSVGEVSFAQERLWFLDQLRPGTPDYLLPLALRIRGPLDVTALT
+                     TALQAIVDRHDVLRTRYVEVDGRPVAHVDPYATVTIAHTTDHRVLERELARPIDIARDL
+                     PFRLSLARLGDDHLLVFVVHHIAFDGWSWGVLARELAAGYAGRTTEVSGLSAQYADFAR
+                     RQRERFTDERSRRQLDYWRAQLAGVPAIELPTDRRRPRTWDGAGDVVRVDLPATLLREV
+                     DAVARSRRVTRFMVLLAAFQIVLARASGQTDFAIGTPVAGRTRVADEDLIGLFVNSVVL
+                     RADLAGAPTFEELLTRVRDNALGAFSHADTPFERIVTDLAPERDLSRNPIFQVSFSLLD
+                     VRAPMSLPGLDVEVVEPPLTGSPFDLFLDVNVRPDGTATARLQYATALFDHARVERLAG
+                     GFADLLRAVVVEPATSVSELAARLELGPRGERDRLLYGWNRTAADFPDQTVDQLVSAQV
+                     RATPDAVAVWTTTEEITYGELDMRVNRLAHHLRALGVRPGSLVAVLLDRGPDLLIALLA
+                     VLRAGGAYVPIDPEYPDARIAFIVADSAAAVVITRSALVDRVGDTGGQHVLVDRDRAVV
+                     AARPSAAVPATATGEQLAYLIYTSGSTGTPKGVMVHHRALTNFVTSIVRRPGLTAGQSV
+                     VALTTISFDPSLLELYVPLLVGATVVLADTEQARDPQRLIDLVALTRPAVLQATPAMLR
+                     ALLEVGWVPPATITVLSGGEKLPTELARRLAAEGAPVWDLYGPTETTVWVTSARLDPTG
+                     AVVDWSPQANCTVHLLDRYAEPVPIGTVGELYIGGSCVALGYRGQPALTAERYVPDPYS
+                     TTPGGRLYRTGDLARRSQDGSVEILGRADRQVKIRGHRMEPSEIEAALLGHDDIRAVAV
+                     HPTATPTGEEQLTAYLVARADTAPPVEELRRFLLRTLPDYMLPAAYVPMEALPLTPNSK
+                     VDYAALPEPATRVAVARVAPRTAEERVVADIWREVLGTGATIDMDDNFFEIGGHSLLAT
+                     RVAVRLRAQLGVDVPVRGLFDHSTVASLAAALPDYPRISQRTTMPTLTARRRHKTR"
+     aSDomain        complement(43654..43854)
+                     /aSDomain="PCP"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101345_PCP.1"
+                     /evalue="3.50E-24"
+                     /label="B170_RS0101345_PCP.1"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="1021"
+                     /protein_start="954"
+                     /score="76.6"
+                     /tool="antismash"
+                     /translation="ERVVADIWREVLGTGATIDMDDNFFEIGGHSLLATRVAVRLRAQL
+                     GVDVPVRGLFDHSTVASLAAAL"
+     aSModule        43654..46701
+                     /complete
+                     /domains="nrpspksdomains_B170_RS0101345_Condensation_LCL.1"
+                     /domains="nrpspksdomains_B170_RS0101345_AMP-binding.1"
+                     /domains="nrpspksdomains_B170_RS0101345_PCP.1"
+                     /locus_tags="B170_RS0101345"
+                     /monomer_pairings="gly -> gly"
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       complement(44146..44208)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0010"
+                     /evalue="1.90E-10"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="857"
+                     /protein_start="836"
+                     /score="32.8"
+                     /tool="antismash"
+                     /translation="LGRADRQVKIRGHRMEPSEIE"
+     aSDomain        complement(44176..45351)
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101345_AMP-binding.1"
+                     /evalue="1.90E-108"
+                     /label="B170_RS0101345_AMP-binding.1"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="847"
+                     /protein_start="455"
+                     /score="354.4"
+                     /specificity="consensus: gly"
+                     /tool="antismash"
+                     /translation="AQVRATPDAVAVWTTTEEITYGELDMRVNRLAHHLRALGVRPGSL
+                     VAVLLDRGPDLLIALLAVLRAGGAYVPIDPEYPDARIAFIVADSAAAVVITRSALVDRV
+                     GDTGGQHVLVDRDRAVVAARPSAAVPATATGEQLAYLIYTSGSTGTPKGVMVHHRALTN
+                     FVTSIVRRPGLTAGQSVVALTTISFDPSLLELYVPLLVGATVVLADTEQARDPQRLIDL
+                     VALTRPAVLQATPAMLRALLEVGWVPPATITVLSGGEKLPTELARRLAAEGAPVWDLYG
+                     PTETTVWVTSARLDPTGAVVDWSPQANCTVHLLDRYAEPVPIGTVGELYIGGSCVALGY
+                     RGQPALTAERYVPDPYSTTPGGRLYRTGDLARRSQDGSVEILGRADRQVKIR"
+     CDS_motif       complement(44302..44388)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0009"
+                     /evalue="2.30E-14"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="805"
+                     /protein_start="776"
+                     /score="45.5"
+                     /tool="antismash"
+                     /translation="PIGTVGELYIGGSCVALGYRGQPALTAER"
+     CDS_motif       complement(44878..44937)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0008"
+                     /evalue="1.40E-10"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="613"
+                     /protein_start="593"
+                     /score="33.0"
+                     /tool="antismash"
+                     /translation="AYLIYTSGSTGTPKGVMVHH"
+     CDS_motif       complement(45130..45171)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0007"
+                     /evalue="9.70E-06"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="529"
+                     /protein_start="515"
+                     /score="18.7"
+                     /tool="antismash"
+                     /translation="LAVLRAGGAYVPID"
+     CDS_motif       complement(45703..45822)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0006"
+                     /evalue="5.20E-20"
+                     /label="C67_LCL_14fromHMM"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="338"
+                     /protein_start="298"
+                     /score="63.9"
+                     /tool="antismash"
+                     /translation="RDNALGAFSHADTPFERIVTDLAPERDLSRNPIFQVSFSL"
+     aSDomain        complement(45862..46701)
+                     /aSDomain="Condensation"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101345_Condensation_LCL.
+                     1"
+                     /domain_subtype="Condensation_LCL"
+                     /evalue="4.00E-96"
+                     /label="B170_RS0101345_Condensation_LCL.1"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="285"
+                     /protein_start="5"
+                     /score="313.3"
+                     /tool="antismash"
+                     /translation="EVSFAQERLWFLDQLRPGTPDYLLPLALRIRGPLDVTALTTALQA
+                     IVDRHDVLRTRYVEVDGRPVAHVDPYATVTIAHTTDHRVLERELARPIDIARDLPFRLS
+                     LARLGDDHLLVFVVHHIAFDGWSWGVLARELAAGYAGRTTEVSGLSAQYADFARRQRER
+                     FTDERSRRQLDYWRAQLAGVPAIELPTDRRRPRTWDGAGDVVRVDLPATLLREVDAVAR
+                     SRRVTRFMVLLAAFQIVLARASGQTDFAIGTPVAGRTRVADEDLIGLFVNSVVLRADL"
+     CDS_motif       complement(45871..45960)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0005"
+                     /evalue="7.30E-14"
+                     /label="C5_LCL_267-296"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="282"
+                     /protein_start="252"
+                     /score="44.1"
+                     /tool="antismash"
+                     /translation="DFAIGTPVAGRTRVADEDLIGLFVNSVVLR"
+     CDS_motif       complement(45970..46026)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0004"
+                     /evalue="7.90E-03"
+                     /label="Cy4"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="249"
+                     /protein_start="230"
+                     /score="9.4"
+                     /tool="antismash"
+                     /translation="VTRFMVLLAAFQIVLARAS"
+     CDS_motif       complement(46285..46350)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0003"
+                     /evalue="1.50E-11"
+                     /label="C3_LCL_132-143"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="144"
+                     /protein_start="122"
+                     /score="36.6"
+                     /tool="antismash"
+                     /translation="VHHIAFDGWSWGVLARELAAGY"
+     CDS_motif       complement(46528..46638)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0002"
+                     /evalue="1.20E-17"
+                     /label="C2_LCL_024-062"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="63"
+                     /protein_start="26"
+                     /score="56.3"
+                     /tool="antismash"
+                     /translation="YLLPLALRIRGPLDVTALTTALQAIVDRHDVLRTRYV"
+     CDS_motif       complement(46663..46695)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0001"
+                     /evalue="2.90E-03"
+                     /label="C1_LCL_004-017"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="18"
+                     /protein_start="7"
+                     /score="10.2"
+                     /tool="antismash"
+                     /translation="SFAQERLWFLD"
+     gene            46901..47092
+                     /locus_tag="B170_RS0101350"
+     CDS             46901..47092
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1009:mbtH-like protein (Score: 87.1; E-value: 8e-27)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018726420.1"
+                     /locus_tag="B170_RS0101350"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="MbtH family NRPS accessory protein"
+                     /protein_id="WP_019870455.1"
+                     /transl_table=11
+                     /translation="MTDEGVYRVVLNDEEQYSIWWADRELPLGWRAEGTAGSKQECLER
+                     IQQVWTDMRPRSLREQMA"
+     gene            complement(47276..47863)
+                     /locus_tag="B170_RS0101355"
+     CDS             complement(47276..47863)
+                     /codon_start=1
+                     /gene_functions="regulatory (smcogs) SMCOG1016:LuxR family
+                     DNA-binding response regulator (Score: 88.4; E-value:
+                     6.5e-27)"
+                     /gene_kind="regulatory"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018739978.1"
+                     /locus_tag="B170_RS0101355"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="response regulator transcription factor"
+                     /protein_id="WP_019870454.1"
+                     /transl_table=11
+                     /translation="MKVQVEAADSTLRATVATKLRLVGIKIVEQPFQVPVVVAAAETVG
+                     RALRSCPQPYLTGDYRLLVLADAFDPAEVRSALRAGVRAMLSTTSAPAKLASAVWATKQ
+                     GESRIPREILLKLLRDRAGGGPDSAPNPSPLTPRQTAVLALMAEGYPNTAIAKNLSCSE
+                     HTVKNVIYDMMTRLQVNNRAHAVARAIRAGHI"
+     gene            complement(47860..48471)
+                     /locus_tag="B170_RS0101360"
+     CDS             complement(47860..48471)
+                     /codon_start=1
+                     /gene_functions="regulatory (smcogs) SMCOG1016:LuxR family
+                     DNA-binding response regulator (Score: 72.3; E-value:
+                     5.5e-22)"
+                     /gene_kind="regulatory"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018584309.1"
+                     /locus_tag="B170_RS0101360"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="response regulator transcription factor"
+                     /protein_id="WP_027654922.1"
+                     /transl_table=11
+                     /translation="MGEPVRVSVTALDPMLEVGATTSLRSSPDVEVVSGPERAQAAVIV
+                     VDTVDEYVLGIVRETRASATCPEVVLVATDLESCAALQAIVAGARGVMRRREADPARLA
+                     RVVVAVADGDCTLPLDILDQLPERGARPLSATSSTDSPLSERERAVLRLVADGHETGEI
+                     ARQLCYSTRTVTSVVHDITRRFRLRNRAHAVAYTLRAGLL"
+     misc_feature    complement(48400..48402)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            48816..51782
+                     /gene="lanM"
+                     /locus_tag="B170_RS0101365"
+     CDS             48816..51782
+                     /codon_start=1
+                     /gene="lanM"
+                     /gene_functions="biosynthetic (rule-based-clusters)
+                     lanthipeptide: LANC_like"
+                     /gene_functions="biosynthetic (rule-based-clusters)
+                     lanthipeptide: DUF4135"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1070:lanthionine synthetase C family protein (Score:
+                     831.7; E-value: 1.4e-251)"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018730279.1"
+                     /locus_tag="B170_RS0101365"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="type 2 lantipeptide synthetase LanM"
+                     /protein_id="WP_027654923.1"
+                     /sec_met_domain="LANC_like (E-value: 6.5e-32, bitscore:
+                     105.2, seeds: 47, tool: rule-based-clusters)"
+                     /sec_met_domain="DUF4135 (E-value: 2.6e-99, bitscore:
+                     327.4, seeds: 79, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MPVAGGEAETEPGFAARLADLGMPHDPHFGALTTQLRRPAWAVLV
+                     EDVLATARPLTSDAQPVADWRAAFARVLAPFVNAALVQIRRHGSRHVDLDRVTAAVSGT
+                     LGPRLVDIAARTLVTELHRWRAEGRLTGGDGPARFHDFVRQLTAPAGLGEVLARYPVLA
+                     RLLAQDTATTADATVELLNRLGHDRDALIATLLGGIDPGPVTSVLAAQGDRHAGGRAVS
+                     FVDFADGRRLVYKPRDLTPYIKLTAILDHLSSAAAGVFPRTPRVLSRTGYGWTEHIAAL
+                     PLLNWEDAELFYRRQGALLALLHLVRATDVHYENLIAHGDQPILVDIETLFHPELAPGG
+                     LGDPAADALAESVHRTALLPLVFVGEQGIADLSGAGGDVSTSPLTVVDWLDAGTDQMRL
+                     TRRAAEFAGAANRPILNGRPVEPHEHDRAIVGGFRQAYDTFIAHRDKLTALVRDCADLE
+                     VRVIVRATWMYKTLLDETTHPDVLRDAVDRDRALSVLYHGRTEQPLLAQLLRSEIATLW
+                     AGDIPMFTASVGTGRIRAVSGTEFTEPLPQTGLTAALSTLASLDEVNRRGQEWIISATL
+                     ASRSRVAPHPEAVPIAAQPEGVVAHPDELLAAACAVADQLVAEAKAGGGRVNWLGLEAV
+                     EDQRWLVLPLGASLGSGYLGVALFFAQLAAVTGICRYADQARAATADLPQLVAALDKRP
+                     DLVAVIGCGGLDGLGGIAYGLTRIGTLLDDHTLTDAAARSIRLAALAATSEAPAGWSTG
+                     LAGCLAALATVQTDLNLPEAGDVARRCADLLIAPLVGSGNPPGHRAATSPDRPGGSGPT
+                     SGGFAEGLAGIGWALTTAGPDEHHQAAGRRVATLLGDRSEPAASGWCRGTAGTVLARAS
+                     LSTDADPRYLTGCVEALADAPVRRDLSLCHGELGVTEVLTQLAGSDRHTFATRALRRRT
+                     GLVLDVLRRHGSLSGVPGGVRSPGLLTGLAGIGYGLLRHAAPQQVPSVLLLQGSSATH"
+     misc_feature    50340..50342
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     misc_feature    50475..50477
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     misc_feature    51756..51758
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            51817..52044
+                     /locus_tag="B170_RS0101370"
+     CDS             51817..52044
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018736302.1"
+                     /locus_tag="B170_RS0101370"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027644637.1"
+                     /transl_table=11
+                     /translation="MSEMIPNTAEEAATAPAGRLRLLPTAVTFADRAAALARVGLPVAM
+                     LAASIAAPALGASAGEATAMNTTCCPDRPM"
+     gene            52165..55161
+                     /locus_tag="B170_RS24695"
+     CDS             52165..55161
+                     /codon_start=1
+                     /gene_functions="regulatory (smcogs) SMCOG1149:LuxR family
+                     transcriptional regulator (Score: 111.7; E-value: 5.3e-34)"
+                     /gene_kind="regulatory"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018739981.1"
+                     /locus_tag="B170_RS24695"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="LuxR family transcriptional regulator"
+                     /protein_id="WP_033664102.1"
+                     /transl_table=11
+                     /translation="MRHFSASLVGRDRVLHALTAGLTAARNGRGNAVFVTGESGIGKSR
+                     LTAAVTELAFTSGMSLMRGRASAVGPTPPFRPLTEAILSHLRIEPVDPAKLGPYGPILG
+                     RLVPEWSAPENSHDSESLVVLAEAVLRLIGLVGRDRGCLLNLDDLHEADPETLAVLEYL
+                     IDNVELQPMLLLGALRDEGPVLSLVRAAARRGACQLIDLDRLSRAELAQLAGACLDVEP
+                     NLVPTSAVDLLWAGSSGNPLVAKELLSTMVDDGILVGDAQGWQINSRPEAPVSAGLARP
+                     LARRVAQLGTRVRELLSVAAVFGQQFPLRVVQHVTGLADRDLLGLLQNDVAGRFVAPDE
+                     QTADWYAFHHQLSREAVLAQLDQDAHARLADMLASAVEAIYPGLPREWCEVAARLRADA
+                     GDPTTAGTLFTEVGRRALALGAANSAVAVLDRALEYIPHDDVATRTGTLELLLQALAEA
+                     GLVERALESVSELDQAGWLTPSRRAALHARLAWAATVAGRTLDGLAQVETARALLGSEG
+                     SAEDLAPIDMVAAHLLLDAGGPDQLAAAENLARQAATVAESVPLPVVACQAWQLVGGLA
+                     RHRDPQEATSVLERARTLAVRHDLPICEIHALIRLGNDDALLRGDLTRLQRASAQATRM
+                     GAVTAQYQAEASIALHTVLHGDFTAAASLTDQVFAATSRLNLLETTQYVLLTRAVLAGH
+                     RGDRNQMESELARFTQWGGDLTLHGPRAHGLAAAFCALLEEDLPRARSDLARAVAAEEH
+                     GSSVYFLSGRRGLHVLLRALAGQAEWPDLEAVTVNPASTLRWDRQFTFFARAVLDGRSG
+                     QRGRASRAVTDALAAGEPYPTSRYLGLRLVSEAALTDGWGEPVTWLRSAEEHFHRTGVN
+                     AVAGACRALLRRAGATVRQRRDGTAGIPNELRSAGVTAREYEVLGLVVKRLGNREIATR
+                     LHLSPRTVERHVHGLMTKTGLPNRIALAKFGAGFVDNPPAAAGTDSPAPSSHTTTDWRS
+                     RPPASGSTT"
+     misc_feature    54313..54315
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(55588..56133)
+                     /locus_tag="B170_RS0101385"
+     CDS             complement(55588..56133)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019870449.1"
+                     /locus_tag="B170_RS0101385"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027654925.1"
+                     /transl_table=11
+                     /translation="MGSSVAFAPEDVQRIAELSEVTAAEGNSTAYSVTARHAGTGKEHE
+                     AMVVTAAVDQQLRSLEVVSGTYPANAGEACVDDQVAASLGWTTGDQLALSRQSGLVEVV
+                     VTGECVRPAGDEFGASELIVAVPLADITSITGSSGADEVMIRLTTPESASTLYDSVSLS
+                     LGRDVAMIYGDHLRGVLE"
+     misc_feature    complement(55834..55836)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(56274..56969)
+                     /locus_tag="B170_RS0101390"
+     CDS             complement(56274..56969)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019870448.1"
+                     /locus_tag="B170_RS0101390"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027654926.1"
+                     /transl_table=11
+                     /translation="MAQEPDDDFDHLRFDLRTFGPVDEQEARRSGFGKDAPAQIARIVS
+                     FDANYDQEVERCELAASKKIGPEAQEVSVSYGELGNTLMGEFGKEYERLIGPQLSELRT
+                     SLRDCLAEAGFQAEDPEDFAREPYPEKLGVRFGAHETIAEEAWSPERKEGTIQIGPAIP
+                     AKKYVPTEEEVELAVAWSKCTQRLEFKERLMPLVISAQQTVYERHEEQLAEHADKTVDL
+                     AKKAADLKW"
+     gene            complement(58291..59037)
+                     /locus_tag="B170_RS24700"
+     CDS             complement(58291..59037)
+                     /codon_start=1
+                     /gene_functions="other (smcogs) SMCOG1286:Pentapeptide
+                     repeat protein (Score: 115.6; E-value: 3.3e-35)"
+                     /gene_kind="other"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018814660.1"
+                     /locus_tag="B170_RS24700"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="pentapeptide repeat-containing protein"
+                     /protein_id="WP_027654927.1"
+                     /transl_table=11
+                     /translation="MNDLAGAELNNRDLREVDLVGVNLARANFAGVDLTGANLAGVDLR
+                     GADLTDVDLTGANLAGVDLRGADLTDVNLTGALLIGANLAGANLAGVDLTAANLRGVDL
+                     AGVDLAGVELTAANLTAADLTRADLTGALLIGADLTGVDLAGANLAGIDLRGVNLTGVD
+                     LTSADLREANLDRANLTGVNLCEANLYGAVLTSTKLAGARWDWATIWPPERAAEIWFRS
+                     AERPDQPGVYVVLPEAGGRDRQSVVV"
+     gene            complement(59237..59662)
+                     /locus_tag="B170_RS0101400"
+     CDS             complement(59237..59662)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018831255.1"
+                     /locus_tag="B170_RS0101400"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_019870445.1"
+                     /transl_table=11
+                     /translation="MPFEPLSTMESALWGLLGSFIVEALELGAALRRAKTLPWKRPDEP
+                     GLPAYLASVVLRLAAGAGLAALIGADGRLASPLAAGLLGITAPLLIEKVLRQVDLASTE
+                     VDTPHHHSTLPLSRSVPPPLATDQKLASGDADSSDVD"
+     misc_feature    complement(59321..59323)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     misc_feature    complement(59429..59431)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(60267..61097)
+                     /locus_tag="B170_RS0101405"
+     CDS             complement(60267..61097)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018744910.1"
+                     /locus_tag="B170_RS0101405"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="ETX/MTX2 family pore-forming toxin"
+                     /protein_id="WP_027654928.1"
+                     /transl_table=11
+                     /translation="MRLKRTRALLAMSIGTAAAVLMTASPAQAATITDITTLLEDMSSH
+                     AYPPFGFEVTATPILITESDAVPVGSAKVVSSAPFYLGCASLTNSTSSDQTLWSHSFSK
+                     AFTNTVSTTVTTGVSSTSKVSGTFSLSKVVGLGLEESVTVSYQDSETQSESIKETHTAP
+                     SQRVLVPAQTTRYVVSSLTQSTYTGELALNANFTGGFTAKSLNGPLPPVLNIYDTLSRA
+                     EDRGGQLPTGFSLNSSTKRLDFQGTGTYTVKAGANFRVEVLETLPGGLKTSQCS"
+     misc_feature    complement(61089..61091)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(61809..62048)
+                     /locus_tag="B170_RS0101410"
+     CDS             complement(61809..62048)
+                     /codon_start=1
+                     /gene_functions="regulatory (smcogs) SMCOG1136:GntR family
+                     transcriptional regulator (Score: 79; E-value: 6.6e-24)"
+                     /gene_kind="regulatory"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018818411.1"
+                     /locus_tag="B170_RS0101410"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="winged helix-turn-helix transcriptional
+                     regulator"
+                     /protein_id="WP_018254638.1"
+                     /transl_table=11
+                     /translation="MPATPDYIRISDEIIDDIRSGRYKAGDKLPSIAQLCERYHVSPST
+                     IQLVNVRLEALEVINRHQGKGVFVTDPKTWLRKP"
+     gene            62242..62646
+                     /locus_tag="B170_RS0101420"
+     CDS             62242..62646
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018733754.1"
+                     /locus_tag="B170_RS0101420"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="DivIVA domain-containing protein"
+                     /protein_id="WP_027654929.1"
+                     /transl_table=11
+                     /translation="MVDVRNPFRRFRHWRGRPAPSHPTARTGSLIGANIGRPAGTDSDA
+                     DRHRSFAGNAGGHHRSATRWPLTPDQVRQRQFPRVRRGLDASEVELFLYRVAADLSALQ
+                     TELRSTRDENIRIKRALRDWQSRTTPGVRA"
+     gene            62643..62829
+                     /locus_tag="B170_RS25845"
+                     /pseudo=""
+     CDS             62643..62829
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018730289.1"
+                     /locus_tag="B170_RS25845"
+                     /note="frameshifted; Derived by automated computational
+                     analysis using gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /pseudo=""
+                     /transl_table=11
+                     /translation="MTVTGLDERPRFVVHLTLHADDLAGARLLARSVARSLGFLPELAQ
+                     RRPRPTRPDDCGPQPEV"
+     gene            complement(62857..63192)
+                     /locus_tag="B170_RS0101425"
+     CDS             complement(62857..63192)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_012180697.1"
+                     /locus_tag="B170_RS0101425"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="DUF1416 domain-containing protein"
+                     /protein_id="WP_027654930.1"
+                     /transl_table=11
+                     /translation="MNVVTASTAAGCAAPDQAAPLPASLDLEKETVITGVVRDAAGEPV
+                     TGAYVRLLDSTDEFTAEVVTSSAGQFRFFAAPGTWRLRALSRHGNGDLVITASRGVNEA
+                     IVPVVVD"
+     gene            complement(63189..64037)
+                     /locus_tag="B170_RS0101430"
+     CDS             complement(63189..64037)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_016814851.1"
+                     /locus_tag="B170_RS0101430"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="sulfurtransferase"
+                     /protein_id="WP_027654931.1"
+                     /transl_table=11
+                     /translation="MSRDTALVSADWAEKNLETPGVVFVEVDEDTSAYDTGHLPGAIKL
+                     DWRTDLQDQVRRDFVNKDQFAALLSERGIANDDTVVLYGGNNNWFAAYAYWYFALYGHR
+                     EVRLLDGGRKKWELDARPLTTELVSRPATRYVAQEPDHTIRAFRDEVVAAIGTKNLVDV
+                     RSPDEYAGRLLAPAHLPQEQAQRAGHVPTALSVPWSKAANEDGTFKSDQELREIYAAAG
+                     LDDSRETIAYCRIGERSSHTWFVLQELLGHQNVKNYDGSWTEYGSLVGVPVALGDEPGK
+                     E"
+     gene            complement(64394..65185)
+                     /locus_tag="B170_RS0101440"
+     CDS             complement(64394..65185)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018254643.1"
+                     /locus_tag="B170_RS0101440"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="DUF2993 domain-containing protein"
+                     /protein_id="WP_027654932.1"
+                     /transl_table=11
+                     /translation="MTTEERPQQDERPRRQRGRRILVVLLVLLLVLVGLLVVADRVAAG
+                     VAERALTDQVREELAKEGVQAGPPEVEIGGFPFVTQVLDGRYERISIGLNEVRGSVQGD
+                     VLALPTLDIDAYDVTAPLDTLRSGRGGVIAGSVTGTGTISYDSIAARLDREGLQLGERD
+                     GQLVVTAPVELLGERVPVSGTADITVDQGQVSLRFTDLTPDGVPNGSLVRALLSSFAEG
+                     ISVDVPLPVLPFDLTVSEVRPLPEGLQVTAEAAEVPLHAAS"
+     gene            complement(65265..66296)
+                     /locus_tag="B170_RS0101445"
+     CDS             complement(65265..66296)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018726406.1"
+                     /locus_tag="B170_RS0101445"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027654933.1"
+                     /transl_table=11
+                     /translation="MLPSSRPETGREPWPEQPSSGPPAPRAGGDDGRSERGGPRRARRD
+                     GESGRRPAGDPGDGHDQDVEEVPPVEVRRTLALAVAGFAVLLGMGLVLAAQTSGPGHRL
+                     PFTAVIFGVQALSVLTWTMAFRPPALMTVAGVGAVAAIVADTVAVRSDPARLMPLVQVL
+                     LVGLVAAVVGQFVRRVDRAQVLESLRGTVLIVAGVVAFPTMIVLTRIPMGTQVITVCLA
+                     AAGVALAVARITDAFAAWPRLAPQVPRGAAGVVGGAMIGTMVSALLGSYLVTPFTPTRA
+                     AIIGLVAAVVAVLADLAVGFAEAGREMAGEPTAGWAIQHIQGPLTGLALAAPAAYALCK
+                     LVL"
+ORIGIN
+        1 cactgcaaac acccacaccc gggattcctc ccacggcagg accaacaccg cgcgggtcac
+       61 cggagcccac cgggctactc gttgagaaag gcggagatgc gctcccgcag gtcagcacgc
+      121 ttggcccaga ggacgccagg ccggtcgtac acgtgcaggg tggcctgggg caacgcggcg
+      181 gcgagccgct cggcgaccgc aaccggatgc agctcatcgc ccacacaccc gatcaccaga
+      241 gccggcgccg tgacctcggc gagttcagcg gcgtcgcgga ccggcactga ttcgggcagg
+      301 ccaaccagtc ccgaggcgag accgtcccgc atgagctgat caaggcgctg ccggaggtat
+      361 gcccagccgg ccggcgtgtt ccggatggcc ggtggaagct ccagctggac cacctccgcg
+      421 agctgaccga catcaccact gccgagcgcg tcgagtagcg ctgtcagccg gcgacgggcg
+      481 gcatcgcccc gcggctggtc cagcaccgcc ggcagataaa agaccagccg gtcgaagcgc
+      541 gtcgggttgt cggcgagtag ccggcagagc gcacccgcgc cgaggctcgc gccgaacgcc
+      601 cgggtagcgc gcccccggtc ggcgaccgac cgcaggtcgc gcgcgagatc gcggtaggtc
+      661 catggcccgg tcggtgcggc ggagcggcca tgcccacgga actggaagaa gagtctgcga
+      721 ccggtgacgc cactaccgaa gggacgggtg gtggcgatgc cgctgcccag accgtgcgcg
+      781 aagacggtga ccgggtcacc cgcgccggtg accaactgct ccaggtggac gccgtgcggg
+      841 gtggcgacca gctcggtctc cggctccggc agtgccggcc gaccggtgcg gggagcactc
+      901 ggcccggggc cccaggtgcg ggggccgcca tccggtgggg gcggccaccg gaagcctctc
+      961 accaggagtt cccccggccg ccccggaggt cccgcagacc agtccggacg tcaagcagat
+     1021 agatcaaccc agcggcgata ccgaccaggc caaagaggct gatcgggccg aagccaagca
+     1081 gggtgagcac cagacagacg gcgaggatcg ccgcccatgc acccttcgga agggtgccga
+     1141 ccgcggcgaa cgcgtcggac cgctgggtga tgacgtggac cagggcgact ccctgcacga
+     1201 tgagtgcgaa gacgagcagg atcagctcta taacgtagcg aacctcaaaa gcgaacggcg
+     1261 cggcgatggc catgccggca agcatatgcc gaagaccccg gaggcgtccg tcaggccgct
+     1321 tccggggtct tcggcatcac cggacactca cccgtcgcgg gaggtcagtc gcgggccggc
+     1381 ggggtccgct tcgtcgcgcg cggtgacttg gtcgccgagg aggccggctt gccggcggcc
+     1441 ttggtggcac gcttcgtgac ggccgccggc ttgacctcag cggcctcggc gagctgcgcc
+     1501 ggagtgggcg ccggcggctg ctcggtcgtc tcgatgtcgg tgttcaccgt gtcggcggcc
+     1561 tcgagcacgc cagcgccgac gacccgctcc ccgtggccga cgagcgcgcc gtaggtggtg
+     1621 accgcccgct cctgcgcggc ctgcgcactg gcgaccacaa cggctgcgtt gcgggtggcg
+     1681 gtctcccgaa gccgactgag gtccaggtcg ctggcggccc gccggcgcag gttctcagcg
+     1741 gtagcggtcg ccgtacgcaa tgtctcggtg gccttctggc gcagctcggc cccgttaacc
+     1801 gtgccgaggt cggccgcgac ccggttgcgc agctcggtca cggccgcggg aagctttcgc
+     1861 agctgctggt acgccagatc gccggcgccg gcggcggcgt agaggggggc agggatacga
+     1921 ctggttttcg gctgactagt catcatttct cctctttggc cgcgtcggcg gcttcggggt
+     1981 cacccttcgg gcggactgct gcactggcgt cgggacggga atggagtcgg ggtcgatggc
+     2041 gatgcgactc acgcaccacc ggtcggcgtg cccccggtcg tcgttgggcc ggtgaccgcg
+     2101 atgttcgcca ggtcggcgga ggtcccggac ggctgggccg ggcccggctc cggttcggtg
+     2161 gtgggcgaac cggcgaccga ttcggtggtg accgtgccgg tcgtgacttc ggtggtggac
+     2221 ggggcggcga ccgattcggt ggtgaccggg ccggtcgcgg cctcggccga cgccgcatcg
+     2281 gcggcggcgg tggcctccgc gagccgcgcg ttctctcgac ggaacgtctc gtaaatctgg
+     2341 gtgagcgact gcttctgtgc catggtcagg tcggggtcca cggctatcgc ggcgagcacg
+     2401 ccctgcccct cacggtcgtc cagcagcccg gcccgtaggt acatcgccgg agtggagacc
+     2461 cgcagcgcgc tggcgagctg ctgaagcacc tccgcgctgg gcttgcgcag cccgcgctcg
+     2521 atctgactca gatacgggtt actgacaccc gcctgctcgg acagctgccg gagggagatc
+     2581 ttcgcactcc ggcgcaggtc acgaatgaac ccgccgatgt tgggaaggtc tttaccactg
+     2641 gccataactc aacgctagct cgcggtgcta actcctgcaa gcaaaacgct agccagagtt
+     2701 agcacagggg tgtgccccgc cgtccgggtg ctggccaccg agccgcagcc agcaccacac
+     2761 caaatcacct ttcgtcagag cgggtcacca gagcgaccgg atggcgccta ccggccgccc
+     2821 accgccgagg agtgggacct cggcgaacac cgccaacgcc ggtgcggtca ccccgagccg
+     2881 gcgcaacgcg gagaccagca ccggcatccg ggcccggccg gcaccatcgt cgatcttcaa
+     2941 cgcgatcgcg ccgacgccgg ggaccgccgc ggcgatgacc ccctccaccc cgatcttcgc
+     3001 gagtagcccc ggcacagccc gcatcatccg gctgtcgtcg gcccgcgtac cgccgacaat
+     3061 ctccggatgg gcccgcatcg agtccgccac cgcccgctcc ggcgagcccg gctccgcctg
+     3121 caccagccgc aggtacgcca gcgcgaggcc ggacaacgac acggccagca ccggtgcgcc
+     3181 acagccgtcg atcccgaccg ccgccgccgg ctcgtcggtg aactcctcaa ccgctgcccg
+     3241 caaccgctcc tgcaacggat gctcgctgcg ccagtacccc tccccgggcc aacccgccgc
+     3301 ctggcaggtc agcagcattc cggtgtgttt tccggagcaa ttcatctgga tccgggtcgg
+     3361 gccaccgccg gcgcgcaaca ccgccgccct cgcctcctcg tccgccggca ggtccggcgg
+     3421 gcagtgcaac gcggactcgt cgagcccggc ccgcgccagc aacccaccga cccgggcccg
+     3481 gtggaattcc tccccctcgt ggctggccga gaccagggcg aggtcagccg agtcggccag
+     3541 ccgcaggccc gcacggatca tcccgaccgt ctgcaacggc ttgttcgacg atcggggaaa
+     3601 gatcggcgac gtcacatccc ctgccttcgc caccgccgcg ccagtcgcgt cgagcgccac
+     3661 caccgaccca cgatgcacgc cctcaacgaa acctgaccgg accacctcag cgagcggcac
+     3721 gccgccctcg tacgtctttc ccacggcgtg gacgttaccg cccttcggga acgtccagcc
+     3781 gaggggtgac cagggaattg ggaacacaac gtcagggggc gacccccaac gcaccactta
+     3841 ccggcgaggg gcgggcacgc cgagcagttc ccgggcctcg gcggtggtga gcggagggcg
+     3901 ctgagcgagc tgggcaaagc cgaccgcgcg ggccacgagc tgcatattgg actcgaccgg
+     3961 ctgtcccttg gcataggtca ccgtgtcctc catgcccacc cggaggtgtc cgcccgccga
+     4021 gagcgaagcc agcaggaccg ggatcgtgct acgaccgacg ccggtcgccg agaaggtggt
+     4081 gccggctggt aggtcccgca gcatctgctc ggcggccacc agggccgcgg gagtgccggg
+     4141 cattccgccg ggcacgccca tgacgaggtc aacgtgcaca tgcccgccgg ccggcaggcc
+     4201 gtacttgccg aggaggcgtt gtagggcggt gaggtgcccc aggtcgaaaa tctcgtactc
+     4261 cgggacgatg ccgcgctcct gcatccgggt gtgcagctca acgatgaatt cccaccggtt
+     4321 gagaaacacg tcggtgccga agttgaccgt gcccatcgtg caggaggcca tgtcaggggc
+     4381 ggcatcaagc acagcgagcc ggtcggcctc cgggtcactg accgcaccac ccgaggagag
+     4441 ctgcacgacc aggtcggtgc tctcgcgaag cgccgccacg gtctcgcgca gccgccgctg
+     4501 gtcgagggtc ggctgcgccg cgccgtcccg gatgtggacg tggaccacgg cggcgcccag
+     4561 cgcctcgcac tccttcgcgg tcagcagcag ctcatcaagg gtgaccggca gcgccggcac
+     4621 ctcaaccttg gccgactcgg ccccggtcgg ggcaaccgtg atcaacgtcc ctgtcgtcat
+     4681 gtccggatcc tagtcgcccg accgatgacc gtccggccgg aattcttccg gcatgccggc
+     4741 tgtcaagcct gaacccttcc gctgtcggca gcctcagacc gggttccttc cctagctatc
+     4801 gatcatcgcg gcggtctccc cgaccagcag ccgggcgtcg tcgggcacgt tgcgcttgac
+     4861 caccgccagg gcgacctggc ccagctcgtg gtggtgcacg gcggtgccga cgaagccgac
+     4921 cgcccgcccg tcccgagtca ccggagtgcc ggccgatggt ggctggtccg tggtcacccc
+     4981 atccagatgc aggaggacga gccgacgcgg cggtcgaccc atgttgtgca cccgggccac
+     5041 cgtctcctgc ccgcggtagc agcccttctc caggtgtacg gccggcccga ccaggccaac
+     5101 ctcggccgga atactccggt ggtcggtatc cagcccgacc cggggccgac gggcggccac
+     5161 ccgcaccgcc tcgtacgccc agagcccggc gaccggcacg cccgcgtcgc tcagctcagc
+     5221 caccacccga cccatggcct cccgagccac cagcaggtca acgccgagcg ggccgcggcg
+     5281 ggcccagccc ccgaccggta gcgcacgaac gtcgtaacgc accgtcgacc ggggcggtac
+     5341 cgagccggcc cggaacttcg ggccgggcac ctcgagcagg tccggctcgg ccaggccgga
+     5401 gacgccgagc gtcgccacgg cgtccaccgc cgccggcccg accagcgaga gcagggcgtg
+     5461 gtccggcgtc acgtcgcgcg gttccacctt gctgaaaaag cgcatccgct ccagataccc
+     5521 gagcagccca gcggtgtcgc ccggctcggt gtccagccag gtcgtaccgc cctcctcggc
+     5581 caccatcgcg tgctgctcga catgcccgtg cggggagagc accagcaact cggtgccctg
+     5641 cccggcgggc aggtccgcca ggtgctgggt ggtgagcgtg tgcagccagc cgaggcgatc
+     5701 ctcgcccggc accgcgatca ccccccggtg cgaacggtcg accaggccga cccccgtctc
+     5761 cagggtgcgc tgctcgcgca gcggatcccc gtagtgcgcc gccaccgagc ggacccccgc
+     5821 cgcggcgtgc gccggctccg gctgatcccg gctgccctcg tcaatgctct cgacggagac
+     5881 cgccccagca atatcgatca ttcctgcgcc ccgttctcac agcgatcaca gcggccgaag
+     5941 agggagacat ggccgacgtc cacccggaac ccccgctgct cggcaagctg gtcagccaag
+     6001 gggcgcagca gggcaggatc gatctcgtcg atcgcgccgc actcccggca gaccaggtgc
+     6061 acgtgctggt cctcgccggc cgcgtggaag gtcggcgagc cgtgcgagag atgggtgtgc
+     6121 gtcaccaggc cgagccgctc cagcagctcc agcgtgcgat agatagtagt gatgttgacg
+     6181 cctgcggcca cctcccggac agccgtgtgg acctgctccg gggtcgcgtg ccccagctcc
+     6241 aacaccgcct ggaggacgag ctgccgctgc gccgtcaagc gcagcccacg ggcccggagc
+     6301 agttccgcga gggaggattc ggacaccgtc caagcatagt tcgctcgggc cgaacagcac
+     6361 tctcccgtcc taccggcccc gttctgccga cgcccgtgtc ggtggtgccg ggccggacgg
+     6421 tacccgacgc ggcccggctg ggccctatgc tcggcggcca tgacgacggc gaggatcgcg
+     6481 gtgctcgggc ggggccgggt gccggtcaca gagccagtgc tgcgcggcga cgacctgggc
+     6541 gtcctacacg gtgacggcct cttcgaaacg atgcacctgc gggcgggtcg gccctggctg
+     6601 cgggaggcac acctggaacg gatgacgagg gcggccccgg tgctgggtct gaccctgccg
+     6661 ccggccgatg ccctggtcgc gctgctcgag gagatctgcg ccgactggcc caccgaggtt
+     6721 gagggggcgc tgcggctggt ctgcacccgc ggcgtggccg acggcgaggc cccgaccgcg
+     6781 tacgccacgc tggccccggt gccgccgtcg gcccgggcgg ctcgccggga cgggatcacc
+     6841 gtggcgacat tgccgctggg cgtgccggcc aacggccgcg ccggcctgga ctggttgccc
+     6901 accggcagca agaccacgtc gtacgcggtg cacaacgccg cccgtcggtg ggcgtcccgc
+     6961 aacggcgtca acgacgcgct ctggacctcc accgacgggt acgtcctgga ggggccgacc
+     7021 gccaacgtcc tctggctcac cggcggggcg ctgcgcacgg tgcctgccgc ggccggcatc
+     7081 ctgcccggca ccaccgccgc gtggctgctg gccaacgccg aacaggtggg gctggccgca
+     7141 tacgagcagc tggcggcccc ggccgagttg cacgccgcgg acgcggtctg gttcagctcg
+     7201 tcggtccggg gcctggtcga ggtccgtgtc ctcgacggca tcggccgacc gcggtcgacc
+     7261 tacacccggc ggctgcaggc cctactcggc ttccccgttc cgcccgacga cgaccaatcg
+     7321 gactgacctc cgccgtcgcg gatcaaccgc actgacctac gccgcgaatc agccggatca
+     7381 gccggactga tctcagccgc ccacccggat cagccgggcg gacaggtgcg gggtgaggcc
+     7441 gtggccgacc gcggccatct cctgcgcgta gagcagggcg ccctccacga tgccgaagag
+     7501 gcggtgaccg gcggtcacct ccttcgcggt gggggtgcgc accaccgcgt cggtggcgaa
+     7561 ctcgagctgg gtgccggtgc gcttgccgag gtgcagctcc atcacgccgg tgggcgtgct
+     7621 catcagcgcc tcccactcgt tggtcgcccg gtcgtcaccg tcgagcaccg gccgccacca
+     7681 acccatctcc cgcccggccg ggcggaccgg gcggctctgc tcgtccagca gccacgcccg
+     7741 cgactcgtag cagaggaacg gtcggccgtc gtggctgatc cggatctcct gggcgtagtc
+     7801 gaaatcctcg atggtggggt agccgccccg gccccgaccc cgccacaccc cgatgtacgg
+     7861 cagcaggccg tccagagtgg ggtgcaattt cggcccggta cgcaggtcgt ggctctcctc
+     7921 gtaggggtac gggtccaccg gaggcgcgtt cagccacggc ggctgaagcg gattctcgtc
+     7981 actcactaat gccctctcga aatgcgtacg gcgaggtaga ccaagccgcc ggcgagccca
+     8041 cccagcgcgg cgaccagcaa acttacgaac cctatctcgg tgaccatcgg cgactatcct
+     8101 atgctggcgc tcgtgggccg aaacctcgtc gtcaaggtca ccgccggagc ggattccccg
+     8161 gagcggtgcg cgcaggcctt cacggttgcg gccaccgcgg ccgccgccgg agttgacgtc
+     8221 tcgctctggc tgaccggcga ggcgacctgg ttcgcgctgc ccggccgggc gcaggagttc
+     8281 gagctgccgc actcggcccc gctgggcgag ctactgcacg tgatcctgac gacgggccgg
+     8341 gtgaccgcct gcacacagtg cgcggcccgc cgggacatcg ggaccggcga cgtgctgccc
+     8401 ggcgtccgga tcgccggctc ggcggtcttc gtcgaagagg tcatggccga ggagagccgc
+     8461 gcgctcgtct actagcgctc cacgacaccg tcccaccgca ggacgccatc ctttggcgcg
+     8521 ggcggaagcc tcggctactg gccacggcga gccggctcag tcgaccgaat gggtggcacc
+     8581 ggggacggcg tggtcgatgg ggccatcgaa ccgagtcgag gcacgtgcca ccgcctgttc
+     8641 tggggtgagg aacctcccga tgtgcgtgac gatcaggcgc cccaccccgg ccgctcgagc
+     8701 agtctcaccg gcatcctccg gtgtgtggtg aacccgttct cccgcgctcg ggacctgcgc
+     8761 gctctcggcc tcacacagca gcacatcgct gccctcggcc agactcgtca ggccagagca
+     8821 gggggctgtg tccccggagt acaccaacga ccgcccccca atatcgacac gcaatgcgaa
+     8881 ggcggggata ccgtgcgcca ccgaacggct ggtcaacgtg agcgcgccga ccgccacccg
+     8941 atccccgtcg tgtagctccc ccacggcgaa ggcggattcg atcgggctgc gggtcgcggt
+     9001 gttggtcaga aagtgcgcca atcggtcggc gatgccaggc gggccgtaca acgggatcgg
+     9061 agccgcaagc tggatatcgg cgtacagcgc cccgtagtag gcggtcagga ggtcggcgct
+     9121 gtgatcagcg tgcaggtgcg agatccagat cgcgtccagt tcgtccagcc ggacatgtcg
+     9181 ttgcagctga gccagcgtcc cgctgcccgc gtccacccac acccgagcac cgccacccga
+     9241 caccaggtag ccggaacagg gattgtccac actcgggtag ggcgttgcac aacccagaac
+     9301 cgtgaattgg agcttctcgc tggtcatccg cgaaaggcta ggagactcgg ccgacacatg
+     9361 gggacgattt ctccctcctc agtcagcgca cccggtcgag aacgccaggt gcagctggtc
+     9421 accggtggcg tcggcgacga tcaggtcggc gccgcgccgg taggcgtacg cctcgggtgt
+     9481 gtcgaccacg acggcgccgg ccgccaacgg ggccagggcg ctcaacgacg ccggcccggc
+     9541 gccggcagct acccgctggg tccatgcctt cgcacccccg gggcaggggg ccacgacctc
+     9601 gtccgagtgc tcgggaaccg ggcggcccaa cgcctgcaac gcggcgcgca gcgccggttc
+     9661 gggcgggttc ccaagcagcc gatcgccgga cccggcgtcg gtcgggcgac agccggtcag
+     9721 tacctcaagc cgaacccggc ccggactcgt tgactccccc tcgaccagga cgaactcacc
+     9781 ggcatcggcg cgcagcagcg ggccctcggc ggcgtcccga acgccggccc gccagcgtgc
+     9841 cggcagcgcc tcggtgacct ggctgagcag ctcgcgctcg cctccctcgg cgaccaggac
+     9901 gtcgatccca cgggtcagtt cggcgcccgt gctgaccggg gttacccggc agccccgctc
+     9961 cacgcgggac ggggtcatcg cccacgccgt gccgtcgagc gccgcgacga gttggccgac
+    10021 cgccgcgctg accaccggcg ccgcctgctc aatcgtgcgc tgctcccgca ctgtcggctc
+    10081 gtcggtgcgg gccgaccacc aggccagccc cgccagcagc accgcccagg ccatcgtgcc
+    10141 cgcaatcagt aggcgtcggg cccacggccg ggacggcggg cgatcaggcc cggagggtgg
+    10201 ggcatacccc ggatggacgg cgctcaccgc gccatcgtgt catgtcccgg accggggtca
+    10261 gccgccgccg ggacggccgc actagccgcc cgcgtcgtcg gagcccagga cgagccggta
+    10321 gccgaccccg cgcacggtca gcacccgtgg gccaccggag agcaggcgca gcttgcgccg
+    10381 gagccgcttg atcgccgagt gcaggatcgc ggtgtcgccg aggtaggcgc cgccccagac
+    10441 cgcggcgaag agtcgctcgt agctccagag ccggaccggc ggggtcacca gccgggtcaa
+    10501 caagcgccgc tcggtacggg tcagcgccag tggatgtccc cgccaggtaa ccaggtgccc
+    10561 cggcgggtca accaccagct cgccgtagcg gaccggggca ttcggtggac cggtaccccg
+    10621 ctcctcggtg acggatggtt caggaaagag catcgcccgc agctccgcaa gatcggcaca
+    10681 gctcagcacc ggccccaccc cgtcgagccg acgcaacacg cgctcgcgca cggccatatc
+    10741 ggaactcacg cagaccacga tcggaccttt cccctcagac acacagcctc cccaggcacc
+    10801 cgcgtggacg tgaccagcat cacctccgtc gagatgatgt ccggccgaac accgagtcag
+    10861 cgtacggcca gaaacgcgcc cagtcactga tcgaatactg accgagacaa tttattgatc
+    10921 agcgtcggta ctttcacgag catggctggc gcgggctcgg aacagcccgg gcccgcggac
+    10981 gtggggagga cacgtgttcg tacgaccatc cgcgcggtca cgcctggggc gtctggccgt
+    11041 cgcgttcggg gcgctggtac tggggttgag cgcccagccc gcgctcgccg cgtcgccgcc
+    11101 cggcgcatcg gagcgggcaa ccgtcgcgtc cgagctgctg gagaccagcg acagcaccag
+    11161 tttcctggtc tacctacggg aaaccgcacc gctcgccagc accgcgaccc tgcaagcgcc
+    11221 cgatgaccgg gcccgtgcgg tccaccaact cctgaccaac accgccgacc gcacccaagc
+    11281 cgacctgctg cggctgcttg aggcgcggaa ggcggagcac acctcctatt ggatcgccaa
+    11341 cgccatccag gtccacggcg accgggccct gatcgacgag atcgcgaacc ggcccgaggt
+    11401 cgagcggatc gagccgatcc gcagtcgcca gctgatcgag ccgacgcccg ccgaggccga
+    11461 ggcccgcacc gacgccatcg agtggggcgt cgccgagatc ggcgcccccc aggtgtggga
+    11521 cgagttcggc gaccgcggcg aaggcatcgt gatcgccaac atcgacaccg gcgtgcagta
+    11581 cgaccacccc gccctcgtca actcctaccg gggcaacctc ggcggcggca gcttcgacca
+    11641 cgcctacaac tggttcgacc cgacgggcat ctgctccgac tcggagccct gcgacaacaa
+    11701 cgaccacggc acgcacacga tgggcacgat ggtcggtgac gacggggccg acaaccagat
+    11761 cggtgtcgca ccgggtgccc ggtggatagc ggcgaagggc tgcgaggtca gcacctgctc
+    11821 ggacgccgcg ctcctcgcct ccggccagtg gatcctggcc ccgaccgacg ccaacggcga
+    11881 gaacccccgc ccggagctgc gccccgacat cgtcaacaac tcgtggggcg gcggtggcaa
+    11941 cgacccctgg taccagcaga ccgtcgacgc gtggcgggcc gccgggatcc tcccggtctt
+    12001 ctccaacggc aacagcggcc cgggctgcgg caccgccggt tctcccgggg actacgagag
+    12061 ctcctacgcc gtcggcgcgt acggctcgaa cggcgccatc gccggcttct ccagccgtgg
+    12121 ctccggcacc gatctgatca agccgaacat cgccgcgcca ggggtggccg tgcgctccag
+    12181 cgtccccggc ggcgggtacg ccgcgttcaa cggcacctcg atggcagccc cacacgtcgc
+    12241 cgccactgcc gctctgatct ggtcggtcgc ccccagcctc cgcggggacc tgccggcgac
+    12301 cgaggcgctg ctggaccgta ccgcccgcga tgtcgatgac accacctgcg gcgggaccgc
+    12361 ggccgacaac aacgtgttcg gcgaaggccg gctcgacgcg tacgcggcgg tcaacgaggc
+    12421 cccccgcggc ccggtcgggc gggtcaccgg caccgtgacc gcagccgagg acggcgagcc
+    12481 gctcgccggg gtgaccatcg acgacggcac ccgcgacacc accaccggcg ccgacggccg
+    12541 gtactcgctg accgttccgt ccggtgagac cacggtgacg gccaccctgt acggctacga
+    12601 gtcgcagtcg gacaccttca ccgtggacga gggcggggcg gtgacccggg acttcgcact
+    12661 cgtcgagagc cccatggtca cggtgagcgg tcaggtgacc gacggctccg gacagggctg
+    12721 gccgctctac gcgaaaatca acatcgccgg caagcccggc gacccggtct tcaccgaccc
+    12781 ggtaacggga gagtggtcgg ccactgtcgc cggtgacaac acctactcaa tcaccgccac
+    12841 cccgcagtac ccggactacc ggacggtgac ccgggaggta ccggtcggta gcgatgccac
+    12901 caccgtcgac atggctgttc agatcgcgga atcctgcacg gcggccggct acaatgccag
+    12961 ctacgacgac ccgctcctga cggaggactt cgccgacagc accacgccgg aaggctggtc
+    13021 ggtggtcaac cgcaccgatg agggcggttg gaccttcgag gacctcggcg gacggggcaa
+    13081 cctgaccggc ggcagcggcg gcttcgcgat catcgacagc gacgatctcg gcctcggcaa
+    13141 cagtcaggac accgacctgg tgagcccgac ggtggatctc tccgggaccc ccgcgccggt
+    13201 gctgcggttc aacactgact ggcgggcaat cggcgtcacc gacagcgccg acatcgacgt
+    13261 caccaccgac ggcggcgcga cctggaccaa cgtctggcac cagaccagca gcctgcgcgg
+    13321 gccgcgggtc gaggaggtgc cgttgacgcc ggcagccggc gcgtcggagg ttcaggtgcg
+    13381 gttccgcttc gccggctcct tcgactggtg gtggcaggtc gacgatgtca tgctggccaa
+    13441 ccggaactgc accccggcgc ccggtggcct ggtggtcggc acgaccagcg accagaacac
+    13501 cgacgcagcc ctcaacggcg tcgcggtgac cagcgtggat cagcccgaag ataacgctgt
+    13561 ctcggccggc acggacgacc cggcggagtc gaagggcttc tactggctct tctccagcct
+    13621 caccggaacg cacccgttca ccgcggagcg ggcaccgtac ccggtggcta cccaggacgt
+    13681 gaccgtcgtc gccaacgacg tgcgacgggc cgacttcgcg ctcgccgccg gaaagctcac
+    13741 ggtcaccccg accgaggtgg agtcacacca gccgtacggc agcacccgga gcacccaggt
+    13801 gacggtgaag aacaccggca ccgccccggc cgacgtcgag gtgttggaac ggtccggcgc
+    13861 gtttgatctg ttggcggcgc cgggggcccc gctgcgcgag gtcacgatga agggcatcag
+    13921 cacggcccgg accgggacca cgttcggtgg agcaccggcc gaggccgaag agtcgacgga
+    13981 caacagctgg acccgggtcg cggacctccc atcgaatgcc ttcgacaact ccgccgccat
+    14041 cctggacggc aaggtgtatt cgatcggcgg cggtagcgcc accggcaacg aacgcgcgac
+    14101 ctgggcctac gacccgggca ccgattcctg gtcggagctg ccgccgctac ccacctcccg
+    14161 gtcgaagccg ggcgtcgcgg cggtcggcgg caagatctac gtgaccggcg ggtggggcaa
+    14221 cgagatcgac ccggacgcca cggttaatgt cttcgatccg gccagcgaaa cctggagcac
+    14281 tctggacggg gtcaccaacc ccgcgccgac cgctgccccc ggaaccgccg tcgttgacgg
+    14341 caagatctac ctggtgggtg gctgcgccaa ctcgagctgc accgcgaccg acgacacggt
+    14401 ggtcttcgac ccgagggccg cgaccttcgc caccgttgcc ccctacccgc agcaggtctc
+    14461 ctggatgagc tgcggtggcg tcggcaccca gatgtactgc gccggtggct cgggcgccga
+    14521 caccgccgcc cacaagtacg acccggcgac ggacacctgg actccgatcg cggacatgcc
+    14581 gctggacctg tggggttcgt cgtccgccgc ggccggcggg atgctcgtgc tggccggcgg
+    14641 gatcaccaac ggctccacca cggtgacgaa ccagacgatc gcctacgacc cggcggccgg
+    14701 aacctggcag gacctgccga acgccgagtt cgcccggtac cggggggccg gcgcgtgtgg
+    14761 ggcctaccgg atcggcggct catttgaccc gttcctcgga acggcggagg tcgaacagct
+    14821 cagcgggctg gagttgtgcg tccaggagac ggagctgccg tggctgagca ccgcaccggc
+    14881 cagcttcacc ctggagccgg gcgagtcccg caaggtgcag ctgaccctca cggccaccgc
+    14941 tgaggccggg gttgagcagc ccggtcgcta cagcggcgag ctggccttcg cggccgacgt
+    15001 gccgtacccg accacgccgg tgaaggtgga gatgaacgtg tctccgccga agagctgggg
+    15061 caagctccag ggcacggtca ccggggttac ctgcggcggg gagaccgtcg gcgtaccggc
+    15121 caccgtccgg gtgaacgcga ccggcagcgg cgccggctac accctgacgg cggacaactc
+    15181 cggcacgtac acggtctggc tgcccaaggg ccgctacgac gtgatcgtcg ccaaggacgg
+    15241 ttgggttccg gagttcgacc gcaccaaggt tgaggcaggg ttcgtcgcga ccctcgactt
+    15301 cagcctggaa ccatcgtcgg actgcacgaa agcaagcggc atctgagtag gtcggtggcc
+    15361 ggcgacccga aagggtcgcc ggccactacc gttcccaccc gccgaggagt gtcgttccca
+    15421 ggcgacccga cggtcgtcgc ctgggagcgg tcaagggcag taggggatgg cgtccgtgcg
+    15481 tcaggcctcc cccacggaca tgaagcccgg cagggtcgtg cccaggccac gctcctcggc
+    15541 tttccgccgg accatcgccg ccactgccag atccaggcag cccaggccga acggagagaa
+    15601 gaccgtcagc gagctgtcgt cgcggctgta gcgatcgccg gccacgagga gctcgccgag
+    15661 tgaggcagcg atgaagtcac gcccgccgga ctgctgctcg gcgaggtgca gcgaggtggc
+    15721 ggcgcggcac acgtggtccg cgtcgtccac gatgttgata ctggtctgga tcgtctcggc
+    15781 gctgaggtca cgcagcgaca ggtgcaggac caacgcgcca gggcgcaagt gctccccggc
+    15841 gagatgtggc acgctcgcgg tggtcgccaa cgtgacgagc gggtgcgcgg cgagagcctc
+    15901 ctcgacccgc gcggcgacct ccaccttgag tctcggccac ctcgcgttca cccgggcggc
+    15961 gaaggactcc gcgcgcgctc ggtcgagatc gtacagggtg atctggtcca gttccggctt
+    16021 gacgagctgc agataccgca gcacctcgaa gccgatcggg ccgcacccga tctgcgacac
+    16081 gcccgactcg ggatgcgacg agcccagggt taccgccgcg agcgcggcgc tcgcggcggt
+    16141 gcgctgtgcg gaaatggcgg cggcctccat gaaaacctcg ggaaaaccgg tccgcgggca
+    16201 gttcaagatc atggatgccg atgctcggtc ctgacccagc cggaggttac ccgggaagga
+    16261 cgcgacccac ttgacgccgg ccaccggggt ccgggttccc aggtaggccg ggagcgcgat
+    16321 aatgcggttc tgcagatcgg ccgggaaacg caggaagacc gagtgcggca ccgccgtacg
+    16381 ccccagagcg tgcagctcgt acgcctctcg caccgctgcc agcacgtccg attccgcgcc
+    16441 gtccagaacc aggttcacct cacttttacc caacatcagc atgacatcgc ctccatctcg
+    16501 ggttccttcc acaggtgggc tacatcaccg aaatgcatgg cgacccaatc gtcgttataa
+    16561 atcgtgtcga gataccgctc accccgatcg ggaaagacca gcgcgcacgt cgagcccggc
+    16621 ggaatccgat cgcgcacgac gtccagggcc gacaccaccg ccccggacga accaccagcc
+    16681 aggatcgcct cgcgggcggc caagcggcga cacccgacga tggcgtcgag gtcgtgaacg
+    16741 cggatcactt ggtcggcgag gccgtcggcg tacaggctcg ggcggaccga cgcgccatga
+    16801 cctggaatca gccggccccc gacgggaggc ccgaaaatcg cgctacccag tgcgtcgacc
+    16861 gcgacgacct gagccggcag ttgatgacgg cgcaggtact ccgcgcagcc ccgcagggtg
+    16921 ccgcaggagc tggtggcaca gaacacaaag tccagcgtcg ggagtgcgtc caggatctcc
+    16981 cgcacggtgc tgtggtgcgc ccgcgggttg agtgggttgg cgtactggtt ggggcagtag
+    17041 gcgtgcgtga tgctctcgac gagctcacga acccgacgaa tccgcaccgg gaggtactca
+    17101 ccagaaactg ggtcgacgtc ggtcaccact tcgacctcag cgccgtacgc acgcataatt
+    17161 gctatgttct gacggttggt cctggggtcc accacgcaga tgaagcgaat tccgtgatag
+    17221 gcgcagatct gggcaaggcc aatgccgagg ttgccggagc tggactcgat gacagtagat
+    17281 tttccgggca caagtcggcc atcccggatc cgctcctgga gcatctccag ggcggaacga
+    17341 tccttgatac tgccaccggg gttgtgtgac tcgagtttcg cgaagatcct gaccgaactg
+    17401 ttggggtcta gtttggtcaa ctcgacgatc ggtgtcgcac cgatcgtcga tagcactccg
+    17461 gacacggagc ttcctccttg gtcgacggga ccgatcaacg aacggtgggt tcggcgtcgg
+    17521 ggacggtggg ggtctcgaca ggtacgaccg gcctgcggag tgcgggggcg aacgtcgcga
+    17581 caagggccag caggcccatc cagccggcga gcaccagtgc ggcggcgcgg gcgtcgaacc
+    17641 attccagcag caggccaccg atcagggcgc cgatcggcaa cgcgccgctg gcgagcaggc
+    17701 ccatcgcgcc aaggacccga ccccgcagtc gatccggggt gattcgaagt tggtgggtgg
+    17761 cgacggcgac gttccacaac gggccgacaa accacattcc ggcatacgca gcggttagta
+    17821 ggtacaggtt gtcggcgaca acgatcgcgc ccatcagcag ggcccagatc cagtttgccc
+    17881 caaccaccag ggccggcagt ggtacccagc gttgacacca gccggcagcg agggagccga
+    17941 gcaccccgcc ggccccggcg accccgagca acaccccgac tgccgccggc gacgccccga
+    18001 catcggttgc catcaccacg acaacaagaa acagtgcacg gaacaggagg ttgctgccgg
+    18061 cgacgagtag tgcggccgtg cgcaggaacg gctggcgcca caaccagcgc atcccctcgc
+    18121 cgacctcggc gagcagcccg gtggttcggg tacgcgctgg ttgtcgacgc tggaagtccg
+    18181 cacgaatgaa cagcaacgtg accagcgaga tcacgtgagt gacggcgtgc agcagaaacg
+    18241 gcatgatgcg gctcagccca aacaggaccc cgccaagagt ggtgccgagc atggtcgccg
+    18301 cccgggaacg cgcctcgttt cgggacagcg cggccgacag atggtccgga tgcacgatgt
+    18361 tgggcacggc ggcgtgtgcc gccaggttga agaacaccga catcgtgccc tcgacgaagc
+    18421 ccaccaccac cacgtgcgcc accgtcaact cgtcgagagc caacgcaagg actacgctcg
+    18481 cggccccggc cgctcgaacc acgtcacacc agatcatcag ccgacgtcgg tcccaccggt
+    18541 caaccaacac cccggccggt agttggaaca gcagtgccgg aagtagcgaa aagaagccaa
+    18601 cgacaccagc tgcggctttc gatccggtag ccgccagaat caacaatgga taggcgaccg
+    18661 tagatacagt taggccgacc agggataccg cggtcccgct ccagagcaac aaaaagtcac
+    18721 ggttgtgacg caacttggaa accggcgcac caggccgggg ttgcgcggtc gtggtcatcg
+    18781 gtccgctcca tcgatgcgat cgtctgggcc cacaggtcgg gccgacaccc gtccagtggc
+    18841 aacgtcacgc cggggaccca tcgagagcgt gccgcgcctt cccgtgcccg atgcagagaa
+    18901 gaacgcgcac agatgccagc agcaggcatg cgaacggagc tgccagttgt tctctgcagc
+    18961 cgggctgccc caccaggaac cctgaatagc atgaagacga gccctcttcc tcagcctctg
+    19021 cggactccct cggacgctga gccggcgctc ccgtatgtcg tgacggcacc ggccccagag
+    19081 acaacggcca cgtcgtttct cgcgacgtcc cgcgaccagg tacgccaacg gttgcgcgag
+    19141 cacggcgcgg tgctgctgcg tggcttcgat gtcgacggtg tcgacggctt cgaccagatc
+    19201 gtgcgctcgg tatccggcac cccactcagc tacgccgagc gatcctcgcc ccgtagcacg
+    19261 atcaagggcc gggtctacac ctcaaccgac taccccccgg gcgaggagat cttcctgcac
+    19321 aacgagaact cctaccaggc gacctggccc atgacactct tcttttactg catcacccca
+    19381 ccggagaccc ttggggccac cccgctggcc gacacccggc aggtcctccg atcgatcgat
+    19441 ccggccgtac gcgacgagtt cgcccgccgt ggctggaccg tggtgcgcaa cttctccgac
+    19501 ggtctgggcg tgccgtggca gcaggcgttc aataccgaca agcccgccga ggtcgaggcc
+    19561 tactgcgccg gcaacggcgt cgaggtggag tgggtcggcc gcaacggcct tcgcaccacc
+    19621 gggcggcgtc aggccgttca ccggcatccg gcaaccggcg cggaggtgtg gttcaaccac
+    19681 ctcaccttct ttcacgtgac gaccctggcc gaggagatgt gcgccggcct tcgggagatg
+    19741 ttcgacgagg tggacctacc gacgaacacc tactacggcg acggcgagcg cgtgcccgac
+    19801 gaggtggtcg cgcacctgcg cgactgctac cgcgcagccc agcgccgctt cgactggcaa
+    19861 cgcgacgacg tcctgctcgt cgacaacatg ctcgccgcac acggccgcga gccgttcacc
+    19921 ggaccacgca agatcgcagt cgcgatggcc gaaccgttcc gcaccgctta gaccagagcc
+    19981 cagcacaggg aggcagatcg atggcaaccg gtgatggcgg catctcgctg tcgttcacac
+    20041 aggagcagct gtggttcctc gaccagctgc gatccggagc tgccacggag tacctactgc
+    20101 acgaggcgtt tcaggtacgg ggccccgtgg acgtcgacgc gctcgcgacc gcgttcaccc
+    20161 gggtgtccga gcgccacgag gtgctgcgca cccggtacga gaccgtggac gacaccgcgc
+    20221 ttcaggtggt tgacgatccg gtcgccgtgc cggtggaggt catcgacctg accgcggtgg
+    20281 cggacgccga caccgagcta cagcggatcc ggctggacca gcggactccg attgacctcc
+    20341 gcaccgagcc accgtggcgg gtgacgctgg tccggctcga ccggtccgac tcggtgctgc
+    20401 tgatcacggt gcaccacatc gccttcgacg gctggtcctg gggcgtgctg gcccgcgagc
+    20461 tcggcgagct gtacggggag ctcaccggcg gtaccgccgc gggactggcc gagccgcccg
+    20521 ttcagtacgg cgactacgcc gactggcagc gcgagtggtg ggcctccgcc gaggaggtac
+    20581 gaagcaaaca gctcggctac tggcggaaca cgctcgccgg actggcaccg ctggacctgc
+    20641 cgaccgatcg tccccgcccc tcgcactgga actccgccgg ggacaacttc gacttcactg
+    20701 ttccggttgc cgtcgccaac gaggtcaccc tgctcgcgcg ggcggctggt gccaccccgt
+    20761 tcatggtgta tctgtcggcg tttcagctgc tcctcggacg ctacgccggt cagcgcgacg
+    20821 tcgccgtcgg ggtgtcgttg gcagggcgca acgacgtcca gttggagccg ctcatcggcg
+    20881 cgttcgtcaa caccatcgtc ctacggacga acctcgccgg agcaccgtca ttcgcggaat
+    20941 tgctggcccg cgtccgggaa accacgctgg atgcgtacgg ccaccaggac gtccccttcg
+    21001 accgggtggt acacgatctc gcccccgacc gggacccgtc gcgcaacccg gtgttccagg
+    21061 tgggcttcgc gatgcacaac gccgaacgag tccggctcag cctgcccggc ctggaagtga
+    21121 cgaagctgcc ggccgcctgg accaactccg cgttcgacct gtcgctacac ctctccgagc
+    21181 ggccggacgg gaccgtacac gcgcgcctga tgtacgtcac cgccctgttc gatcgggcgc
+    21241 ggatcgaacg gatggccgcc aactacctgc ggctgctgtc ccgcgcactc gcggagccca
+    21301 cccgcccggt gacccgcctc agcctggtgg cggagccaga gctacaccaa ctccacgagt
+    21361 ggaaccacac gaacgcaccc acgtcgcggc tgctcctgcc cgagctattc ctggcgcagg
+    21421 cccggcgtac tccggacgcc gtcgccgtag ccggcgcgga cggggacctg acctacgccg
+    21481 aactagccgc ccgggtcacc gcgctgacca gctatctgtt gtcccgcggg gtgaccacag
+    21541 aaagacccgt cggagtttcg ctgcatcccg gcgccgacct ggtgacgacc ctactggccg
+    21601 tgctcgccgc cggcggcgtg tacgtgccgc tgccacccga gcaccctgcc gagcgactgg
+    21661 cgatgatggt cgccgacgcc ggcgtggaac tcatcgtcac caactccgcg ctacgggacc
+    21721 agttgcccac ggcgcagctc atcgccctcg attccgacca ggccctgatc gcctcggcac
+    21781 cgaccgccgt accgccggtc atccaccccg gcaacgccgc gtacgtgatg tacacgtccg
+    21841 ggtccaccgg gcggcccaag ggggtcacca tcacccacgg cggcatccgc aaccgggtgc
+    21901 tgtggtcggt tcaccggtac gggatggccc cgggagaccg ggtactgcag aagaccacga
+    21961 tcggcttcga cgcctccgtg tgggagttcc tgtcaccgct ggtatccggt ggggccgtgg
+    22021 tgacgccacc agccggcgta caccgggatc ccgccgcgat ggtcgaagcg gtcgccaccc
+    22081 acggtgtgac ggtgttgcag ctcgtgccgt cggtgctgcg tctcctggtg gaggtgcccc
+    22141 acctggcagg ctgttccgcg ctgcggctgc tctgctcggc aggcgaaccc ctacccgtcg
+    22201 ccctgtgcga acggctactc gacaccctcg acgtcgagat aatgaacacg tacggcccga
+    22261 ccgagtgcgc gatcgactcg accgcggcct ggttccgccg cggcgagcag ggtgagaccg
+    22321 taccgatcgg caccccgctg cagaacatgc gtgcgtacgt cgtggatgcc tcggacgagc
+    22381 tcgtgccgct cggggttccg ggtgagctgt gtgtgtcggg cgtcgggctg gcccgcggct
+    22441 acgtggggcg tggcgacctg accgcggaac ggttccgtcc caatccgtac gcgcgggtgc
+    22501 ccggggaacg ctggtatcgc accggcgacc tggtccgttg gcgcgacgac ggggtcctgg
+    22561 agttcatcgg gcgggtggac gagcaggtca agattcgggg ggtacgggtc gaaccagccg
+    22621 aggtggaggc ggccgtgcgc acccaccccg acgtgggcga ggccgtggtg accgcgcgcc
+    22681 gtggcgagtt gggcgacctc gaactggtcg cctacaccgt gccggcgaac ggcaccccgg
+    22741 tttccctgga gacgttggcc gcgcacctcg ccgaggtgtt gccggctccg atgattccct
+    22801 cgaaccacgt cggcctcgac gtgttgccgt tgacctcgaa cggcaaggtc gaccgcgcgg
+    22861 cgctaccgga gcccgggacg ctacccgcgt ccccgacgga cgaacacgtc agccccagga
+    22921 cgcccaccga acgggcggtc gcggcgttga tggaggaggt actcggcatc gagcgggtcg
+    22981 gggcggagga cgacttcttc acctacgggc actcattgct cgcgatccgg ttcgtgctca
+    23041 ggctacgccg caccttcgat atcgaactga ccgttggcga tctgttcgcc gcacgcaccg
+    23101 tcgccgcgct cgccgcacat atcgatgtcg ccgccgccga cggtccggtg atcccaccgg
+    23161 tgccccggga cggggtactc cccctgtcct tcgcgcagca gcgcatgtgg ttcctcgacc
+    23221 agctcgaacc cggcagcgtc gagtacctcg tcccgctggc gctgcggcta cgggggccgc
+    23281 tagacaccga ggcgctccgc cgtgccatgg acgccgtcgc cgcccggcac gagatgctgc
+    23341 gcacgcgtta cgtcagtgcg ggtgacagtc cggtacaggt gatcgatccg cccggcccgg
+    23401 tatggttcga ggtggttgac ctgaccggtg cgtccgacgc ggcggtgcag gcgctcgttg
+    23461 accgttcctg ctcccagccg ttcgacctct cccaggagcg tccgctccgg gtcaccgtgg
+    23521 tgcgccgggg ggccgaggac cacctggtcg ctgtcagcct gcaccacgtg gccttcgacg
+    23581 cctggtcgat ggacctgttc atgcgggatc tacggaccgc ctacgcggct atccgtggtg
+    23641 gcgctgacgt accactggcg cccccgacgg tgcagtacgc cgacttcgcc gcctggcaac
+    23701 ggagccgcga ggcagagctg ggtgaccagc tcgactactg gcgggagcgg ctcaccggcc
+    23761 tcgatccggt ggagctgccc actgaccggc ctcgaccggc ggtgcgcgac ccccgtggcg
+    23821 gcaccgtctc cgtcgatgtg cccgatgagc tggcggcagg cctgcacgag ctggccggtc
+    23881 ggcacggggc cacccttttc atgacgctgc ttgccggatt ccaggtcctg ctggcccgct
+    23941 acaccgggcg aaccgacctg gccgtcggaa cgccggtcgc ggggcggact cggccggaga
+    24001 ccgaagaact tctcggcttc ttcgtgaaca cgctcgtcct gcggcatgac ctgagtggca
+    24061 accccacctt cgtcgaacta ctcgaccagg tacgccgtag ttccctggac gcgttcgcca
+    24121 accaggacgt gccgttcgaa cacctcgtgg acgcgctcgc cgccaaccgg gacatgtcgc
+    24181 gcaacccgct gttccagatc atgtttgagc tggcccacct ggaccagttc ccgaccaccc
+    24241 tcggtgaggc cgctatcgag ccggtgcacg cgggggtgcc ggttgccaag ttcgacctca
+    24301 ccctgacggt caagcagcgt tccagggggc ggctgcgatg cacgttcgag tacgcgaccg
+    24361 gcctgttcga ccggtcgacg gtcgagcggc tcgccggcca ctacctgaac ctgctgaccg
+    24421 cgatcgtcgg ttcccccacg gcccggctga actcgctccc cgtcctgtcc gacggcgagc
+    24481 gcgacgtgct ggtgcgggag tggcctgacc cggcgtccac ccggctgccg ctactcgacc
+    24541 cggtggacga gcgccaccgg acggtacccg agctgttcga gcgacaggcc aagcggacgc
+    24601 cggacgccgt ggccatggtc ttcggcgagc aggaggtgac ctaccgcgag ctcaacgagc
+    24661 gcgccaacca gctcgcccac cacctgcggt cgctgggtgt cggtccagag gtcgtcgtcg
+    24721 catcgtgcct ggaacgcggc cccgacgcgg tggtcgtact gctagccgcc ctcaagtcgg
+    24781 gtggggtgta cgtcccgttc gacccggacc atcccaccga gcgactggac ttcatgctca
+    24841 ccgacgcggc ggcgcacctg gtggtgacca cccgggccgc tgcccagcgg ctcgcgggcc
+    24901 atcgggtcgt gaccgttgac gacgaccagc tcgcgaccgc cccggcgact gacctggaga
+    24961 gcccaccgag gccacacaac ctggcctatg tcatctacac gtcggggtcc acgggccgcc
+    25021 ccaagggcgt gatgatcgag catcgttcct acgtccacca ctgccgagtg atcagcgacg
+    25081 cctacggcat cgggccggac gatcgggtgg tgctgctgtc cgcactgacg ttcgacgtgg
+    25141 caatggacca gatcgcggcg actctgctcg ccggcgcgac cgtggtagtc agtgatccgg
+    25201 tgttctggac gccgagcgaa ctaccggcac ggctcgccga gcacggcgta acaatcatgg
+    25261 agatcacccc ggcctactac cgggagttac ttgaggccga tgtcgacagg ttgtcggcgc
+    25321 tgcggctgat gaacgtcggc agtgacgtgg tgacggtcgc cgacgcccgc cgctgggccg
+    25381 cgaccggact gcccgcccgg ttcctgtgca actacggtcc gacggaggcg accgtcacct
+    25441 gcgtcctaca cccggtcgct gggctggacg ccgacgaacg ggacgaggca gcgatgccga
+    25501 tcgggcggcc ggtggccggc acccgcggct acgtgctgga cgccgggctg atgccggtgc
+    25561 ccgtgggggt ccccggtgag ttgtgcctgg gcgggatacg cctggcgcgc ggctacctca
+    25621 accggccgga gctgaccgct gaccgcttcg tccccgatcc gcactccggt gatcccggcg
+    25681 cgcggctgta ccgcaccggc gacctggtgc gctggcggcc ggacggcacg atcgagttca
+    25741 tcggcaggat cgaccaacag gtcaaggttc gggggttccg catcgaactg ggtgagatcg
+    25801 aggcggccct ggccgagcac ccggcagtgc acgcgagtgt cgtcaccgtc cgcgaggtcg
+    25861 ggccgggtga gaaacagctc gtgggctatg tggtcccccg tgaccgctcc cgaccggaca
+    25921 tcgcggaact ccgggcccac ctgcgcgacc gggtaccgga gtacatggtg ccggcccgct
+    25981 gggtcacgct cgacgcgctg ccgctgaccc cgagcaagaa ggtcgaccgc aaggcgctac
+    26041 ccgcaccgtc ggcccccgac ggggagcgca cgttgacctc gccgcgggac gagacggagg
+    26101 cagcgctcgc cgggatctgg gcggaggtgc tcgacgtgga acaggtcggg atccatgaca
+    26161 acttcttcga actcggcggg cactcgctgc tggccacccg ggtgctggcc cggattcgta
+    26221 cggcgttcgc cgtcgacctg ccgcttcgac ggctgttcga ggccacgacc gtcgccgaac
+    26281 tcgcgatcga ggttggcgcg gcggtggagg ccgacgtcgc cctgctcacc gacaccgaga
+    26341 tcgaagccct gctcgctgaa gaagaaggtg cacgatgacc aggacaatcg accgggcggc
+    26401 gctgcggacc gcgctgctgc gcaagcgcct gagcggacag gccggcgcct cccccgaagg
+    26461 cgcccccgcc cgcgtgtccc gcgacggtca cctgccactc tcctctgctc agcggcgact
+    26521 ctggatcctc gaccggctac gaccgggcag ccccgagtac ctgatgacca cagctctgcg
+    26581 tatccgcggc cagctgtgcc ggcccgcact gcagacggcg ctggacggct tggttgcccg
+    26641 ccacgaggtg ctgcggaccc gttacgtcga cgtcaacggc gaaccggcac aggtgatcga
+    26701 cgatccgacc ccggtcacgc tgcaccgcag agacggcctc gacgcactcg acgcggtgct
+    26761 gtccaccgaa ctacccaaca ttgacctcgc cgccggtccg gtcttccggc caacgttggt
+    26821 gttcctcggc gaggacgacc acgcgctggt gctgaccctg caccacatcg ccggtgatgc
+    26881 ctggtcggaa gaggtgatgg tgcgcgagct gggcgagcgg tacacggccg cgtctgccgg
+    26941 ccgtgaaccg gagttcgccg agctgcccgt ccagtacgtg gacttcgccg tgtggcagcg
+    27001 ggaccgctcc tccgggcagg cgctggccgg agatctggcg tactggcggg agcggctcgc
+    27061 cgggctgaac cccctggagc tgccgaccga ccggccccgc ccaccggtac gggacggggc
+    27121 gggcgcgctg gtgcaggtcg acgtgtcggc cccgatcgcc acccggttcg ggcggctcgc
+    27181 ccgcgaccac ggggtcaccc ccttcacggc gttcctggcg gcgttcaagg tgcttctcgc
+    27241 ccgctatacc ggtcagaccg acatcgccgt gggcaccccg gtggccggcc gggcacggcc
+    27301 ggagacccag gacctggtgg gcctgttcct caacaccctg gcgctgcgaa ccgacctttc
+    27361 cggttcgccg tcctttcgcg acgtgttgga tcgggttcgg gaaaccgtcc tggacgggca
+    27421 gtcgcaccag gagctgccct tcgaacagat cgttgacgag cttgccccgg tccgggaccc
+    27481 gtcacgcagc ccgctcttct cgacgatgtt cctgatgacc gatcgggtca ccgaggcgcc
+    27541 ctccttcggg gacctgacgg tgacggccct gccggtcggc gaggtcgcgg cgaagtttga
+    27601 cctgacgttg tcggtgatcg agcgcgccaa cggcacgctc ggggtggggg tgaactacgc
+    27661 gaccgcgctc tttgagccgg agaccatgag ccggttggcg gggcactacg cccacctgct
+    27721 ccagtcgatc gtgtcggacc cggacacacc ggtccgccag ctggcgttgc tgtcggcggc
+    27781 ggagcgaaag caggtggtca ccagctggaa cgacaccgcc gtcgaccagc ccagcgccac
+    27841 cctgccgggg ctcatcgcgg accaggtgcg gcgcaccccg cagcgcgagg ccgtccggtt
+    27901 cgacggcagt tcgctgacgt acgccgagtt ggctgcccgg tcgaatcaac tcgcccacca
+    27961 cctgcgctca ctcggcgtcg gtccggagtc gatcgtcggc gtctgcctgc cccggagcct
+    28021 ggatttggtc gtcgcgctgc tggccgtaca gaaggccggc ggggcctacc tgccgctcga
+    28081 tcccgatcac ccggcggagc gcctgcgcta tctgcgggag gactccggcg ccaccgcgat
+    28141 gatcgatacc gacacgttcg ccgctctcgc cggctatccg acggtggacc cgggggtagc
+    28201 ggtccgcccg gaacacccgg cgtacgtgat ctatacctcc ggatccaccg gacgccccaa
+    28261 gggagtcgtg gtggaacacc ggggcatcgt caaccggctg cgctggatgc agcacgccta
+    28321 cgggcttgac gcgaccgacc gcgtgttgca gaagactccg gccagcttcg acgtctccgt
+    28381 ctgggagctc ttctggccgc tgatcacggg cgccaccctg gtcgtcgccc ggccggacgg
+    28441 gcaccgcgac cccgcctacc tggcccgatt gatcgacagc gaacgcatca ccactctgca
+    28501 tttcgttccc tcgatgctgc gcgcgttcct taccgaaccc ttcgccgggc tgccgtcgct
+    28561 acgccgcgtg atctgcagcg gtgaggcact cacctccgac ctcgtcgccg ccgtgcacga
+    28621 ccggatcggc tgcgagctac acaacctcta cgggcccacc gaggcctccg tcgacgtcac
+    28681 cgcggcgcgt tgtcgtcctg gtgagccggt cacgatcggg acccccatcg cgaacacccg
+    28741 cgcctacatc ctggaccagg atctgcagcc cgttccggtc ggcgtcccgg gcgagttgat
+    28801 gctggccggt gttcagctcg cccgcggcta cctgcaccgg cctgtcctga ccgccgaccg
+    28861 gttcgtgccg gaccccttca ctccgggagg aaggctgtac cgcacgggtg acctcgcccg
+    28921 tcaccgcccc gacggccaga tcgactacct gggccggctc gaccaccaag tgaagatcaa
+    28981 cggaattcgg gtggagttgg gggaggtgga gcacgccctg accgaaaacc cagccgtccg
+    29041 cgccgccgcc gtcaccgtcg acgatgggca actcgtcgcc cacctggtcg gcgacgtcga
+    29101 cctggcgacg ctgcccgact tcctccgtgc gcaactaccc gaggccatgg tccccgcaca
+    29161 ctggctcacg tatccggcgt taccgctgac caccagcggc aaagtcgacc gcaacgccct
+    29221 gtcggctccc gaccgcaacc ggaccacgac tggcgggtac gtcgcgccac gtaccccgct
+    29281 cgaacacatg atcgccggcg cgatcgccga tgcgctggac atcgacaacg tcggcattga
+    29341 ggaccggttc ttcgccatcg gcggggactc catgcgggcg atccgggtgg tcggagccct
+    29401 ccgtgcggcc ggcgtcgagc tggccgtgca tgacctgttc acccaccaga ccgtcgccgg
+    29461 actcgccgga ctcgccggag cggcgaccac ggaggacacc ctcgtcgaac ggttcgccca
+    29521 actgtccgag gccgaccgac agctactgcc gaacggcctg gttgacgcct atccgctcgc
+    29581 cgagacccag gccggcatgg tctacgagat gttggccgcc cccgaccgca ccgtctacct
+    29641 caacgtctct tgctaccggg tacacgacga actgccgttc gacctgaaca ccctgcgtgc
+    29701 cgcgaccgcg atcctggtgg gccggcacga gatcctgcgc acctcattcg acctctccac
+    29761 ctactccgag acgatgcaac tggtgcacgc cacggccgag ttgcccgtgg cccacaccaa
+    29821 cctcaccggt ctcgcctcgc aggctcagcg cgccgcggtc gacgagtggc tcgtggccga
+    29881 acgggggcgt ccgttcgaca tcgcccagcc gccgttgctg cgctaccacg tacacgagat
+    29941 cagtgcggac gagtggtggc tcacccacac ggagtgccac gccatcctcg acggatggag
+    30001 ccacacgtcc gtggtcaacg aactcgtctc gatctaccgg aggctccgca ccggccacca
+    30061 gcccgacctc gcgcctccac cggaggtccg cttcgccgac ttcgtcgccg ccgagaagcg
+    30121 tgctctggcg accagcaccg accacgggtt ctgggccacg gcgatcggcc gctacgacaa
+    30181 gctggagctg ccggacggtt gggccagcga acgacgagac gacaaagcca cgatcatcga
+    30241 cgtgccgtgg gccgacctcg cgcccggcct gcgtcgactc gccgcggccg ccggggcgtc
+    30301 gatgaagagc gtgctgcatg ccgcccatct gaaagcgatc agcatcgtca ccggcaggcg
+    30361 tcagttcttc gggggcctgg tctgcaacgg tcgtccggag gagctgcgcg gcgacgaggt
+    30421 tttcggcatg tacctgaaca cggtgccttt cgccgccgac gtgaccgccg cgacctggcg
+    30481 cgactttgtc gccgacgtgt tcgccggcga ggcggaactg tggccgcacc gccgctaccc
+    30541 gatgcccgcc atgcgccggg agtggagtcc cggcagtccg ctgatcgacg tcgccttcgg
+    30601 atacctcgat ttccacgtcc tggactggga ggccgacacg gtcggcatga tcgatgactt
+    30661 cagcccgagc gagctgccgt tggaggtgtg gacctttccc ggcctactgc gcctgggcgg
+    30721 gcggccgagc cggatcggtc gcgagaacct ggaactgctc ggcagaacct accggcgggt
+    30781 gctcgaggcg atgtccctcg atcccgatgc cagcaccgac gtcacgctcg cccccgtcga
+    30841 ccacgaccac gccctgcacc tcggcgggga cagcacccgc gactacccca ccgaggagtt
+    30901 ggtgcaccag ctcgtcgagc accaggcaac cgccgctccc gacgcggtcg cggtgcgcca
+    30961 ggccgaccac acgctcacct acgccgagct ggacgccgcc gccaaccggc tcgcacaccg
+    31021 cctgcgggca ctcggcgctg gccccggcac gctcgtgggc ctgttcctca cgcgcggccc
+    31081 agatctggtc gtcggcatgc tcgccacgct tcgggcggga gcggcgttcc tgccgctgga
+    31141 ccccgcctat cccgccgaac gactgcgcta cctgatcact gacgccgagg tcgggctgct
+    31201 gctcaccgaa ccggacctgc cgcttccgac cggggtcacg gccaccgtcg aaatcgtcgc
+    31261 tgactatccg gacctgccct ccgcccggcc ggcggtggcg cccagcctgg aagatctggc
+    31321 gtacgtgatc tacacctccg gatcgaccgg ccgtcccaag ggggtggggg tgccgcaccg
+    31381 aggtgcgctg aacctccggc acgcccaacg ggagcacctc gacgttcgac ccggcgaccg
+    31441 ggtgctgcag ttcgcctcac cgagctttga cgcgtcggtg tgggagctgt tgatgtcgct
+    31501 gaccaacggc gccgaactgg tgctgccacc ccgtggcacc gaccctggtg acctacgcca
+    31561 gcaggcaggg ctggtgaccc acatgacgtt gccaccgtcg ctgctggaac ggctctcgcc
+    31621 ggaggacttt ccccacctcc gggtactggt gtcagccggt gaggcgtgcc ccgtcgacca
+    31681 ggtcgcgcgg tggagtgggc aggcccggtt catcaacgcc tacgggccga ccgaaacgtc
+    31741 ggtgtgcgcg acgctgaccg aggtcgcgcc gacggtgacc gccccgccgt cgatcggcag
+    31801 cacgatcggt ggcgtctccg cctacgtgct cgaccccgat ctgcgtccac tgtcggtggg
+    31861 cgtccgcggc gagctgtacg tcggcggagc cggacttgcc cggggctatc tggggcgtcc
+    31921 cgggctgacc gccgaacggt tcgtgccgaa cccgtacgga cccgtcggcg cacgcatgta
+    31981 ccggaccggg gacgtggtgt cccgtaaccc tgacggcacg atccagtacc acggccgaac
+    32041 cgaccaccaa gtaaaggtac gcggccaccg gatcgagctg ggcgagatcg aagcggcatt
+    32101 gagcgggcac ccggcggtcg cgtcggcggt cgccgccgta caccgctccg gcaccaccga
+    32161 cgccgccctg gtcgcctaca cccgtgccgt tgacgtaccg ccgaccccgg cggagctccg
+    32221 ggagtacctg cgtgcctgcc tgcccggtca cctcctgccc acgcactgga tcgcggtcga
+    32281 ggacttcgcc ctgacccctg caggcaaggt ggatcgggca gtactgcccg gaccggacgg
+    32341 ctctcggccc gagctggact cggcgtacgt cgcgccgtcg gacgagaccg agcgggcgct
+    32401 ggccgcggcg tggcgtgagg cgttgggggt ggaccgggtc ggagtgcacg acgacttctt
+    32461 cgaactgggc ggtcattcgc tggcgatgat gcgagtgatt gcgacgctac gggcccgcga
+    32521 cggcatcgag ctgacgttcc ggtcgttcat cacgcaccgt acgatcgctg ctctcgccac
+    32581 gacggtcacg gacgagccgg ctggcaaggc gatgatgtgg ctgcgccgga gcggctcggc
+    32641 caccccgctg ttctgcgtgc accccggtgg cggcagcgcg cactggtacc tacggctggt
+    32701 accccacctg gcgcccgaca tcccggtcgc ggctttcgag tggccggcga cacacaacga
+    32761 ggttccgacc gcggaacaga tggccgagcg ctacctggcc gagctgcggg ccgcccagcc
+    32821 gcggggtccg taccggctgt tcagctggtg tggcggcagc agcattgcca ccgagatggc
+    32881 gcggcgcttg accgacgccg gtgagacggt cacgtttatg ctgctcgacc ccggcctcga
+    32941 cgcccacact cgggccgagg gctggcagga gctgaactac attcggcggc tggaggcgct
+    33001 ggtcgagcag atcgtggccg acccccgggc cgacaccgcc gagcgtcgcg ccgagatcct
+    33061 cgccctcctt gagcatctgg tggacgacgt ggatccggcg gtcgggatca ccctgccggc
+    33121 ccggggcgtc ggcgacgtct ggccgaggtc ggtccggatc tggcgcgagg tgatggagct
+    33181 cgacctcgcc taccgtcaca ccccgtactc gggacagcta cacctgatcg tgagcgacga
+    33241 actcgagcgg ggcgagcacg aggtggcggc cggtcaggcg ttcgacgggt acgtggcacg
+    33301 gtggcgcgag ttgacggcgg ggggcgtgac cgtgcaccgg gtaccgggcg accacttcgg
+    33361 cgtgatgaaa ccgccgcacg tcgcggatct gggcgcgctg ctcagccgcc tgaccgaccg
+    33421 gagctgagcc taatggagcg ggcggtggtg tgggaggtgt acacctccca cacggaatcg
+    33481 acggtgacgg tcggcgggct gtcgacatgt tccgcggcac tggcgcgggt gttcgcggca
+    33541 gtggcgagac tgggtgtcga accgacgacg gtcgccggtt ccggggccgg ggtgacgttg
+    33601 gtggtgcccc ggccccgggg gcaggccgta gccgcctccc tagccgccgc gggcactcgg
+    33661 gttcagctgt cgaacgcggt ggcgcgggtc ggcgtccggg gcatcggtct gcgcgcggat
+    33721 tccgcggtcg cggcgacgtt ctgccaaacg gtggtcgcgg ctggcgtaac gctgtccgcc
+    33781 gtctccgtcg agtcgaccga catcagcgtc atgtgcccgg agcaccgggc ggaggccgcg
+    33841 gccggagcgc tggcgaaggc cttcggcacc gccacccacg acatcgggcg ggacctcgac
+    33901 ccccggcgtg gaccgacgct ggtcgtcgcg ggtggcggcc cgctctgacc agcggccgat
+    33961 ccaccgctgg cctgtttcac ggacgagtgg aactcagccg ggcgggtgga agctccgcgg
+    34021 acgcggcggt gggctcagga gttgtccacc gccacgaacc tcagctcggc cgtgtagcgc
+    34081 tcgccctggt cgtccatcaa ccaggtctgc tctggtgtcg gcagcatctc cgtgatcacc
+    34141 agccgtgcct ccgggtcgcc ctggcggtgc agccgtcgag ctgacttggc caggatgttc
+    34201 acgtacacgg gagagtcgaa gtcgacgaag aacggccgcg gttccgtcgg cgacacgacg
+    34261 aagacgaagc ggggaagctc ggcctgctcg cgccaccgtc gggcccggac gaaccgtccc
+    34321 gcctcgctct tctcctcgat gaacggcagc gcagccgtcg ggaagcgcca ggactcccgt
+    34381 gccaccacca tccggtccat cgtcacccgg ggagtgtggt cggcctctgg tatcaggcgg
+    34441 aacatatcca tcaccagcgt cgtcagcacg tgggagaaga cgtccacaat gccgaactcg
+    34501 gcgccgtcgg gcaggaccgc caccaggcgg tcgccctgcg cacgcaccgt gacgtccgcg
+    34561 ctccgtaccg tccggggccg cgccggatca gcggtctgat cgaccaacgc cacgtagtag
+    34621 tcctccggcc gcaccagcgt gtgtcgaatc cgcgccgaca acctcgctcg gtgttccttg
+    34681 ggcaacaacg gcagcaacct cggttccgga tggtcacgcg cggtctgcgc cagcagcgac
+    34741 tccgggtccg gatgctggtt gacaaacagc gaggcaccca gcgtgttggt cgccacgtgt
+    34801 agctcgccca ggaccagttc tcccccggga gacaccaaca cgtcggggct gagataccgg
+    34861 gcagccgtcc agcctgcgtc cgccgcggcg aaggcctctc gtaccgctcc cgcgatctcc
+    34921 gcggcgtcga cctggatccg ggaaccggtc agcggcggca gcaccgaccg ccaccgacgc
+    34981 cggaactcct cctggacctg gacggcgatt cccgcggcct caccatgcag caccggcata
+    35041 cacgcgaacc agaatgtcgc cagatccatc gggccgtcga acacctcccg cacccgcgcc
+    35101 atcacccgct cggcgacggt cgacgtgagc catcgacccg cggtcagtag gagattgagt
+    35161 ggcgccaacg cgtcgagcag gtcagcgccg agccgcaccc gcgcggatcg gcgggcgtcg
+    35221 gagtagacca gcgtccggca cggcgcggtc ttggcgttct tctcccgaac ggcggtctcg
+    35281 tcggtcaacg ccacgaactg ggactccagg tcggtcagag ccgccttcag ctcctcgggt
+    35341 ccgggcgcgg ccgcgacccg ggaacgcccg tgtacgagta cctccaacag ctccgccgcc
+    35401 cgaccaccgg gtgcgccgac cgactccagc cagtgccgca tccacttctc gggacgcgcg
+    35461 tccgccggta catccagtcg ccacaaaacg atgcgacggc gtaccagttc ctccagttgc
+    35521 acggccgggc cgacctcacg ggccggtcgg accccgtcgc agcgggacag cagttcgatc
+    35581 agctccggcg gcagcacctg cggcggacgc ccgggcacga gcaccgagtt gtggttgacc
+    35641 cgtacgaagg gcaccagccg gggggcgatc cacggccgca gctcggggtc cgcgttaacc
+    35701 agtcgggcca ccgcgtcaac cgcccagctg gcgaagtaca cctctgacga ctcgacgagt
+    35761 cccacgcccg aggtcaccgc gatccccgac gtagatgtgt cccagtgtcc ccagcccacc
+    35821 gggccgaaaa agccgatggt gtcgttcttg acgcagaacc gctgccagta gtgagcgacc
+    35881 agttcctcgc gctgccgcgg catgctggtc cggcccgcgg cgctcggcgt ccaggccagg
+    35941 aacggtgcga tgcccgagtt gagcaggggc cgattctgcc aggccaccgc agtttggaac
+    36001 gccggcagtg ccgcgactcg ctgcagctcg gacgcggtgg ccaccgccgc gtccgcgtag
+    36061 agctcctcaa aggccgtcca ggccgcgccg gacaacgcct cgtccgcact gaacttgtcg
+    36121 gcggcctccc ccagtccggc cggtgcgagg cgtaacacgc cggaggccgg aaagcccgga
+    36181 ccacggagcg cgaactggga ccagagccgc cagttcgcgc caaggggtac cgatgtgtcg
+    36241 tccacagtag tcgctcctag aagtcagcgg cgacgacctc ggcgaggtcg gccggcgacg
+    36301 ggtaggcgaa cacgagcgcg acgggaacct cgatatccag cgtcgcttgg agtcgcgcag
+    36361 tgatctggaa ggcggtcaac gaatcaccac cggcctcgaa gaagtcactg ttcgcgtcaa
+    36421 gcgtctcgtc atgcagcgtt tcccgataaa tcgatacgat aagttcagac acgtcgatag
+    36481 ttgtagtcat tgtgcttcct ttcatcgaat gtccacggcg ccgcggacag cacctcggat
+    36541 gtgttgccgc ccgacaccac cgccactgca tgaccaccac acccggcctg catcgctccg
+    36601 gccagcgcga ccgccccact cggctcagcg gcgactccgg ccacccgcaa cacgcccagc
+    36661 gcatggacga tggcgtcgtc ggtcacgcca atcaactcgt ctactcgacg gcgaatgatc
+    36721 ggcagtggca cagcccccgg ccgctggcca cgcaaaccat cggcgatcgt ggacgacggc
+    36781 ggcagctcga ccggtccacc cgcggcgatg gaaatcgcgt agcggcgggt gtgtaccggc
+    36841 tccacgccga ccacccgcac cgggttgtcg aacgcgtcaa cggccagaca caccccggcc
+    36901 aggagtccac ctccgccggt cgggacgaag atcgtggtga tgtcgggagc gtcctcggcc
+    36961 acctcaaggc cgacggtgcc ggctccggcc accacaagct catgatcaga tgagggcagg
+    37021 tacaccgcgc cggtccggtc cgcgatcgac cgcgcccgcc gctcccgctc cgccacgccg
+    37081 ccctcgatgt gtaccacccg cgcacctcga gcacggatcg cccgcgcctt ggcctcgctg
+    37141 gtgccggcgg ccatgaccac ggtcaccggg atatcgcacg cagcgccgat cgtggcgacg
+    37201 gcgataccgt gattgcccga cgatccggtg accaccgcgg ccggtcgcaa caccaccatc
+    37261 gcgttcgccg caccacgcag cttgaacgac ccaccgtgct ggcgatgctc gcccttgacc
+    37321 aacaggttcg aaccaagggc cagcaacggg gtacgccgca ccagcccgga aatccgctcc
+    37381 gcagccaccc gtacgtcggc tatccccaac ccggaccgcg tggcgctccc gatggtggtc
+    37441 atcacggtcc cgctgtcagg gcgcggtgat cgaccttgcc actggccgtg gtcggcaggc
+    37501 gtgcgatccg ggtgaacctg cggggcagca tgtacggcgg cagcgtcgcc gccagacccg
+    37561 ctcggagcgc cgcgtcggtc acctcagcca gttcaccggc gacgtgggcg accaggaaca
+    37621 cccggccacg gtcatcggtg gccgccgtta ccgccgcgcc atcgaccgcg gggtggttga
+    37681 gcagcgcacc ctcgatctcg gccggatcca cccggtagcc gcgaattttg atctgccggt
+    37741 ccacccggcc cagatattcg aggacgccgc cacggagtcg ggccaggtct ccggtgcggt
+    37801 acatgcggtt gccgggaccg ttgaacgggt cgggcacgaa cctctcggcg gtgagatccg
+    37861 ggcggccacc gtagccccgg gtgacaccga tcccaccaac ccacatctga ccaacggcac
+    37921 cagccggcac cgggttcaga tcatcgtcga gcacatagac ggtcactccc tcgatcggtg
+    37981 tgccgacaag gtccatcgtg gtgtccggat ccgggggcac cacaaagcgg gttgaggtca
+    38041 tcgtggcctc ggtcgggccg tactggttga ccaaccggcc acgcaaccgc tctcggcccc
+    38101 cggcggtcag aaacggccgt agggattcac cactcgacac ggtcagccgt agcaacggca
+    38161 cgtcgtggcc ggagacgaag gtgagaaagg tgggcgtggc gctgaggatg gtgtccactc
+    38221 cgaagccccg tagggtcgcg gtgaactcgt caacacgcag tagcgccgag cgggcgacca
+    38281 tcaccagttg actgccggcc atgagcggag cgaacgtgtc gcggatcgag gcgtcgtaac
+    38341 cgagcggggc gagctgcagg acgacggtct ccgtaccgag gtcgtagtcg cttacgacgc
+    38401 acctcagata gttgtccaac ccacggtgct ccaccagcac cgcgttgggg gtaccggtgg
+    38461 acccggaggt gtggctgaca taggccagcg accgcgtggc gatgggcggc aggcggaccg
+    38521 tggcaccggg atccggttcg tcggtgtgca cccggaggcc gccgaacgcc aggtcgagct
+    38581 gcccggccaa cgccgacgtg gtgaccaggc accgagcctg cccactacgg atcatggtcg
+    38641 ccagccgggg gccgggcagc tcgacgtcga gggtgaggaa ggccgcacca gctcgcaggg
+    38701 cggcagccat ggcgatgacg gcctccggtc cgcggtcgac cgcgatcgcg cacacctgtt
+    38761 ccgggccgac gccccgggcg accagcaccc gggcgagccg gtcgacacga gcgacgagtt
+    38821 cgccgtaggt gacgaccgtg tccggggtga cgatcgcggg tgcagcgggt cggtctcggc
+    38881 cctgggccac cagctggtcg aggaacgtgg tcaccggctg cccccgaccg tggcggccac
+    38941 cgcatccgtg gccgccaccc cttcggtggc cgccaccgtc tggtcgacgg cgacgaaccg
+    39001 gagctcagcg gtgtagcggt caccggcgtc gtcggtgagc caggcctgct cgggggtggg
+    39061 tagcatctcg gtgacggtga accgggcctc gggatccttg cggccaagcc gacggatggc
+    39121 cttggcgagg atgttcacgt aaacggggct gtcgaagtca acgtagaacg gccgtggctc
+    39181 ggtcggcatc accacaaaca cgaaccgggg cagccccagc tccgcccgcc acccccgcgc
+    39241 gtagacaaat ctacgggcct cactcttgtc gtgggcgaac cgcacgtcgg cggccggaac
+    39301 gcgccaggac tcgcgggcga cgacggtccg atcgatggtg atccgcggcg cgtgcgggga
+    39361 gtcgccacgc agtgtgaacc ggtccatcac ccggttggtc agcgcgttgc cgaaaacatc
+    39421 gagaacgtcg aactccgcgc cgtcgggcag taccagtacc agccgaccgg cgtgctcctc
+    39481 gactcggatg tccgcagcca ggaggttgcg gggacggctc gggtcgcccg tgtggtccac
+    39541 cagtgccacg acgtagtcct cgggccgcac cagggccggc cggctccggg ccgaccagcg
+    39601 cggcggttgt tccttgggca gcatcggcat caggcgcgga ccgggaaagt cccggctggt
+    39661 ttcggccaac agcgagtcga cgtccgggtg ctgcatcacg aacagggagg cgccgacagt
+    39721 gttcatcgcg acgtggagtt cgcccagcac cagttcgaac tcgccgcggt cgaccgcctc
+    39781 cgggtcctcg gcgcacacca gcaggtccgg gctgacatag cgggcgatgt tccagccatt
+    39841 tccgggctcg gcgaacagct cgtacacccg accggcgatg tcggcggaac gaagctgcac
+    39901 ccgtcgggtc ccggccggcg cgtcaacgag ctcggcccac cgtgcacgga gttcggcctg
+    39961 caccgccgcg acgtcggccg cggactccgg gtgcggcacc ggcaggcagg cgaaccagag
+    40021 cgcaccgaga tcaacactgc cgtgttcgtc gcgcagccgc tcataggctg cgcggattcg
+    40081 ggcaccgacc cggtcggcga accggttggt catccaacgg gcggcggtga ggaagagccc
+    40141 gagcggggtc agctcgtccc ggatcgcggt gccgatcgtc gcggtcgccg aacgacgggc
+    40201 gtccccgtac agcaatgatc ggcacggtgc gacccgggcg cccttcgccc tggcggcggc
+    40261 ctgctcggtc accgtggcga aatcggtctc cagatcggcg agcgcaccag ccagcgcgtc
+    40321 ggcgtccatt ccggccgcgt gtacccggtc ccgggcgcgt tcgacgacgg cgagcttcgc
+    40381 gagggcgcgg gcacgaaccg ggtcgtcggt gacccgctcc accgccgagc gcagccatcg
+    40441 ctccgggtag gcgctggtcg gaacctcgag ccgccgtacg atccagcggc gccggagcag
+    40501 ttcggtcagt gcctcctcga tggccgacac cggcacggtc aacagctccg cgatctcggc
+    40561 ggcagtgcgc accccgtcgc acaggtccag aacgtcaccg tggaaccgga ggatctgctg
+    40621 aggggggcgg cctggcatgg cgacggtgtg accgacgcgg cgtacgaacg acagcctgcg
+    40681 gggtgggacc cacggccgta cggcggagtc tgcctcgatc gcgcgggcta cgtggtcgat
+    40741 cgcccaactg gagaagtaga cccgtgcagc gtcgacgagc ccggtgccgg gttcaaccac
+    40801 gattccactg gtcgagagat cccaccgccc ccagcccacc gggccgaaaa agccgatggt
+    40861 gtcgttcttg acgcagaacc gctgccagta gtgggcgacc agttcctcgc gctgccgcgg
+    40921 catgctggtc cggcccgcgg cgctcggcgt ccaggcgagg aagggggtga tgccggagtc
+    40981 cagcaactgc cggttctgcc aggccagggc cgcccggaac atcggcagcg cggcgatccg
+    41041 ctgtagctcc tgcgcggtcg ctaccatcgc ctcgtcaaag tcctgttcga acgccgccca
+    41101 ttccgccccg gaggggacga tgccggcgtc gaacttgtcg gcgtgttcag ccaggccggc
+    41161 gggggccaac gccagcactc cggcagcggg aaatcccggc ccccgtagcg cgaactggct
+    41221 ccacagccgc caccccccga cgggcaactc gacgtgctcg gacatctcaa cctcccgcga
+    41281 tccgccagtt cggcgtgttc ccggtgcacc actccaggac ggcgcgcgca ctgtgatatt
+    41341 tgttctcggc ctgggcgaag gtgatgctcg tgggaccgtc gagtaccgcg gcggtgacct
+    41401 cctcgccccg gtgtgccggc aggtcgtgca tgaagactgc gcccgggcag gcggccatca
+    41461 gggcctcgtc aacctggtac ggggtgaatt cccgccgcca gtccggggtt ggcttggtgg
+    41521 taccggtggt ctgccagcgg gtggtgtaaa cgacatccac cgacggcagg tcggtggggt
+    41581 cgtgccgttg ttcgaccact gccccgctgc gtttagcggc ggcctgcgcc cgttcgagca
+    41641 cgctcgggtg caccccgtaa ccgggcgggg tacggaggtg taactgggtg tcggtgtagc
+    41701 gggcgagcgc gagcgccagc gcggcggcgg tgttgttgcc ctcgcccaga tacagcacgc
+    41761 gcagaccctc gacctggccg aagtgccggg tcagggtggt gaggtcggcg agggcctggg
+    41821 tgggatgctc ggccgcgctc atcgcgttga ccaccgccat ccggtgttgc ttcgcgtagg
+    41881 cgcgcagttc ctcctcgggc ccggcggtcc gggcgaccag cacatcgatc atccgggaca
+    41941 gcaccgcggc ggtgtcctcg gccgtctcgc cggtgttttc ctgtaggtcc cccggaccgt
+    42001 aggtgatcaa tcgggcgccc aggcgcagtg agccggcaga gaaggcggtc cgggtacggg
+    42061 tcgaggtctt ccggaacaac acgcccacga ccaggtcggc caaggatcgg gcgtcctcgg
+    42121 cggcaccggc ggcgaactcg gtgccgcgcc ggacgatctc gcgcaggtcg gtgtcggtga
+    42181 ggtcatcgat ggagatcagg tggcgtcggt tcgccatgac gggctctctt ccctgtccgg
+    42241 gccgggtggg gtcgggctga cttccggctg ctggtcagac cgcgagcagc ccgtcccgga
+    42301 gcacctcgag ccctcggtcg aggcggacga tgtcgatcgc tatcggcggc agcaccttga
+    42361 tgacctcgtc gtggcgcccg caccgctcga cgattacgcc atggtcaaag gcgtagcgct
+    42421 ggaggcgctc cgcgcgatcg gggccgccga cccgtccgag gtcaatgccg agggccatgc
+    42481 ctcggccccg cacgaccagt ccggcgtcaa cgctggtcag ctcggcccgg aagcgctcca
+    42541 accgccggga ggcaaccgcg atgtcggtgc gaaacttcgg atcaccccag agctcacagg
+    42601 cggcggtggc ggcgacgaag gcgagctggt tgccgcggaa ggtgccggtg tgctcccccg
+    42661 gctcccacac gtccagctcg cgccggaaga gcgacatcga caggggcagg ccgtagccac
+    42721 cgatggactt ggacaccgtg accacatccg gcacgacgcc ggaatgctca aaacagaaga
+    42781 aggtgccggt gcgcccacag ccggcctgga tctcgtcaac gaccagcaga atcccgtgtt
+    42841 gctcggtgag ggtgcgcagc cgccgcagcc agtccgcgga ggccgggtag accccgcctt
+    42901 ccatctgcat cggctcaacg atcaccgcgg cgggtatctc cataccggaa gatgggtcgt
+    42961 cgagcatgcg ctcgatgagt gctatcgagt cgaacggacc ctgcggtcca tcctcatagg
+    43021 gcacgaaggt gacatctccg ccgccgattc caccggcacg tcgggcgcgg cgactgccgg
+    43081 tgaccgccaa cgatccccga gacatgccgt ggtacgcgcc gctgaacgcg atcaccccgc
+    43141 tccggccggt cgccttgcgg gcgagcttga gcgcggcctc caccgcgtcg gtgccggtcg
+    43201 ggccgcagaa ctgcaccttg aagtcgaggc cccggggctg cagcacggtc ttgttgaacg
+    43261 cggtgaggaa ctcccgcttc gccacggtgt acatgtccag gccatggacg acaccgtcgc
+    43321 tgttcagata gtcgagcagg cgacgtttga taaaggggtt gttgtggccg tagttaagag
+    43381 tgccggcacc ggcgaagaag tcaatgaacc gtttgccgtc ctcgctgtag agctccgcgc
+    43441 cgcgagcacg atggaacaca gcagggaatt ttcggcagta cgaccgtacc tctgactcca
+    43501 ggctttcgaa ggcggcgaac ggcgtggtcg cctccagcac ggatgtcgaa tctacggtga
+    43561 ttgtcatggc aggtcctttc aacgcgtctt atgacgacgc cgggcggtca gcgtgggcat
+    43621 cgtggtgcgc tgggagattc gcggataatc agggagcgca gcggcgaggc tggccaccgt
+    43681 gctgtggtcg aacaggcccc gtaccggaac gtcgacaccc aactgggcgc ggaggcgcac
+    43741 cgcgacccgg gtggcgagca acgagtgccc gccgatctcg aagaagttgt cgtccatgtc
+    43801 gatggtggcg ccggtcccca gaacctcccg ccagatgtcg gccacgacgc gttcctcggc
+    43861 ggtacgcggg gccactcgcg ctaccgcgac ccgagtcgcc ggttccggca gtgccgcgta
+    43921 gtcgaccttg ctgttcggcg tcaacggaag agcctccatc ggcacgtacg ccgcggggag
+    43981 catgtagtcg ggcagggtcc gcagcaggaa cctccgcagc tcctcaaccg gcggtgcggt
+    44041 gtccgccctg gcgacgaggt aggcggtcag ctgctcttcc ccggtggggg tggccgtggg
+    44101 gtggacggcg accgcacgaa tgtcgtcgtg gccgagcagt gccgcctcga tctcgctggg
+    44161 ctccatacga tggccgcgaa tcttgacctg ccgatcggca cgtccgagga tctccaccga
+    44221 gccgtcctgg ctacggcggg ccaggtcgcc ggttcggtac aggcgtccgc cgggcgtggt
+    44281 ggagtagggg tcgggtacgt accgctccgc ggtcagcgcg ggctgacccc ggtagccgag
+    44341 cgcgacgcaa ctgccaccga tgtacagctc accgaccgtg ccaatgggca ccggctcggc
+    44401 gtaccggtcg agcaggtgga ccgtgcagtt ggcctgcggc gaccagtcca ccaccgcgcc
+    44461 ggtcgggtcg agacgagccg aggtcaccca tacggtggtc tccgtcgggc cgtacaggtc
+    44521 ccacaccgga gccccttcag cggcgagccg ccgggccagc tcggtcggca gcttctcgcc
+    44581 cccggacagc acggtgatcg tggccggggg aacccaccca acctcgagca gcgcccgcag
+    44641 catcgccggg gtcgcctgca gcaccgcggg gcgggtgagc gccaccagat cgatcagccg
+    44701 ctgcgggtcg cgggcctgtt cggtatcggc gaggacgacc gtcgccccga cgagcagcgg
+    44761 tacgtacaac tccagcagcg acggatcgaa cgagatcgtg gtgagcgcga cgactgactg
+    44821 gccggccgtg agcccgggcc gccgcacgat cgaggtgacg aagttggtca gcgcccgatg
+    44881 gtggaccatg acccccttgg gcgtcccggt ggagccggac gtgtagatca ggtaggcaag
+    44941 ttgctcgccg gtcgccgtgg caggcacggc agcagagggc cgggctgcca caacggcccg
+    45001 gtcccggtcc accagtacgt gctgtccacc ggtgtcacca acccggtcga cgagcgcgga
+    45061 ccgggtgatc acgaccgccg cggcggagtc ggccacgatg aaggcgatcc gggcgtccgg
+    45121 gtactcggga tcgatcggta cgtaggcgcc tccggcccgg agcacggcga ggagtgcgat
+    45181 gagcaggtcg ggaccgcggt cgagcaggac ggcgacgagc gagccgggcc gaacgcccag
+    45241 cgcgcgcagg tggtgcgcga gccggttgac cctcatgtcc agttcgccgt aggtgatctc
+    45301 ctcggtggtc gtccacacgg ccacggcatc cggcgtggcc cgcacctgag cagaaaccaa
+    45361 ctgatcaact gtctggtcgg gaaagtccgc ggcggtgcgg ttccagccgt acagcagacg
+    45421 gtcgcgctcc ccgcgcgggc ccagctccag gcgcgcggcc agttcactga cgctggttgc
+    45481 cggctcgacg acgacggccc gcagcaggtc ggcgaaaccc ccggcgagcc gctccacccg
+    45541 ggcgtggtcg aacaacgcgg tcgcgtattg cagccgtgct gtcgccgtgc cgtccggccg
+    45601 cacgttgacg tcgaggaaaa ggtcgaacgg ggaacccgtc agtggcggct ccaccacttc
+    45661 gacgtccagc ccgggaagcg acatcggggc ccgcacgtcg agcaggctga acgacacctg
+    45721 gaagatcggg ttgcgggaca gatcccgctc cggagcaagg tccgtgacaa tgcgctcgaa
+    45781 cggggtgtcg gcatgggaga acgcaccgag cgcgttgtcc cggacgcggg tgagcagctc
+    45841 ctcgaaagtg ggtgcgccgg ccaggtcggc gcgcagcacc accgagttga cgaagagacc
+    45901 gatcaggtcc tcgtccgcaa cgcgggtccg cccggcgacc ggcgtgccga tggcgaagtc
+    45961 ggtttgaccg ctggcacgtg cgagcacgat ctggaaggca gcgagcagga ccatgaagcg
+    46021 ggtgacccgg cggctacggg ccaccgcgtc gacctctcgc agcagggtcg cgggcaggtc
+    46081 gacacggacg acgtcgcccg cgccgtccca ggtccggggc cgccgccggt cggtgggcag
+    46141 ttcgatggcg ggcacaccgg cgagttgagc ccgccagtag tcgagctgac ggcggctgcg
+    46201 ctcgtcggtg aaccgctcgc gttgccggcg ggcaaagtcg gcgtactgcg cggacagccc
+    46261 gctgacctcg gtggttcgac cggcgtagcc ggcggccagc tcacgggcga gcactcccca
+    46321 ggaccagccg tcgaaggcga tgtggtggac gacgaagacc aggaggtggt cgtcgccgag
+    46381 acgggccagc gagagccgga acggcagatc tcgggcgatg tcgatggggc gggcgagctc
+    46441 tcgctccagg acacggtggt ccgtcgtgtg cgcgatggtg accgtggcgt atgggtcgac
+    46501 gtgggccacc ggccggccgt cgacctcaac gtagcgggtg cgcaacacgt catggcgatc
+    46561 cacgatcgcc tgtagtgccg tggtgagggc ggtgacgtca agcggtccac ggatgcgcag
+    46621 cgcgagcggc agcaggtagt ccggcgttcc gggccgcagc tgatcgagga accaaagccg
+    46681 ctcctgcgcg aacgacacct ctccgacgct gtccaccggt acacctccgc tggctgtgtt
+    46741 catgccgagg tgttgagcat gcgcggctcg cgggtccgga gaacagggaa ggacccgcag
+    46801 ggcgcaggtg cagattttgc tgcgtattcg tcccttcccg tggcggagtg gctgcgacac
+    46861 gctcgacttc gccatggtcg tgtcgacagc gggaggaacg atgaccgacg agggtgtgta
+    46921 ccgcgttgtg ctcaacgatg aggagcagta ctcgatctgg tgggcggacc gggagctgcc
+    46981 gctgggatgg cgtgccgaag gaacagctgg ctcgaaacag gagtgcctgg agcgcattca
+    47041 gcaggtgtgg acggacatgc ggccccgcag tctgcgcgaa cagatggcct gaggctccgg
+    47101 aacggcaggc cgatcgtcga tcggctgccg ggtccggccg gcgcgacgag ggggcatact
+    47161 ccaccccacg agcccgtccc gacgacgtag gcctgtcggt ccgcccccgc tgcccgggtg
+    47221 aacgacagaa gtcagtccgt gcggtgtttg gggggtcagg gcgcgggcac ttcgatcaga
+    47281 tgtgcccggc ccggatcgct ctggcgaccg catgggcccg attgttgacc tgaagtctcg
+    47341 tcatcatgtc gtagataaca ttcttcaccg tgtgctccga gcaggacaga ttcttcgcga
+    47401 tcgccgtatt cgggtagccc tccgccatga gagccagtac cgctgtttgc cggggggtca
+    47461 ggggggacgg gttcggggcc gaatccggac ctcctcctgc cctgtcccgc aacaacttca
+    47521 gcaggatctc gcggggaatc ctgctctccc cctgcttggt ggcccacacc gctgaggcca
+    47581 gcttcgccgg ggccgaggtg gtcgatagca tcgctcgcac ccccgcccgc agggcggatc
+    47641 tgacctccgc cgggtcgaag gcgtcggcca ggaccagcag gcggtagtcg ccggtgagat
+    47701 acggctgcgg gcacgaccgg agcgcccgtc cgaccgtctc cgccgccgcc accacgaccg
+    47761 gcacctggaa cggctgctcc acgatcttga tcccgaccag acgcagcttc gtcgccacgg
+    47821 tggcgcggag cgtggaatcc gcggcctcga cctgcacctt cacagcagac ctgcgcggag
+    47881 cgtgtaggcc acggcgtggg cccggttccg gagccggaat cggcgggtga tgtcgtgcac
+    47941 gacgctggtc acggtccgag tcgagtagca gagctgtcgg gcgatctcac cggtttcgtg
+    48001 gccgtcagcg accagtcgca gcaccgctcg ctccctctca ctcaacggcg agtcggtgga
+    48061 ggatgtcgct gacagcggac gggcacctcg ctccggcaac tggtcgagaa tgtccagcgg
+    48121 aagggtgcag tccccatcgg ccacagccac cacgacgcgg gccaggcggg ccgggtcggc
+    48181 ctcccgccgc cgcatcacac cccgtgcccc ggcgacgatc gcctgcaggg cggcgcagga
+    48241 ctccaggtcc gtcgccacca agaccacctc ggggcaggta gcgctcgccc gtgtttcccg
+    48301 gacgatgccc aggacgtact cgtcgaccgt gtcgacgaca atcacggccg cctgcgcccg
+    48361 ttcgggtccc gacaccacct caacgtctgg ggaacttcgt aacgaggttg tggcgcccac
+    48421 ctcgagcatt gggtccaacg ctgtgacgct gacccgaact ggctcaccca cctgcactcc
+    48481 tcacggtcgt cggcctatcg cgcctcacgg tcgccggccc ctcacgacca gcctcgaccg
+    48541 gtgggtctct cggcacatcg ggcccggaca cgcacatttc tccaccggct gggcaccggt
+    48601 gcggggactc ccgaccgtgg cggtccacca ggtaggttcc gggcttacct gacctgctga
+    48661 tcagtgagct cggatgaatc tgggggtcga gcacccatga cctgaggccc ggccctggtt
+    48721 acgttcgggg tgtgagttca gcgagtttgg ctgcggccaa ccccttaccg gacccggcgt
+    48781 ggtgggccgc tggcctcgcc ctgcacgagc gggacgtgcc ggtcgcgggt ggcgaggccg
+    48841 agaccgagcc gggcttcgcc gcccgactcg ccgacctggg gatgccgcac gatccgcact
+    48901 tcggcgcgct caccactcaa ctccgtcggc ctgcctgggc cgtcctggtg gaggacgtcc
+    48961 tggccaccgc ccggccgctg acctccgacg cgcagccggt ggccgactgg cgagcggcgt
+    49021 tcgcccgggt tctcgcgccc ttcgtcaacg ccgcgttggt ccagattcgc cggcacggta
+    49081 gtcgacacgt ggacctggac cgggtcaccg ccgcggtcag cggcacgctc gggccgcgcc
+    49141 tggtcgacat cgcggcccga acgctggtca ccgagctaca ccggtggcgt gccgaaggcc
+    49201 gcttgaccgg tggggacggc ccggcacgct ttcatgactt cgtccgccag ctcaccgcgc
+    49261 ccgcggggct cggtgaggtc ctcgcccgct atccggtcct ggcccgtcta ctcgcccagg
+    49321 acactgccac caccgccgac gcgaccgtgg agctactcaa ccggctcggc cacgaccgcg
+    49381 acgcgctgat cgccaccctg ctcggcggta tcgacccggg tccggtcacc tcggtgctcg
+    49441 cggcgcaggg agaccgtcac gccggcggac gcgctgtgtc cttcgtggat ttcgcggacg
+    49501 gacggcgact cgtctacaag ccacgtgacc tgactccgta catcaagctg accgcgattc
+    49561 tggaccacct ctcctcggcc gccgccgggg tgttcccccg caccccgcga gttctctccc
+    49621 gaaccggtta cggctggact gagcacatcg ccgcgctacc gctgctcaac tgggaggacg
+    49681 cggaactctt ctaccgccgc caaggtgcgt tgctcgccct gttgcacctc gtccgtgcca
+    49741 ccgacgtgca ctacgaaaac ctcatcgccc acggtgacca gccaattctc gtcgacatcg
+    49801 agactctgtt ccatccggag ctcgcccccg gtggtctggg tgaccccgcc gccgacgcac
+    49861 tggccgaatc cgtgcaccgc accgccctat tgccgctggt cttcgtcggc gaacagggca
+    49921 tcgctgacct gtccggcgct ggcggcgacg tctcgacgtc cccgttgacc gtcgtcgact
+    49981 ggctggacgc gggtacggac cagatgcgcc tgacgcgccg ggccgccgag ttcgctggcg
+    50041 cggctaaccg gccgatcctc aacggtcgac cggtcgagcc acacgagcat gatcgcgcca
+    50101 tcgtcggtgg gttccgtcag gcgtacgaca cgttcatcgc ccaccgcgac aagctcaccg
+    50161 cgcttgtgcg ggactgcgcc gatctcgagg tccgcgtcat cgtcagggcg acctggatgt
+    50221 acaagacgct gctcgacgaa accacccacc ctgatgtcct ccgcgacgct gtcgaccggg
+    50281 accgggcact ctccgtgctc taccacggca ggaccgagca gccgctgctc gcacagctgt
+    50341 tacggtcgga gatcgcgacc ctgtgggcgg gggacatacc aatgttcacc gcctcggtcg
+    50401 gaaccggccg aatccgcgcc gtctccggta ccgagttcac cgaaccgctg ccacagaccg
+    50461 ggctcaccgc agcgttaagc actctcgcct cgctcgacga ggtgaaccga cgcggccagg
+    50521 aatggatcat ctccgcgacc ctggcgtccc gctcccgggt cgcccctcac cccgaggcag
+    50581 tcccgatcgc ggcccaaccc gagggcgtgg tggcgcaccc cgacgaactc ctggcggcgg
+    50641 cctgcgcggt cgccgaccag ctggtcgcgg aagcgaaggc cgggggcggg cgggtcaact
+    50701 ggctggggct ggaggccgtt gaggaccagc ggtggctggt gctgccgctt ggcgccagcc
+    50761 tcggtagtgg gtacctcggt gtggcgctgt tcttcgccca gctcgcggcg gtcaccggaa
+    50821 tctgccgcta cgccgaccaa gcccgcgccg ccaccgccga cctgccacag ctcgtcgctg
+    50881 cgctggacaa gcgacccgat ctcgtcgcgg tcatcggttg cggcgggctg gatgggttgg
+    50941 gcggcatcgc ctacggcctc acccgcatcg ggaccctact cgacgatcac accctcaccg
+    51001 atgccgctgc ccgcagcatt cggctcgccg cgctggcggc gacctccgag gcgccggctg
+    51061 gttggtccac cggactcgcc ggttgcctgg cggctctggc cacagtgcag accgacctga
+    51121 acctccccga agcgggtgat gttgcccgcc ggtgcgccga cctcctcatc gcaccgctag
+    51181 ttgggtccgg caacccaccc gggcaccgtg cggcgacgtc accggaccgg cccggtggct
+    51241 ccgggccaac atcgggcggg ttcgccgaag ggctggccgg gatcggatgg gcgttgacca
+    51301 ccgctgggcc cgacgagcac catcaggctg cgggccgtcg ggtggccacc ctgctcggcg
+    51361 accggagtga gccggcggcg tccgggtggt gtcgcggcac cgccggaacc gtactggccc
+    51421 gtgcgtcgct gtcgaccgac gctgaccctc gctacctgac cggctgcgtt gaggccctgg
+    51481 ccgacgcacc cgtacggcgg gatctgagtc tgtgtcacgg tgagctcggg gtgaccgagg
+    51541 tgttgaccca gctcgccggt tccgatcggc acacgttcgc gacccgggcc ctgcgccgcc
+    51601 gaactggact ggtcctcgat gtgctgcgtc ggcacggctc gctgagcggg gtgcccggcg
+    51661 gggtccgttc cccggggcta ctcaccgggc tggccggtat cggttacggc ctacttcggc
+    51721 acgccgcacc acagcaggtg ccctcggtgt tgctgttaca aggttcctcg gctactcact
+    51781 aacgttcctg ccccacgaga aaaggagatg cacgtcatgt cggaaatgat cccgaatacc
+    51841 gctgaagaag ctgctaccgc tccggccggc cgcctacgtc tgctgccaac cgcggtgacc
+    51901 ttcgccgacc gtgcggcagc gctggcgcgc gtcggtctgc cggtcgccat gctggccgca
+    51961 agcatcgccg cgccggcgct gggagccagt gcgggtgaag cgacggcgat gaacaccacg
+    52021 tgctgcccag atcgtccgat gtaagcaatt cgacagccac ccgaagcgtg gtgggcagcg
+    52081 gcccggtcgg agaaccccgg acctggccgc tgcctcccaa agcctgcgat tccatcgcag
+    52141 gtcgccgatg ataatgtcat tgttgtgcgg cacttttcgg caagtttggt aggccgggac
+    52201 agggtgctgc acgcgctgac ggccgggttg accgccgcca gaaacggccg cggtaacgcg
+    52261 gtttttgtga ccggcgagag cggcatcggc aagtcccggc tgaccgcagc cgtcaccgag
+    52321 ctcgccttca cctcgggcat gagcctgatg cgcggacggg cgagcgccgt cggccccacc
+    52381 ccgccgtttc gaccgctcac cgaggcgatt ctgtcgcacc tccgcatcga gcccgtcgac
+    52441 ccggcaaaac tcgggccgta cgggccgatc ctcggccgac tggtgccgga gtggagcgcc
+    52501 ccggagaaca gccacgacag cgagtcactg gtggtgctgg ccgaagccgt gctgaggttg
+    52561 atcgggcttg tcgggcgaga ccggggctgc ctgctcaacc tcgacgacct gcacgaagcc
+    52621 gatccggaga ccctcgccgt actcgagtac ctgattgaca atgtcgagtt gcagccgatg
+    52681 ctgctgctgg gcgcccttcg cgacgaggga ccggtgctgt cgctggtccg cgccgccgcc
+    52741 cgccgcggcg cctgtcaact catcgacttg gaccggctgt cccgggcgga actcgcacag
+    52801 ttggccggag cgtgcctgga cgtcgagccc aacctggtcc ccacctcggc agtcgaccta
+    52861 ctgtgggccg gaagctccgg gaacccgttg gtcgccaagg aactcctcag cacaatggtg
+    52921 gatgacggca tcctggtggg cgatgcgcag ggctggcaga tcaacagtcg ccccgaggca
+    52981 cccgtgtccg caggtctcgc ccgcccgctt gcccgccgcg tcgcccagct cgggacccgc
+    53041 gtccgcgagc tgctgtcggt cgccgcggtg tttggacagc agttcccgct ccgggtcgtt
+    53101 cagcacgtca ccgggctggc cgaccgggac ctgctcggtc ttctgcagaa cgatgtcgct
+    53161 gggcgctttg tcgcccccga cgagcagacc gccgactggt acgccttcca ccatcagctc
+    53221 agccgggagg cggtgctcgc ccagcttgac caggacgccc atgcgcgact cgcagacatg
+    53281 ttggcgtcgg cggtcgaggc gatctaccca ggacttccgc gggagtggtg cgaggtcgcc
+    53341 gcccggctac gggcggatgc cggggacccg accaccgccg ggacgctctt cacggaggtg
+    53401 gggcggcggg cgctggcact cggcgcagcc aactcggccg tcgcggtgct ggaccgggca
+    53461 ctggaataca tcccgcacga cgacgtggcg acccgcaccg gcacgttgga gttgttgctg
+    53521 caggcgctgg ccgaggcagg gctggtcgag cgggcgctcg agtcggtcag cgagttggac
+    53581 caggccggct ggctcacccc gagccggcgg gccgccctgc acgcccgact ggcctgggcc
+    53641 gcaacggtcg ctgggcgcac cttggacggg ctggcgcagg tggagaccgc ccgagcgctg
+    53701 ctgggctcgg agggctcagc cgaggatctg gcaccgatcg acatggtcgc cgcacacctg
+    53761 ctgttggacg ctggcggtcc ggaccaactc gccgccgccg agaacctcgc ccggcaggcc
+    53821 gcgaccgtag ccgaatcagt gccgctgccg gtggtggcgt gccaggcctg gcagctcgtc
+    53881 ggcggcctcg cccgccatcg ggacccgcag gaggcgacct ccgtgctgga acgggcacgc
+    53941 accctggccg tccgccacga cctgcccatc tgtgagatcc acgcgttgat ccggctgggc
+    54001 aacgacgacg cgttgctgcg cggcgacctc acccggctcc agcgcgccag cgcgcaggcg
+    54061 acccggatgg gtgcggtgac cgcccaatac caggcggagg cgagcatcgc gctgcacacc
+    54121 gtcctgcacg gcgacttcac cgcggccgcg tcgctcaccg accaggtctt cgcggcgacc
+    54181 agccggctaa atctactgga gacgacccag tacgtgctgc tgacccgcgc ggtgctcgcg
+    54241 gggcaccgag gcgaccgcaa ccagatggag tcggagctgg cgcggttcac gcagtggggt
+    54301 ggggacctga cgttacacgg gccgcgggcg cacgggctgg cggcggcgtt ctgcgccctc
+    54361 ctggaggagg atctaccgag ggcacggagc gatctggcgc gagcggtcgc cgccgaggaa
+    54421 cacgggtcga gtgtgtactt tctgtccggc cgacgtgggc tacacgtgtt gctgcgggcg
+    54481 ctcgccggcc aggcggagtg gcccgatctc gaggcggtga ccgtcaaccc ggcaagtacg
+    54541 ctgcgctggg accgccagtt cacgttcttc gcacgcgccg tcctggacgg ccggtcgggt
+    54601 caacgcggcc gcgccagccg ggctgtgacc gatgcgctgg cggcgggtga accgtatccg
+    54661 acgagccgat acctgggtct ccgcctggtc agcgaggcag cgctcaccga cggctggggc
+    54721 gagccggtga cctggctacg gagtgcggag gagcactttc accgtacggg cgtgaacgcc
+    54781 gtggccgggg cgtgccgggc cctactccgc agggccgggg caacggtgcg gcaacgccgg
+    54841 gacggtaccg cgggcattcc gaatgagctc cggtccgctg gcgtgacagc gcgggagtac
+    54901 gaggtgctgg gcctggtggt gaagcgcctg gggaaccgtg agatcgccac gcgcctgcac
+    54961 ctgtctcccc gaacagtgga gcggcacgtg catgggttga tgaccaagac tggactcccc
+    55021 aaccgaatcg cactggccaa gttcggcgcc gggttcgtcg acaacccacc ggctgcggca
+    55081 gggactgaca gcccggcccc gtccagtcac acgacaacgg attggcggtc tcggccgccg
+    55141 gcttctggta gcactacgta gacgcccggt tgatccggtc gttccgccga ccggaaccag
+    55201 tcaccaccga tggcgtcggc ggcgccgcat ctgcggccgc ctgctcgggt gagcgaagtt
+    55261 tggggcccaa ccagaacgac accccaacca acgcaccaac cagcacaaag atcccggcga
+    55321 tcgagagcgg ccggccaagt ttctgccgca atggtcgacc gcttcttcct gtggacttga
+    55381 gtcccaaatt cggggctccc ccacaaagca atcagctcga cgagccagtg tgtcaactct
+    55441 gaggttgcgg acagcgacct aaatcaggcg ttcgtcaatg caacgaatcg attcatttca
+    55501 gagctaacct cctcgtttgt gggtgaatag tgtcgacttt ctgagtcgcc gacttcaatc
+    55561 cgccagaccc tctatagctg ccgttggtca ttccaggacg ccacgtagat ggtcaccata
+    55621 aatcattgcg acgtcccgcc ctagcgagag actaactgaa tcgtaaagcg tggacgcgga
+    55681 ctcgggagta gtcagtcgga tcatcacctc gtcggcaccg ctactgccgg taatactcgt
+    55741 tatatccgcc agcggtacgg ccacgatcag ctcggaggca ccgaactcat cgcccgccgg
+    55801 ccgcacgcat tcaccagtta cgacgacctc gactaagcca ctctgcctcg acaacgcgag
+    55861 ttggtcaccc gtcgtccagc cgagcgaggc ggcgacttga tcgtccacac atgcctcgcc
+    55921 ggcgttggcg gggtaggtgc ccgataccac ctccagcgac cgcaactgtt ggtcaacagc
+    55981 ggccgtaacg accatggctt cgtgctcctt accagtgccc gcatgtcggg ccgtgacgct
+    56041 gtaggcggtg ctatttcctt ccgcggcggt aacctcggag agctcagcga tccgctgaac
+    56101 atcctccggc gcaaacgcaa ccgagctacc cacacttaca tcaacaggcc cggggagcgg
+    56161 gtgaaagcgc gttgcattcg cgtcgttccc actgccgcag gcgcccaacc cgattgtgga
+    56221 cgcggcgaat gccagcggca ggataccgcg atggaggatt aactgcgcac gtctcaccat
+    56281 ttaaggtcgg ctgccttctt agcgagatcg acagtcttat ccgcatgctc ggcaagctgt
+    56341 tcctcgtgcc gctcgtacac agtttgctgc gccgagatga ccagaggcat caggcgctcc
+    56401 ttgaactcta ggcgttgggt gcatttagac caggcaacgg ccagctcgac ctcctcctca
+    56461 gtaggaacat atttctttgc cggaattgct ggacctatct ggatagtgcc ctccttgcgc
+    56521 tccggcgacc acgcctcctc ggctattgtt tcgtgagcac cgaagcgcac tccgagcttt
+    56581 tccggatagg gttcccgggc gaaatcctcg gggtcttctg cctgaaagcc cgcctccgcg
+    56641 aggcaatctc gcagcgacgt acgcagctcg gacaactgag gacctattag cctttcgtat
+    56701 tcctttccga attcgcccat gagcgtgttg cccagctcgc cgtaactgac ggacacctcc
+    56761 tgcgcctccg gaccgatttt cttcgaagct gccagctcac atcgctccac ctcctggtcg
+    56821 taattcgcat cgaagctcac aatgcgagca atttgggctg gagcgtcttt cccgaatcct
+    56881 gaccggcgcg cctcttgctc gtcaaccgga ccaaacgttc gaaggtcgaa gcggaggtgg
+    56941 tcgaaatcgt catccggctc ctgtgccatg tgggtcaggt tctgcggata gccggcctcg
+    57001 gcgaggcact cgtttcgcag tttacggatc gagtggcgaa gaatgccaag ctcttcacct
+    57061 cgcaaagcgt cgaacggttg agcggtagag gcatcagagt cggctgacgc cgcattgtcg
+    57121 gtcgacgccc ggtcgtcgaa tgagcaaccg gcgatgaggc cggctacaag cagcgctgca
+    57181 gagctcactc ggagtagagg cgccggaaaa gtctgtctca ttgctgcagt tcaccttgca
+    57241 ttctggcttg ttgccttatg ctgagacgcg gaagataatt acggatgata ctagagacag
+    57301 cgtagtagcc agcttagcga ctggcaaata gctagccgcc ttagtcaagt ctggccgcaa
+    57361 cacgtccttg tatggcgccg gcccagcttc cggcttctga cctgcgttct gagggacttc
+    57421 tccggcgacc gagaggagcg ttgatgattt cctgtagtcg tagttgcatt ggaccatgcc
+    57481 gccaggacgg ggcggtttca gccgatggaa gtcagtcgaa acgcccagta tatccatggc
+    57541 ccggatccgg atccggatcc ggatccagca aggcgtaccc gcagcggcgc gcatgacgca
+    57601 ttcgatgatc gctatgccaa ctttatgatc aactacctcc caggtcaccg agcgctagtc
+    57661 cgtcacccgg gatcccagcc tgtgggtacc tgtgggtacc tgtggtggca acagcggcag
+    57721 caactgcgcc ttactgccga atagctccgc ctggacatgt tcccgggcca cggagaaaac
+    57781 agctggactc taggcagttc ggcgaacaag ccgagaccta catctggagc cgtggtggac
+    57841 gacggccgag atcccagttt ccgtcccagt tctttttaaa acaaatttcg ccgacactgc
+    57901 aggctaggag cccgtcgcct tcgtcagcgg cggctggcga cgatggcacc gcaactgcag
+    57961 cagctcccgc caggccaatc acggccgccg tccggattgc gcgcttgaag atttggccgc
+    58021 aacttccgac attttcataa tcctctttcg cctggtccag agacgcggat gactctggca
+    58081 ctacagcact taacgcacca ctcgtagcgc attgctcgaa tgtggaccga tcgtacatga
+    58141 tctgccgcca gttcggtgtc ccgcgacgct gcgcttcggg ttgctgcagg tcacggtgac
+    58201 ttcgaggtcg ccgatcgcat cgagaagctc ggggattcgg gatgaaggcc cgagagatgt
+    58261 acttgtgctt accccaacgc ctacgtacgg tcacacaaca acggattggc ggtctcggcc
+    58321 gccggcttct ggtagcacga cgtagacgcc cggttgatcc ggtcgttccg ccgaccggaa
+    58381 ccaaatttcc gccgcccgct cgggcggcca gatggtggcc caatcccacc gcgcccccgc
+    58441 aagtttcgtg ctggtgagaa cggcaccgta gaggttggcc tcacagaggt tgaccccggt
+    58501 gaggttggcg cggtcgaggt tggcctcacg gagatcggcg ctggtgaggt cgacgccggt
+    58561 gagattgact ccgcgaaggt cgatgccggc aaggttcgcg ccggcaagat ccacaccggt
+    58621 taggtcggca ccgatgagaa gcgcgccggt gagatcggcc cgcgtgaggt cggccgccgt
+    58681 caggttggca gcggtcaact cgacaccagc gaggtcgacg ccggcaaggt caacaccacg
+    58741 gaggttggcg gcggtcaggt cgacgccagc gagattggca ccggcgaggt tggcaccgat
+    58801 gagaagcgcg ccggtgaggt tgacgtcggt gaggtccgcg ccacgcaggt caacaccggc
+    58861 gaggttcgcg ccagtgaggt cgacgtcggt gaggtccgcg ccacgcaggt caacaccggc
+    58921 gaggttggca ccggtgaggt cgactccggc gaagttggcg cgggccaggt tgactccgac
+    58981 gagatcgacc tcgcgaagat ccctgttgtt gagctccgca ccagccaagt cgttcatgcg
+    59041 ggaatcgcca atgcgcgagg cgtcctgacg gagatcggcg ttgggcaggc taccgcgttg
+    59101 cgggctggcg aaggctgggg tacgtcggct caacgcagca atgaggtgtc ttaaccggcc
+    59161 aggtcgggct gctcgtggtg agtgaaaggc gggggtggaa cgaccgagcg cgagcacgag
+    59221 ttgacggcgg aaagagtcag tcgacatcgg aagaatccgc atctcctgag gccagcttct
+    59281 ggtccgttgc cagcgggggt ggcacggaac ggctgagggg taatgtcgag tggtggtgcg
+    59341 gtgtgtccac ctcggtcgat gccaggtcaa cctggcgcag aactttttcg atcagtagcg
+    59401 gtgcggtgat gccgagaagc ccggcggcta aggggctggc caggcgcccg tccgcgccga
+    59461 tgagggcggc cagtcccgcg ccggcggcga gccgaagcac gactgaggcc aggtaagcgg
+    59521 ggagccctgg ctcgtcgggg cgtttccagg gcagggtttt cgcacgtcgc aacgcagcgc
+    59581 cgagttcgag tgcttccacg atgaagctac ctagcagccc ccagagggcc gactccatag
+    59641 tggaaagggg ctcgaacggc ataggcgcac aatagccgcc cccttccttc tgccaccggt
+    59701 tggccaccgg tggaccgcca gcccgccagc agctacggga gaacgtcgaa gacggcgaaa
+    59761 tcttagaacc cggaccgagg tcgaatcaat atcagaacta tgaaggtggt aaataatcac
+    59821 accgccatgc ggtacacgat gttcacgtga acgttcgatt tgttgccatc cacccacaac
+    59881 aggccagtga gtcatcgtcg gaagcgcaaa atctgagatt ttgcctaaaa cccatcaaac
+    59941 catccagtat gggcactccc agtgttcagc accgcccgat cccgcctgtg cgcgagtcag
+    60001 ttgacggcca ggtcgcgcgg ctgacgactc acgccaccct ccggtgccga actgccgttc
+    60061 gtgctcgccg ccgcgtcggt gacagtggcg gccggaggct ggtcctggtc cccacgtcgc
+    60121 tgccgagctc gtcggggcta tcgggagcgc tcgtcacggt gccccgcctg acctcacggt
+    60181 cgggcggggc accgttgttg tggcaggcgc cggcgggacg gccccggtgg ctgcaccctt
+    60241 ggcggccacc ggggtcccgt ttcgactcag ctgcactgtg aagtcttcaa accccccggc
+    60301 aacgtttcca ggacttcaac gcggaagtta gccccagcct tcaccgtgta ggtcccggta
+    60361 ccctggaagt ccaacctttt ggtggaggag ttcagcgaga atcccgtggg aagctggccg
+    60421 ccacggtctt ccgcccgaga cagggtgtca tagatattga gcaccggcgg aagcggaccg
+    60481 ttcagactct tggccgtaaa gccgccagtg aaattggcat tcagcgccaa ctcgccagtg
+    60541 taggtggatt gcgtcagcga cgacacgacg taccgggttg tttgtgcggg caccagcaca
+    60601 cgctgagacg gcgcggtgtg cgtctccttg atcgactccg actgggtttc cgaatcttgg
+    60661 tacgacaccg tcactgactc ttcgaggccg agaccgacca ctttcgaaag ggagaaggta
+    60721 cccgaaacct tcgaggttga cgacacacca gtggtgacgg tcgtcgacac cgtgtttgtg
+    60781 aaggccttac tgaacgagtg gctccacagg gtctgatccg aacttgtgga gttcgtcaaa
+    60841 ctcgcgcacc ccaggtagaa cggggcactc gacaccacct tcgccgaacc caccggaacc
+    60901 gcatccgatt ccgtaatcag gatcggggtg gcggtaacct caaaaccaaa aggagggtag
+    60961 gcgtgactcg acatatcttc gagcagcgtg gtgatgtcgg tgatcgtcgc tgcctgtgcg
+    61021 ggcgaggcgg tcatcaacac cgccgccgcg gtgccgatcg acatcgccag gagcgctcgc
+    61081 gtcctcttta acctcatacc attcctcttc cgacttggcg gctacccggt aggcaatatc
+    61141 cagattgctg gcccgcggcg tgcttcatga cacgactagg ccacccaatc actttccctt
+    61201 ccgcacaccc ggtcgatccg accgagcgcc ggtgttgacg tagacgaatc atacacatga
+    61261 ttgggcccca agcaatcctg gcgacaccaa gcgccttacc gcaccgctag aagccagctc
+    61321 tgacctcggc ttttagcaaa aaaatacaac ttgtccgctg cttcacagat gctttatgtc
+    61381 acctactcct cttaccgatt cgttaccaag tttatgtatt cgataaacta gtaactggga
+    61441 ctcggccgaa tgcgccaccg caacagcggg caatgagatg gtcacgcaat ccgtcagcgc
+    61501 agtggggcgt gtgcggcgtc gccccgctca gccggcgaag gtggcggtgt tgacagtgga
+    61561 gcggcgctat cgcccaaggg gcgaccaccc cagctcctcc cgaccgtgcg acgccagccg
+    61621 ccggcacgcc cggtcatgcg tcgactgacc acggccgccg gccgttcgat gtcgagcacc
+    61681 agacgtcgtc caccggggac gacaccgcgc atccaccttc gctggtcatg gcgagcgatc
+    61741 gccgtcgaga ggacgtgctc cagcccgagt agccgtcgga caatagccag cccggttcgc
+    61801 cctgcggctc agggcttccg gagccatgtc ttcggatcgg tcacgaagac gcccttgccc
+    61861 tggtgacggt tgatcacctc cagcgcctcc agtcgcacgt tgacgagctg gatcgtggac
+    61921 gggcttacgt ggtaccgctc gcagagctga gcgattgagg gcagcttgtc ccccgctttg
+    61981 tatcggcccg acctgatgtc atcaatgatc tcatcggaga tccggatata gtccggtgtc
+    62041 gctggcatgt cactcctcgc gtggcacctc cgattcgatc acgagaaaga caaggacgac
+    62101 aagttcaagg tgttccttgc ctaccttggc ttccttgtat aagttgagcg gcaggtcctc
+    62161 atcgcgtggc aacgagtagg gccgatcccc cgggcggggt gggctgggca tggctcaccc
+    62221 cggcccgtcc gatccggaga ggtggttgac gtgcgtaacc cgttccgacg ctttcgtcac
+    62281 tggcgaggcc gccctgcccc gagccacccc actgctcgca ccggctcgct gatcggtgcg
+    62341 aacataggcc gccccgccgg caccgacagc gatgcggacc gccaccggtc gttcgccggc
+    62401 aacgcgggcg ggcaccaccg gtcggcgaca cgctggccgt tgacccccga tcaggtacgc
+    62461 cagcggcagt tcccacgggt ccgacgggga ctcgacgcct ccgaggtgga actcttcctc
+    62521 tatcgggtcg cagcggacct gtccgcgctg cagaccgagc tgaggagcac ccgggacgag
+    62581 aacatccgga tcaagcgggc gctgcgcgac tggcagtccc ggaccacccc cggcgtacgg
+    62641 gcatgaccgt gaccggcctc gacgagagac cacgtttcgt cgtccatttg accctgcacg
+    62701 ccgacgacct cgccggcgcg cgcctgctcg cccgctcggt ggcccgctcc ctgggcttcc
+    62761 tgcccgagct ggcccaacgt cggccacgcc cgacgcgacc agacgactgc ggcccgcaac
+    62821 cggaggtagc gggccgcagt ccgacagcgc gtggtgtcag tcgacgacga ccgggacgat
+    62881 cgcctcgttg acgccccggc tggcggtgat gacgaggtcg ccgttgccgt gccgggacag
+    62941 cgcacgcagt cgccacgtgc ccggcgccgc gaagaagcgg aactgcccgg ccgacgaggt
+    63001 gaccacctcg gcggtgaact cgtcggtgga gtcgagcaga cggacgtacg caccggtcac
+    63061 cggctcaccc gcggcgtcac ggacaacacc ggtgatgacg gtctccttct ccaggtcgag
+    63121 gctggccggc agcggggcgg cctgatccgg ggcggcgcaa ccggccgcgg tcgaagcagt
+    63181 cacgacgttc actccttccc cggctcgtcg ccgagcgcca ccggcacacc gacaagtgag
+    63241 ccgtactcgg tccaggagcc gtcgtagttc ttcacgttct ggtggccgag cagctcctgg
+    63301 agcacgaacc aggtgtgcga ggagcgctca ccgatccggc agtaggcgat cgtctcccgg
+    63361 ctgtcgtcca gcccggccgc ggcgtagatc tcgcgtagct cctggtcgga cttgaaagtg
+    63421 ccgtcctcgt tggccgcctt ggaccacggc acgctgagcg cggtgggcac gtggcccgcg
+    63481 cgctgcgcct gctcctgcgg taggtgggcg ggggcgagca ggcggcccgc gtactcgtcg
+    63541 gggctgcgga cgtcgaccag gttcttcgtg ccaatagcgg cgaccacctc gtcgcggaac
+    63601 gcccggatgg tgtggtccgg ctcctgcgcc acgtaccgag tcgccggacg ggacaccagc
+    63661 tcggtggtca gcgggcgggc gtccagctcc cacttcttgc gaccgccgtc gagcagccgg
+    63721 acctcacggt ggccgtagag cgcgaagtac cagtacgcgt acgcggcgaa ccagttgttg
+    63781 ttgccgccat agaggacgac ggtgtcgtcg ttggcgatgc cccgctcgga gagcagcgcc
+    63841 gcgaactggt ccttgttcac aaagtcccgg cggacctggt cctgaaggtc ggtcctccag
+    63901 tcgagcttga tcgcgccggg caggtggccg gtgtcgtagg ccgaggtgtc ctcgtcaacc
+    63961 tcgacgaaga cgacacccgg ggtttcgagg ttcttctcgg cccagtcggc cgagacgagt
+    64021 gcggtgtcac gactcatcag atcactcctg gtgaggatgg gatggtgagc cagcgcgcgg
+    64081 gagtcatggt gtgtcagtgg tccaccacgc gcgggaccca tggctcggat cggatcacgg
+    64141 gttcgtgcga cggcgccgct ggttggcgca ggagggggca ccagtaaggt gcgcagaccc
+    64201 tgggcgctgg gaggccgcgt caggcggccg agaacagccc cgccgtcaac tggacggggc
+    64261 aacacaggca ggtggccaca cggcacaggt cgaccgcgcg ccgcttggtg aggaacatcc
+    64321 ccatgggcag ggagactacc agcgatgtcg ccgccggcca cggctcaacc agcatccggg
+    64381 acgcgtactc gactcagctc gccgcgtgaa gcggcacctc ggccgcctcc gcggtgacct
+    64441 ggagcccttc gggtagtggc cggacctcgc tgacggtgag gtcgaacggg agcaccggca
+    64501 gtggcacgtc tacggagatg ccctcggcga agctactcag gagcgcccgg accagcgacc
+    64561 cgttcggcac cccatcgggg gtcaggtcgg tgaaccgcag cgacacctga ccctggtcga
+    64621 ccgtgatgtc ggcggtgccg ctgaccggca cccgctcccc gaggagctcc accggagcgg
+    64681 tcaccacgag ttggccgtcc cgctccccca gctgcagccc ctcccggtcg agccgggccg
+    64741 cgatgctgtc gtagctgatg gtgccggtgc cggtgacgct cccggcgatc accccgcccc
+    64801 gtccggagcg aagggtgtcc agcggggcgg tcacgtcgta ggcgtcgatg tcgagggttg
+    64861 gcagggccag cacgtcgccc tggactgatc cccggacctc gttgagcccg atggagatgc
+    64921 gctcgtagcg gccgtcgagg acctgggtga cgaaggggaa gccgccgatc tcgacctcgg
+    64981 gcggcccagc ctgaacgcct tccttggcga gttcctcgcg tacctggtcg gtcagggcgc
+    65041 gttcggccac ccccgccgcc acccggtcgg ccaccaccaa cagcccgacc aggaccagaa
+    65101 gcaggaccag gagcacgacg agtatccgcc gcccgcgctg ccgccggggg cgttcgtcct
+    65161 gctgcgggcg ctcctcggtc gtcacagctc ctcctggcac cactgttgct cctgtcgccg
+    65221 ccgtcgctgc ggcgaggtta cccgggcgat ggcgctccga ccgctcagag aaccagcttg
+    65281 cacagggcgt acgcggccgg cgcggcgagg gcgaggccgg tgagcggacc ttggatgtgc
+    65341 tggatcgccc acccggctgt cggctcgccg gccatttccc gacccgcctc cgcgaaccca
+    65401 acggcgaggt cggccaggac ggcgacgacc gccgcgacca gtcctatgat cgcggcccgg
+    65461 gtcggggtga acggggtgac gaggtagctg cccaggagcg cgctgaccat ggtgccgatc
+    65521 atggcgccgc cgaccacacc ggccgcgccc cgcggcacct ggggggccag ccggggccag
+    65581 gcggcgaacg cgtcggtgat tcgggctacg gcgagcgcga ccccggccgc ggccaggcag
+    65641 accgtgatga cctgggtgcc catcgggatc cgggtcagca cgatcatggt ggggaaggcg
+    65701 acaaccccgg cgacgatgag cacggtgccg cgcaacgatt cgaggacctg cgcccggtcg
+    65761 acccgccgga cgaactgccc cacgaccgca gcaaccaggc cgaccagcag gacctgcacc
+    65821 agcggcatca gccgggccgg atcactccgg acggcgacgg tgtcggcgac gatcgcggcg
+    65881 acggcaccca ccccggccac cgtcatcagc gccggtgggc gaaacgccat cgtccaggtc
+    65941 agcaccgaga gcgcctggac accgaagatg acagcggtga aaggtagccg gtgcccgggg
+    66001 ccgctggtct gcgccgccag caccagcccc atcccgagca gcaccgcgaa gccggcgacg
+    66061 gccagcgcga gggttcggcg cacctcgacc ggcgggacct cctccacgtc ctggtcatgg
+    66121 ccgtcgccgg ggtcacccgc gggccgacgg cctgactccc cgtcccgccg ggctcggcgt
+    66181 gggccaccgc gctccgaccg cccatcgtcg cccccggccc gcggtgcggg cggaccgctg
+    66241 gacggctgtt cgggccaggg ctcacggccg gtctcgggcc tgctggaggg aagcacccac
+    66301 cgatcgtgcc agaccgcgtg gcaccgcggg cggcatggtt tcggtgacgt taaaacctac
+    66361 cccccagtca tgggcataac agacgaaacg gatttgcgct gcaggttgac gcagggcgat
+    66421 cggttaggct caacctgttt acccgcccgt cagtgacgcc gggaccacgc agtaccccag
+    66481 cgccctcagt gcggagcgcg cgctggtcac gcgcggccac cgcgccgccg ggacggaggt
+    66541 gatcgtggag atcctgcttc tggtgacggc acgcgcaggt gaaccatccg ctgtgctgcc
+    66601 cgcgctcgac ttactacccc actcggtccg caccgcccca cgcgacgtac gtacgctggt
+    66661 cgccggcccc agcccggacg tggtcgtgat cgacgcccgt tccgagctga gcgagg
+//

--- a/tests/unit/data/antismash_duplicated_bgc_ids/GCF_000514855.1/contig_1.region001.gbk
+++ b/tests/unit/data/antismash_duplicated_bgc_ids/GCF_000514855.1/contig_1.region001.gbk
@@ -1,0 +1,3633 @@
+LOCUS       NZ_AZWB01000005        66716 bp    DNA     linear   CON 29-NOV-2019
+DEFINITION  Salinispora pacifica CNT029 B170DRAFT_scaffold_1.2_C, whole genome
+            shotgun sequence.
+ACCESSION   NZ_AZWB01000005
+VERSION     NZ_AZWB01000005
+KEYWORDS    .
+SOURCE      Salinispora pacifica CNT029
+  ORGANISM  Salinispora pacifica CNT029
+            Bacteria; Actinobacteria; Micromonosporales; Micromonosporaceae;
+            Salinispora.
+COMMENT     REFSEQ INFORMATION: The reference sequence was derived from
+            AZWB01000005.
+            The annotation was added by the NCBI Prokaryotic Genome Annotation
+            Pipeline (PGAP). Information about PGAP can be found here:
+            https://www.ncbi.nlm.nih.gov/genome/annotation_prok/
+            COMPLETENESS: not full length.
+            ##antiSMASH-Data-START##
+            Version      :: 5.2.0-8ecc354
+            Run date     :: 2020-09-21 13:16:59
+            NOTE: This is a single cluster extracted from a larger record!
+            Orig. start  :: 246431
+            Orig. end    :: 313147
+            ##antiSMASH-Data-END##
+FEATURES             Location/Qualifiers
+     protocluster    1..66716
+                     /aStool="rule-based-clusters"
+                     /contig_edge="False"
+                     /core_location="[266431:293147]"
+                     /cutoff="20000"
+                     /detection_rule="(cds(Condensation and (AMP-binding or
+                     A-OX)) or (Condensation and AMP-binding))"
+                     /neighbourhood="20000"
+                     /product="NRPS"
+                     /protocluster_number="1"
+                     /tool="antismash"
+     proto_core      20001..46716
+                     /aStool="rule-based-clusters"
+                     /tool="antismash"
+                     /cutoff="20000"
+                     /detection_rule="(cds(Condensation and (AMP-binding or
+                     A-OX)) or (Condensation and AMP-binding))"
+                     /neighbourhood="20000"
+                     /product="NRPS"
+                     /protocluster_number="1"
+     cand_cluster    1..66716
+                     /SMILES="NC([*])C(=O)NC([*])C(=O)NC(CO)C(=O)NC(Cc1ccccc1)C(
+                     =O)NCC(=O)O"
+                     /candidate_cluster_number="1"
+                     /contig_edge="False"
+                     /detection_rules="(cds(Condensation and (AMP-binding or
+                     A-OX)) or (Condensation and AMP-binding))"
+                     /detection_rules="((LANC_like and (Lant_dehydr_N or
+                     Lant_dehydr_C) or cds(LANC_like and (Pkinase or DUF4135)))
+                     and not (YcaO or TIGR03882))"
+                     /kind="interleaved"
+                     /product="NRPS"
+                     /product="lanthipeptide"
+                     /protoclusters="1"
+                     /protoclusters="2"
+                     /tool="antismash"
+     region          1..66716
+                     /candidate_cluster_numbers="1"
+                     /contig_edge="False"
+                     /product="NRPS"
+                     /product="lanthipeptide"
+                     /region_number="1"
+                     /rules="(cds(Condensation and (AMP-binding or A-OX)) or
+                     (Condensation and AMP-binding))"
+                     /rules="((LANC_like and (Lant_dehydr_N or Lant_dehydr_C) or
+                     cds(LANC_like and (Pkinase or DUF4135))) and not (YcaO or
+                     TIGR03882))"
+                     /tool="antismash"
+     gene            complement(75..962)
+                     /locus_tag="B170_RS0101195"
+     CDS             complement(75..962)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_011904239.1"
+                     /locus_tag="B170_RS0101195"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="alpha/beta hydrolase"
+                     /protein_id="WP_027654901.1"
+                     /transl_table=11
+                     /translation="MRGFRWPPPPDGGPRTWGPGPSAPRTGRPALPEPETELVATPHGV
+                     HLEQLVTGAGDPVTVFAHGLGSGIATTRPFGSGVTGRRLFFQFRGHGRSAAPTGPWTYR
+                     DLARDLRSVADRGRATRAFGASLGAGALCRLLADNPTRFDRLVFYLPAVLDQPRGDAAR
+                     RRLTALLDALGSGDVGQLAEVVQLELPPAIRNTPAGWAYLRQRLDQLMRDGLASGLVGL
+                     PESVPVRDAAELAEVTAPALVIGCVGDELHPVAVAERLAAALPQATLHVYDRPGVLWAK
+                     RADLRERISAFLNE"
+     gene            complement(959..1273)
+                     /locus_tag="B170_RS0101200"
+     CDS             complement(959..1273)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018254623.1"
+                     /locus_tag="B170_RS0101200"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="DUF2516 family protein"
+                     /protein_id="WP_026271676.1"
+                     /transl_table=11
+                     /translation="MAIAAPFAFEVRYVIELILLVFALIVQGVALVHVITQRSDAFAAV
+                     GTLPKGAWAAILAVCLVLTLLGFGPISLFGLVGIAAGLIYLLDVRTGLRDLRGGRGNSW
+                     "
+     gene            complement(1365..1943)
+                     /locus_tag="B170_RS0101205"
+     CDS             complement(1365..1943)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_011904237.1"
+                     /locus_tag="B170_RS0101205"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_019870483.1"
+                     /transl_table=11
+                     /translation="MTSQPKTSRIPAPLYAAAGAGDLAYQQLRKLPAAVTELRNRVAAD
+                     LGTVNGAELRQKATETLRTATATAENLRRRAASDLDLSRLRETATRNAAVVVASAQAAQ
+                     ERAVTTYGALVGHGERVVGAGVLEAADTVNTDIETTEQPPAPTPAQLAEAAEVKPAAVT
+                     KRATKAAGKPASSATKSPRATKRTPPARD"
+     gene            complement(2049..2645)
+                     /locus_tag="B170_RS0101210"
+     CDS             complement(2049..2645)
+                     /codon_start=1
+                     /gene_functions="other (smcogs) SMCOG1148:hypothetical
+                     protein (Score: 87.4; E-value: 2.3e-26)"
+                     /gene_kind="other"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_011904236.1"
+                     /locus_tag="B170_RS0101210"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="helix-turn-helix transcriptional regulator"
+                     /protein_id="WP_019870482.1"
+                     /transl_table=11
+                     /translation="MASGKDLPNIGGFIRDLRRSAKISLRQLSEQAGVSNPYLSQIERG
+                     LRKPSAEVLQQLASALRVSTPAMYLRAGLLDDREGQGVLAAIAVDPDLTMAQKQSLTQI
+                     YETFRRENARLAEATAAADAASAEAATGPVTTESVAAPSTTEVTTGTVTTESVAGSPTT
+                     EPEPGPAQPSGTSADLANIAVTGPTTTGGTPTGGA"
+     gene            complement(2785..3798)
+                     /locus_tag="B170_RS0101215"
+     CDS             complement(2785..3798)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018584331.1"
+                     /locus_tag="B170_RS0101215"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="asparaginase"
+                     /protein_id="WP_050588275.1"
+                     /transl_table=11
+                     /translation="MPWSPLGWTFPKGGNVHAVGKTYEGGVPLAEVVRSGFVEGVHRGS
+                     VVALDATGAAVAKAGDVTSPIFPRSSNKPLQTVGMIRAGLRLADSADLALVSASHEGEE
+                     FHRARVGGLLARAGLDESALHCPPDLPADEEARAAVLRAGGGPTRIQMNCSGKHTGMLL
+                     TCQAAGWPGEGYWRSEHPLQERLRAAVEEFTDEPAAAVGIDGCGAPVLAVSLSGLALAY
+                     LRLVQAEPGSPERAVADSMRAHPEIVGGTRADDSRMMRAVPGLLAKIGVEGVIAAAVPG
+                     VGAIALKIDDGAGRARMPVLVSALRRLGVTAPALAVFAEVPLLGGGRPVGAIRSLW"
+     gene            complement(3838..4680)
+                     /locus_tag="B170_RS0101220"
+     CDS             complement(3838..4680)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018218117.1"
+                     /locus_tag="B170_RS0101220"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="3-keto-5-aminohexanoate cleavage protein"
+                     /protein_id="WP_027654903.1"
+                     /transl_table=11
+                     /translation="MTTGTLITVAPTGAESAKVEVPALPVTLDELLLTAKECEALGAAV
+                     VHVHIRDGAAQPTLDQRRLRETVAALRESTDLVVQLSSGGAVSDPEADRLAVLDAAPDM
+                     ASCTMGTVNFGTDVFLNRWEFIVELHTRMQERGIVPEYEIFDLGHLTALQRLLGKYGLP
+                     AGGHVHVDLVMGVPGGMPGTPAALVAAEQMLRDLPAGTTFSATGVGRSTIPVLLASLSA
+                     GGHLRVGMEDTVTYAKGQPVESNMQLVARAVGFAQLAQRPPLTTAEARELLGVPAPRR"
+     gene            complement(4792..5901)
+                     /locus_tag="B170_RS0101225"
+     CDS             complement(4792..5901)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019870479.1"
+                     /locus_tag="B170_RS0101225"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="folate-binding protein YgfZ"
+                     /protein_id="WP_027654904.1"
+                     /transl_table=11
+                     /translation="MIDIAGAVSVESIDEGSRDQPEPAHAAAGVRSVAAHYGDPLREQR
+                     TLETGVGLVDRSHRGVIAVPGEDRLGWLHTLTTQHLADLPAGQGTELLVLSPHGHVEQH
+                     AMVAEEGGTTWLDTEPGDTAGLLGYLERMRFFSKVEPRDVTPDHALLSLVGPAAVDAVA
+                     TLGVSGLAEPDLLEVPGPKFRAGSVPPRSTVRYDVRALPVGGWARRGPLGVDLLVAREA
+                     MGRVVAELSDAGVPVAGLWAYEAVRVAARRPRVGLDTDHRSIPAEVGLVGPAVHLEKGC
+                     YRGQETVARVHNMGRPPRRLVLLHLDGVTTDQPPSAGTPVTRDGRAVGFVGTAVHHHEL
+                     GQVALAVVKRNVPDDARLLVGETAAMIDS"
+     gene            complement(5898..6326)
+                     /locus_tag="B170_RS0101230"
+     CDS             complement(5898..6326)
+                     /codon_start=1
+                     /gene_functions="regulatory (smcogs) SMCOG1266:hydrogen
+                     peroxide sensitive repressor (Score: 114.4; E-value:
+                     6.2e-35)"
+                     /gene_kind="regulatory"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018736279.1"
+                     /locus_tag="B170_RS0101230"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="transcriptional repressor"
+                     /protein_id="WP_018730254.1"
+                     /transl_table=11
+                     /translation="MSESSLAELLRARGLRLTAQRQLVLQAVLELGHATPEQVHTAVRE
+                     VAAGVNITTIYRTLELLERLGLVTHTHLSHGSPTFHAAGEDQHVHLVCRECGAIDEIDP
+                     ALLRPLADQLAEQRGFRVDVGHVSLFGRCDRCENGAQE"
+     gene            6460..7326
+                     /locus_tag="B170_RS0101235"
+     CDS             6460..7326
+                     /NRPS_PKS="Domain: Aminotran_4 (47-275). E-value: 5.6e-34.
+                     Score: 109.6. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101235_Aminotran_4.1"
+                     /NRPS_PKS="type: other"
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018736280.1"
+                     /locus_tag="B170_RS0101235"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="aminotransferase IV"
+                     /protein_id="WP_027654905.1"
+                     /transl_table=11
+                     /translation="MTTARIAVLGRGRVPVTEPVLRGDDLGVLHGDGLFETMHLRAGRP
+                     WLREAHLERMTRAAPVLGLTLPPADALVALLEEICADWPTEVEGALRLVCTRGVADGEA
+                     PTAYATLAPVPPSARAARRDGITVATLPLGVPANGRAGLDWLPTGSKTTSYAVHNAARR
+                     WASRNGVNDALWTSTDGYVLEGPTANVLWLTGGALRTVPAAAGILPGTTAAWLLANAEQ
+                     VGLAAYEQLAAPAELHAADAVWFSSSVRGLVEVRVLDGIGRPRSTYTRRLQALLGFPVP
+                     PDDDQSD"
+     aSDomain        6601..7284
+                     /aSDomain="Aminotran_4"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101235_Aminotran_4.1"
+                     /evalue="5.60E-34"
+                     /label="B170_RS0101235_Aminotran_4.1"
+                     /locus_tag="B170_RS0101235"
+                     /protein_end="275"
+                     /protein_start="47"
+                     /score="109.6"
+                     /tool="antismash"
+                     /translation="REAHLERMTRAAPVLGLTLPPADALVALLEEICADWPTEVEGALR
+                     LVCTRGVADGEAPTAYATLAPVPPSARAARRDGITVATLPLGVPANGRAGLDWLPTGSK
+                     TTSYAVHNAARRWASRNGVNDALWTSTDGYVLEGPTANVLWLTGGALRTVPAAAGILPG
+                     TTAAWLLANAEQVGLAAYEQLAAPAELHAADAVWFSSSVRGLVEVRVLDGIGRPRSTYT
+                     RRLQAL"
+     gene            complement(7393..7986)
+                     /locus_tag="B170_RS0101240"
+     CDS             complement(7393..7986)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_007465734.1"
+                     /locus_tag="B170_RS0101240"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="FABP family protein"
+                     /protein_id="WP_018730256.1"
+                     /transl_table=11
+                     /translation="MSDENPLQPPWLNAPPVDPYPYEESHDLRTGPKLHPTLDGLLPYI
+                     GVWRGRGRGGYPTIEDFDYAQEIRISHDGRPFLCYESRAWLLDEQSRPVRPAGREMGWW
+                     RPVLDGDDRATNEWEALMSTPTGVMELHLGKRTGTQLEFATDAVVRTPTAKEVTAGHRL
+                     FGIVEGALLYAQEMAAVGHGLTPHLSARLIRVGG"
+     gene            8101..8475
+                     /locus_tag="B170_RS0101250"
+     CDS             8101..8475
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_007073224.1"
+                     /locus_tag="B170_RS0101250"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="DsrE family protein"
+                     /protein_id="WP_018739966.1"
+                     /transl_table=11
+                     /translation="MLALVGRNLVVKVTAGADSPERCAQAFTVAATAAAAGVDVSLWLT
+                     GEATWFALPGRAQEFELPHSAPLGELLHVILTTGRVTACTQCAARRDIGTGDVLPGVRI
+                     AGSAVFVEEVMAEESRALVY"
+     gene            complement(8557..9327)
+                     /locus_tag="B170_RS0101255"
+     CDS             complement(8557..9327)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_011904228.1"
+                     /locus_tag="B170_RS0101255"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="MBL fold metallo-hydrolase"
+                     /protein_id="WP_027654906.1"
+                     /transl_table=11
+                     /translation="MTSEKLQFTVLGCATPYPSVDNPCSGYLVSGGGARVWVDAGSGTL
+                     AQLQRHVRLDELDAIWISHLHADHSADLLTAYYGALYADIQLAAPIPLYGPPGIADRLA
+                     HFLTNTATRSPIESAFAVGELHDGDRVAVGALTLTSRSVAHGIPAFALRVDIGGRSLVY
+                     SGDTAPCSGLTSLAEGSDVLLCEAESAQVPSAGERVHHTPEDAGETARAAGVGRLIVTH
+                     IGRFLTPEQAVARASTRFDGPIDHAVPGATHSVD"
+     gene            complement(9379..10227)
+                     /locus_tag="B170_RS0101260"
+     CDS             complement(9379..10227)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018586895.1"
+                     /locus_tag="B170_RS0101260"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027654907.1"
+                     /transl_table=11
+                     /translation="MSAVHPGYAPPSGPDRPPSRPWARRLLIAGTMAWAVLLAGLAWWS
+                     ARTDEPTVREQRTIEQAAPVVSAAVGQLVAALDGTAWAMTPSRVERGCRVTPVSTGAEL
+                     TRGIDVLVAEGGERELLSQVTEALPARWRAGVRDAAEGPLLRADAGEFVLVEGESTSPG
+                     RVRLEVLTGCRPTDAGSGDRLLGNPPEPALRAALQALGRPVPEHSDEVVAPCPGGAKAW
+                     TQRVAAGAGPASLSALAPLAAGAVVVDTPEAYAYRRGADLIVADATGDQLHLAFSTGCA
+                     D"
+     gene            complement(10282..10737)
+                     /locus_tag="B170_RS0101265"
+     CDS             complement(10282..10737)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018743155.1"
+                     /locus_tag="B170_RS0101265"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="winged helix-turn-helix transcriptional
+                     regulator"
+                     /protein_id="WP_019870472.1"
+                     /transl_table=11
+                     /translation="MAVRERVLRRLDGVGPVLSCADLAELRAMLFPEPSVTEERGTGPP
+                     NAPVRYGELVVDPPGHLVTWRGHPLALTRTERRLLTRLVTPPVRLWSYERLFAAVWGGA
+                     YLGDTAILHSAIKRLRRKLRLLSGGPRVLTVRGVGYRLVLGSDDAGG"
+     gene            10994..15346
+                     /locus_tag="B170_RS0101270"
+     CDS             10994..15346
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional
+                     (rule-based-clusters) Peptidase_S8"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018586893.1"
+                     /locus_tag="B170_RS0101270"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="S8 family serine peptidase"
+                     /protein_id="WP_027654908.1"
+                     /sec_met_domain="Peptidase_S8 (E-value: 2.1e-40, bitscore:
+                     133.4, seeds: 43, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MFVRPSARSRLGRLAVAFGALVLGLSAQPALAASPPGASERATVA
+                     SELLETSDSTSFLVYLRETAPLASTATLQAPDDRARAVHQLLTNTADRTQADLLRLLEA
+                     RKAEHTSYWIANAIQVHGDRALIDEIANRPEVERIEPIRSRQLIEPTPAEAEARTDAIE
+                     WGVAEIGAPQVWDEFGDRGEGIVIANIDTGVQYDHPALVNSYRGNLGGGSFDHAYNWFD
+                     PTGICSDSEPCDNNDHGTHTMGTMVGDDGADNQIGVAPGARWIAAKGCEVSTCSDAALL
+                     ASGQWILAPTDANGENPRPELRPDIVNNSWGGGGNDPWYQQTVDAWRAAGILPVFSNGN
+                     SGPGCGTAGSPGDYESSYAVGAYGSNGAIAGFSSRGSGTDLIKPNIAAPGVAVRSSVPG
+                     GGYAAFNGTSMAAPHVAATAALIWSVAPSLRGDLPATEALLDRTARDVDDTTCGGTAAD
+                     NNVFGEGRLDAYAAVNEAPRGPVGRVTGTVTAAEDGEPLAGVTIDDGTRDTTTGADGRY
+                     SLTVPSGETTVTATLYGYESQSDTFTVDEGGAVTRDFALVESPMVTVSGQVTDGSGQGW
+                     PLYAKINIAGKPGDPVFTDPVTGEWSATVAGDNTYSITATPQYPDYRTVTREVPVGSDA
+                     TTVDMAVQIAESCTAAGYNASYDDPLLTEDFADSTTPEGWSVVNRTDEGGWTFEDLGGR
+                     GNLTGGSGGFAIIDSDDLGLGNSQDTDLVSPTVDLSGTPAPVLRFNTDWRAIGVTDSAD
+                     IDVTTDGGATWTNVWHQTSSLRGPRVEEVPLTPAAGASEVQVRFRFAGSFDWWWQVDDV
+                     MLANRNCTPAPGGLVVGTTSDQNTDAALNGVAVTSVDQPEDNAVSAGTDDPAESKGFYW
+                     LFSSLTGTHPFTAERAPYPVATQDVTVVANDVRRADFALAAGKLTVTPTEVESHQPYGS
+                     TRSTQVTVKNTGTAPADVEVLERSGAFDLLAAPGAPLREVTMKGISTARTGTTFGGAPA
+                     EAEESTDNSWTRVADLPSNAFDNSAAILDGKVYSIGGGSATGNERATWAYDPGTDSWSE
+                     LPPLPTSRSKPGVAAVGGKIYVTGGWGNEIDPDATVNVFDPASETWSTLDGVTNPAPTA
+                     APGTAVVDGKIYLVGGCANSSCTATDDTVVFDPRAATFATVAPYPQQVSWMSCGGVGTQ
+                     MYCAGGSGADTAAHKYDPATDTWTPIADMPLDLWGSSSAAAGGMLVLAGGITNGSTTVT
+                     NQTIAYDPAAGTWQDLPNAEFARYRGAGACGAYRIGGSFDPFLGTAEVEQLSGLELCVQ
+                     ETELPWLSTAPASFTLEPGESRKVQLTLTATAEAGVEQPGRYSGELAFAADVPYPTTPV
+                     KVEMNVSPPKSWGKLQGTVTGVTCGGETVGVPATVRVNATGSGAGYTLTADNSGTYTVW
+                     LPKGRYDVIVAKDGWVPEFDRTKVEAGFVATLDFSLEPSSDCTKASGI"
+     gene            complement(15481..16482)
+                     /gene="sbnB"
+                     /locus_tag="B170_RS0101275"
+     CDS             complement(15481..16482)
+                     /codon_start=1
+                     /gene="sbnB"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1158:ornithine cyclodeaminase (Score: 355.7; E-value:
+                     2.9e-108)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_020215520.1"
+                     /locus_tag="B170_RS0101275"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="2,3-diaminopropionate biosynthesis protein SbnB"
+                     /protein_id="WP_027654909.1"
+                     /transl_table=11
+                     /translation="MLMLGKSEVNLVLDGAESDVLAAVREAYELHALGRTAVPHSVFLR
+                     FPADLQNRIIALPAYLGTRTPVAGVKWVASFPGNLRLGQDRASASMILNCPRTGFPEVF
+                     MEAAAISAQRTAASAALAAVTLGSSHPESGVSQIGCGPIGFEVLRYLQLVKPELDQITL
+                     YDLDRARAESFAARVNARWPRLKVEVAARVEEALAAHPLVTLATTASVPHLAGEHLRPG
+                     ALVLHLSLRDLSAETIQTSINIVDDADHVCRAATSLHLAEQQSGGRDFIAASLGELLVA
+                     GDRYSRDDSSLTVFSPFGLGCLDLAVAAMVRRKAEERGLGTTLPGFMSVGEA"
+     gene            complement(16476..17498)
+                     /gene="sbnA"
+                     /locus_tag="B170_RS0101280"
+     CDS             complement(16476..17498)
+                     /codon_start=1
+                     /gene="sbnA"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1081:cysteine synthase (Score: 377.3; E-value:
+                     7.7e-115)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018800097.1"
+                     /locus_tag="B170_RS0101280"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="2,3-diaminopropionate biosynthesis protein SbnA"
+                     /protein_id="WP_027654910.1"
+                     /transl_table=11
+                     /translation="MIGPVDQGGSSVSGVLSTIGATPIVELTKLDPNSSVRIFAKLESH
+                     NPGGSIKDRSALEMLQERIRDGRLVPGKSTVIESSSGNLGIGLAQICAYHGIRFICVVD
+                     PRTNRQNIAIMRAYGAEVEVVTDVDPVSGEYLPVRIRRVRELVESITHAYCPNQYANPL
+                     NPRAHHSTVREILDALPTLDFVFCATSSCGTLRGCAEYLRRHQLPAQVVAVDALGSAIF
+                     GPPVGGRLIPGHGASVRPSLYADGLADQVIRVHDLDAIVGCRRLAAREAILAGGSSGAV
+                     VSALDVVRDRIPPGSTCALVFPDRGERYLDTIYNDDWVAMHFGDVAHLWKEPEMEAMSC
+                     "
+     gene            complement(17495..18778)
+                     /locus_tag="B170_RS0101285"
+     CDS             complement(17495..18778)
+                     /codon_start=1
+                     /gene_functions="transport (smcogs) SMCOG1020:major
+                     facilitator transporter (Score: 341.3; E-value: 1.2e-103)"
+                     /gene_kind="transport"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018824930.1"
+                     /locus_tag="B170_RS0101285"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="MFS transporter"
+                     /protein_id="WP_027654911.1"
+                     /transl_table=11
+                     /translation="MTTTAQPRPGAPVSKLRHNRDFLLLWSGTAVSLVGLTVSTVAYPL
+                     LILAATGSKAAAGVVGFFSLLPALLFQLPAGVLVDRWDRRRLMIWCDVVRAAGAASVVL
+                     ALALDELTVAHVVVVGFVEGTMSVFFNLAAHAAVPNIVHPDHLSAALSRNEARSRAATM
+                     LGTTLGGVLFGLSRIMPFLLHAVTHVISLVTLLFIRADFQRRQPARTRTTGLLAEVGEG
+                     MRWLWRQPFLRTAALLVAGSNLLFRALFLVVVVMATDVGASPAAVGVLLGVAGAGGVLG
+                     SLAAGWCQRWVPLPALVVGANWIWALLMGAIVVADNLYLLTAAYAGMWFVGPLWNVAVA
+                     THQLRITPDRLRGRVLGAMGLLASGALPIGALIGGLLLEWFDARAAALVLAGWMGLLAL
+                     VATFAPALRRPVVPVETPTVPDAEPTVR"
+     gene            18991..19971
+                     /locus_tag="B170_RS0101290"
+     CDS             18991..19971
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1046:Dioxygenase TauD/TfdA (Score: 416.3; E-value:
+                     1e-126)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018791342.1"
+                     /locus_tag="B170_RS0101290"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="TauD/TfdA family dioxygenase"
+                     /protein_id="WP_027654912.1"
+                     /transl_table=11
+                     /translation="MKTSPLPQPLRTPSDAEPALPYVVTAPAPETTATSFLATSRDQVR
+                     QRLREHGAVLLRGFDVDGVDGFDQIVRSVSGTPLSYAERSSPRSTIKGRVYTSTDYPPG
+                     EEIFLHNENSYQATWPMTLFFYCITPPETLGATPLADTRQVLRSIDPAVRDEFARRGWT
+                     VVRNFSDGLGVPWQQAFNTDKPAEVEAYCAGNGVEVEWVGRNGLRTTGRRQAVHRHPAT
+                     GAEVWFNHLTFFHVTTLAEEMCAGLREMFDEVDLPTNTYYGDGERVPDEVVAHLRDCYR
+                     AAQRRFDWQRDDVLLVDNMLAAHGREPFTGPRKIAVAMAEPFRTA"
+     gene            20001..26378
+                     /locus_tag="B170_RS0101295"
+     CDS             20001..26378
+                     /NRPS_PKS="Domain: Condensation_LCL (7-305). E-value:
+                     4.5e-97. Score: 316.4. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_Condensation_LCL.1"
+                     /NRPS_PKS="Domain: AMP-binding (469-866). E-value: 1e-107.
+                     Score: 352.0. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_AMP-binding.1"
+                     /NRPS_PKS="Domain: PCP (976-1043). E-value: 1.6e-21. Score:
+                     68.1. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_PCP.1"
+                     /NRPS_PKS="Domain: Condensation_LCL (1059-1351). E-value:
+                     1.6e-111. Score: 363.9. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_Condensation_LCL.2"
+                     /NRPS_PKS="Domain: AMP-binding (1525-1924). E-value:
+                     1.8e-112. Score: 367.7. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_AMP-binding.2"
+                     /NRPS_PKS="Domain: PCP (2032-2096). E-value: 3.8e-28.
+                     Score: 89.3. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101295_PCP.2"
+                     /NRPS_PKS="type: NRPS"
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     AMP-binding"
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     Condensation"
+                     /gene_functions="biosynthetic-additional
+                     (rule-based-clusters) PP-binding"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1127:condensation domain-containing protein (Score:
+                     433.3; E-value: 2e-131)"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019030251.1"
+                     /locus_tag="B170_RS0101295"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="non-ribosomal peptide synthetase"
+                     /protein_id="WP_027654913.1"
+                     /sec_met_domain="Condensation (E-value: 1e-75, bitscore:
+                     249.1, seeds: 42, tool: rule-based-clusters)"
+                     /sec_met_domain="AMP-binding (E-value: 2.7e-119, bitscore:
+                     393.0, seeds: 400, tool: rule-based-clusters)"
+                     /sec_met_domain="PP-binding (E-value: 1.1e-16, bitscore:
+                     55.7, seeds: 164, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MATGDGGISLSFTQEQLWFLDQLRSGAATEYLLHEAFQVRGPVDV
+                     DALATAFTRVSERHEVLRTRYETVDDTALQVVDDPVAVPVEVIDLTAVADADTELQRIR
+                     LDQRTPIDLRTEPPWRVTLVRLDRSDSVLLITVHHIAFDGWSWGVLARELGELYGELTG
+                     GTAAGLAEPPVQYGDYADWQREWWASAEEVRSKQLGYWRNTLAGLAPLDLPTDRPRPSH
+                     WNSAGDNFDFTVPVAVANEVTLLARAAGATPFMVYLSAFQLLLGRYAGQRDVAVGVSLA
+                     GRNDVQLEPLIGAFVNTIVLRTNLAGAPSFAELLARVRETTLDAYGHQDVPFDRVVHDL
+                     APDRDPSRNPVFQVGFAMHNAERVRLSLPGLEVTKLPAAWTNSAFDLSLHLSERPDGTV
+                     HARLMYVTALFDRARIERMAANYLRLLSRALAEPTRPVTRLSLVAEPELHQLHEWNHTN
+                     APTSRLLLPELFLAQARRTPDAVAVAGADGDLTYAELAARVTALTSYLLSRGVTTERPV
+                     GVSLHPGADLVTTLLAVLAAGGVYVPLPPEHPAERLAMMVADAGVELIVTNSALRDQLP
+                     TAQLIALDSDQALIASAPTAVPPVIHPGNAAYVMYTSGSTGRPKGVTITHGGIRNRVLW
+                     SVHRYGMAPGDRVLQKTTIGFDASVWEFLSPLVSGGAVVTPPAGVHRDPAAMVEAVATH
+                     GVTVLQLVPSVLRLLVEVPHLAGCSALRLLCSAGEPLPVALCERLLDTLDVEIMNTYGP
+                     TECAIDSTAAWFRRGEQGETVPIGTPLQNMRAYVVDASDELVPLGVPGELCVSGVGLAR
+                     GYVGRGDLTAERFRPNPYARVPGERWYRTGDLVRWRDDGVLEFIGRVDEQVKIRGVRVE
+                     PAEVEAAVRTHPDVGEAVVTARRGELGDLELVAYTVPANGTPVSLETLAAHLAEVLPAP
+                     MIPSNHVGLDVLPLTSNGKVDRAALPEPGTLPASPTDEHVSPRTPTERAVAALMEEVLG
+                     IERVGAEDDFFTYGHSLLAIRFVLRLRRTFDIELTVGDLFAARTVAALAAHIDVAAADG
+                     PVIPPVPRDGVLPLSFAQQRMWFLDQLEPGSVEYLVPLALRLRGPLDTEALRRAMDAVA
+                     ARHEMLRTRYVSAGDSPVQVIDPPGPVWFEVVDLTGASDAAVQALVDRSCSQPFDLSQE
+                     RPLRVTVVRRGAEDHLVAVSLHHVAFDAWSMDLFMRDLRTAYAAIRGGADVPLAPPTVQ
+                     YADFAAWQRSREAELGDQLDYWRERLTGLDPVELPTDRPRPAVRDPRGGTVSVDVPDEL
+                     AAGLHELAGRHGATLFMTLLAGFQVLLARYTGRTDLAVGTPVAGRTRPETEELLGFFVN
+                     TLVLRHDLSGNPTFVELLDQVRRSSLDAFANQDVPFEHLVDALAANRDMSRNPLFQIMF
+                     ELAHLDQFPTTLGEAAIEPVHAGVPVAKFDLTLTVKQRSRGRLRCTFEYATGLFDRSTV
+                     ERLAGHYLNLLTAIVGSPTARLNSLPVLSDGERDVLVREWPDPASTRLPLLDPVDERHR
+                     TVPELFERQAKRTPDAVAMVFGEQEVTYRELNERANQLAHHLRSLGVGPEVVVASCLER
+                     GPDAVVVLLAALKSGGVYVPFDPDHPTERLDFMLTDAAAHLVVTTRAAAQRLAGHRVVT
+                     VDDDQLATAPATDLESPPRPHNLAYVIYTSGSTGRPKGVMIEHRSYVHHCRVISDAYGI
+                     GPDDRVVLLSALTFDVAMDQIAATLLAGATVVVSDPVFWTPSELPARLAEHGVTIMEIT
+                     PAYYRELLEADVDRLSALRLMNVGSDVVTVADARRWAATGLPARFLCNYGPTEATVTCV
+                     LHPVAGLDADERDEAAMPIGRPVAGTRGYVLDAGLMPVPVGVPGELCLGGIRLARGYLN
+                     RPELTADRFVPDPHSGDPGARLYRTGDLVRWRPDGTIEFIGRIDQQVKVRGFRIELGEI
+                     EAALAEHPAVHASVVTVREVGPGEKQLVGYVVPRDRSRPDIAELRAHLRDRVPEYMVPA
+                     RWVTLDALPLTPSKKVDRKALPAPSAPDGERTLTSPRDETEAALAGIWAEVLDVEQVGI
+                     HDNFFELGGHSLLATRVLARIRTAFAVDLPLRRLFEATTVAELAIEVGAAVEADVALLT
+                     DTEIEALLAEEEGAR"
+     aSDomain        20022..20915
+                     /aSDomain="Condensation"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_Condensation_LCL.
+                     1"
+                     /domain_subtype="Condensation_LCL"
+                     /evalue="4.50E-97"
+                     /label="B170_RS0101295_Condensation_LCL.1"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="305"
+                     /protein_start="7"
+                     /score="316.4"
+                     /tool="antismash"
+                     /translation="ISLSFTQEQLWFLDQLRSGAATEYLLHEAFQVRGPVDVDALATAF
+                     TRVSERHEVLRTRYETVDDTALQVVDDPVAVPVEVIDLTAVADADTELQRIRLDQRTPI
+                     DLRTEPPWRVTLVRLDRSDSVLLITVHHIAFDGWSWGVLARELGELYGELTGGTAAGLA
+                     EPPVQYGDYADWQREWWASAEEVRSKQLGYWRNTLAGLAPLDLPTDRPRPSHWNSAGDN
+                     FDFTVPVAVANEVTLLARAAGATPFMVYLSAFQLLLGRYAGQRDVAVGVSLAGRNDVQL
+                     EPLIGAFVNTIVLRTNL"
+     aSModule        20022..23129
+                     /complete
+                     /domains="nrpspksdomains_B170_RS0101295_Condensation_LCL.1"
+                     /domains="nrpspksdomains_B170_RS0101295_AMP-binding.1"
+                     /domains="nrpspksdomains_B170_RS0101295_PCP.1"
+                     /locus_tags="B170_RS0101295"
+                     /monomer_pairings="X -> X"
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       20031..20063
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0001"
+                     /evalue="1.40E-01"
+                     /label="C1_LCL_004-017"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="21"
+                     /protein_start="10"
+                     /score="5.5"
+                     /tool="antismash"
+                     /translation="SFTQEQLWFLD"
+     CDS_motif       20091..20198
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0002"
+                     /evalue="4.20E-12"
+                     /label="C2_LCL_024-062"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="66"
+                     /protein_start="30"
+                     /score="38.5"
+                     /tool="antismash"
+                     /translation="YLLHEAFQVRGPVDVDALATAFTRVSERHEVLRTRY"
+     CDS_motif       20409..20474
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0003"
+                     /evalue="2.20E-11"
+                     /label="C3_LCL_132-143"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="158"
+                     /protein_start="136"
+                     /score="36.1"
+                     /tool="antismash"
+                     /translation="VHHIAFDGWSWGVLARELGELY"
+     CDS_motif       20523..20558
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0004"
+                     /evalue="2.90E-03"
+                     /label="C4_LCL_164-176"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="186"
+                     /protein_start="174"
+                     /score="10.5"
+                     /tool="antismash"
+                     /translation="QYGDYADWQREW"
+     CDS_motif       20817..20906
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0005"
+                     /evalue="8.50E-11"
+                     /label="C5_LCL_267-296"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="302"
+                     /protein_start="272"
+                     /score="34.3"
+                     /tool="antismash"
+                     /translation="DVAVGVSLAGRNDVQLEPLIGAFVNTIVLR"
+     CDS_motif       20955..21074
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0006"
+                     /evalue="9.20E-22"
+                     /label="C67_LCL_14fromHMM"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="358"
+                     /protein_start="318"
+                     /score="69.5"
+                     /tool="antismash"
+                     /translation="RETTLDAYGHQDVPFDRVVHDLAPDRDPSRNPVFQVGFAM"
+     aSDomain        21408..22598
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_AMP-binding.1"
+                     /evalue="1.00E-107"
+                     /label="B170_RS0101295_AMP-binding.1"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="866"
+                     /protein_start="469"
+                     /score="352.0"
+                     /specificity="consensus: X"
+                     /tool="antismash"
+                     /translation="FLAQARRTPDAVAVAGADGDLTYAELAARVTALTSYLLSRGVTTE
+                     RPVGVSLHPGADLVTTLLAVLAAGGVYVPLPPEHPAERLAMMVADAGVELIVTNSALRD
+                     QLPTAQLIALDSDQALIASAPTAVPPVIHPGNAAYVMYTSGSTGRPKGVTITHGGIRNR
+                     VLWSVHRYGMAPGDRVLQKTTIGFDASVWEFLSPLVSGGAVVTPPAGVHRDPAAMVEAV
+                     ATHGVTVLQLVPSVLRLLVEVPHLAGCSALRLLCSAGEPLPVALCERLLDTLDVEIMNT
+                     YGPTECAIDSTAAWFRRGEQGETVPIGTPLQNMRAYVVDASDELVPLGVPGELCVSGVG
+                     LARGYVGRGDLTAERFRPNPYARVPGERWYRTGDLVRWRDDGVLEFIGRVDEQVKIR"
+     CDS_motif       21594..21632
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0007"
+                     /evalue="3.60E-03"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="544"
+                     /protein_start="531"
+                     /score="11.0"
+                     /tool="antismash"
+                     /translation="LAVLAAGGVYVPL"
+     CDS_motif       21819..21878
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0008"
+                     /evalue="7.00E-10"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="626"
+                     /protein_start="606"
+                     /score="30.8"
+                     /tool="antismash"
+                     /translation="AYVMYTSGSTGRPKGVTITH"
+     CDS_motif       22251..22274
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0009"
+                     /evalue="6.90E-02"
+                     /label="NRPS-A_a5"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="758"
+                     /protein_start="750"
+                     /score="6.4"
+                     /tool="antismash"
+                     /translation="YGPTECAI"
+     CDS_motif       22386..22475
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0010"
+                     /evalue="2.80E-15"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="825"
+                     /protein_start="795"
+                     /score="48.4"
+                     /tool="antismash"
+                     /translation="PLGVPGELCVSGVGLARGYVGRGDLTAERF"
+     CDS_motif       22563..22628
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0011"
+                     /evalue="3.40E-10"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="876"
+                     /protein_start="854"
+                     /score="32.0"
+                     /tool="antismash"
+                     /translation="FIGRVDEQVKIRGVRVEPAEVE"
+     aSDomain        22929..23129
+                     /aSDomain="PCP"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_PCP.1"
+                     /evalue="1.60E-21"
+                     /label="B170_RS0101295_PCP.1"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1043"
+                     /protein_start="976"
+                     /score="68.1"
+                     /tool="antismash"
+                     /translation="ERAVAALMEEVLGIERVGAEDDFFTYGHSLLAIRFVLRLRRTFDI
+                     ELTVGDLFAARTVAALAAHIDV"
+     aSDomain        23178..24053
+                     /aSDomain="Condensation"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_Condensation_LCL.
+                     2"
+                     /domain_subtype="Condensation_LCL"
+                     /evalue="1.60E-111"
+                     /label="B170_RS0101295_Condensation_LCL.2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1351"
+                     /protein_start="1059"
+                     /score="363.9"
+                     /tool="antismash"
+                     /translation="LPLSFAQQRMWFLDQLEPGSVEYLVPLALRLRGPLDTEALRRAMD
+                     AVAARHEMLRTRYVSAGDSPVQVIDPPGPVWFEVVDLTGASDAAVQALVDRSCSQPFDL
+                     SQERPLRVTVVRRGAEDHLVAVSLHHVAFDAWSMDLFMRDLRTAYAAIRGGADVPLAPP
+                     TVQYADFAAWQRSREAELGDQLDYWRERLTGLDPVELPTDRPRPAVRDPRGGTVSVDVP
+                     DELAAGLHELAGRHGATLFMTLLAGFQVLLARYTGRTDLAVGTPVAGRTRPETEELLGF
+                     FVNTLVLRHDL"
+     aSModule        23178..26288
+                     /complete
+                     /domains="nrpspksdomains_B170_RS0101295_Condensation_LCL.2"
+                     /domains="nrpspksdomains_B170_RS0101295_AMP-binding.2"
+                     /domains="nrpspksdomains_B170_RS0101295_PCP.2"
+                     /locus_tags="B170_RS0101295"
+                     /monomer_pairings="X -> X"
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       23187..23219
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0012"
+                     /evalue="2.40E-03"
+                     /label="C1_LCL_004-017"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1073"
+                     /protein_start="1062"
+                     /score="10.5"
+                     /tool="antismash"
+                     /translation="SFAQQRMWFLD"
+     CDS_motif       23244..23354
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0013"
+                     /evalue="1.40E-17"
+                     /label="C2_LCL_024-062"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1118"
+                     /protein_start="1081"
+                     /score="56.0"
+                     /tool="antismash"
+                     /translation="YLVPLALRLRGPLDTEALRRAMDAVAARHEMLRTRYV"
+     CDS_motif       23559..23624
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0014"
+                     /evalue="3.80E-09"
+                     /label="C3_LCL_132-143"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1208"
+                     /protein_start="1186"
+                     /score="29.1"
+                     /tool="antismash"
+                     /translation="LHHVAFDAWSMDLFMRDLRTAY"
+     CDS_motif       23673..23708
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0015"
+                     /evalue="2.70E-05"
+                     /label="C4_LCL_164-176"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1236"
+                     /protein_start="1224"
+                     /score="16.7"
+                     /tool="antismash"
+                     /translation="QYADFAAWQRSR"
+     CDS_motif       23955..24044
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0016"
+                     /evalue="6.20E-17"
+                     /label="C5_LCL_267-296"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1348"
+                     /protein_start="1318"
+                     /score="53.9"
+                     /tool="antismash"
+                     /translation="DLAVGTPVAGRTRPETEELLGFFVNTLVLR"
+     protocluster    24035..61782
+                     /aStool="rule-based-clusters"
+                     /contig_edge="False"
+                     /core_location="[280465:298213]"
+                     /cutoff="20000"
+                     /detection_rule="((LANC_like and (Lant_dehydr_N or
+                     Lant_dehydr_C) or cds(LANC_like and (Pkinase or DUF4135)))
+                     and not (YcaO or TIGR03882))"
+                     /neighbourhood="10000"
+                     /product="lanthipeptide"
+                     /protocluster_number="2"
+                     /tool="antismash"
+     proto_core      34035..51782
+                     /aStool="rule-based-clusters"
+                     /tool="antismash"
+                     /cutoff="20000"
+                     /detection_rule="((LANC_like and (Lant_dehydr_N or
+                     Lant_dehydr_C) or cds(LANC_like and (Pkinase or DUF4135)))
+                     and not (YcaO or TIGR03882))"
+                     /neighbourhood="10000"
+                     /product="lanthipeptide"
+                     /protocluster_number="2"
+     CDS_motif       24093..24206
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0017"
+                     /evalue="9.50E-21"
+                     /label="C67_LCL_14fromHMM"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1402"
+                     /protein_start="1364"
+                     /score="66.2"
+                     /tool="antismash"
+                     /translation="RRSSLDAFANQDVPFEHLVDALAANRDMSRNPLFQIMF"
+     aSDomain        24576..25772
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_AMP-binding.2"
+                     /evalue="1.80E-112"
+                     /label="B170_RS0101295_AMP-binding.2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1924"
+                     /protein_start="1525"
+                     /score="367.7"
+                     /specificity="consensus: X"
+                     /tool="antismash"
+                     /translation="FERQAKRTPDAVAMVFGEQEVTYRELNERANQLAHHLRSLGVGPE
+                     VVVASCLERGPDAVVVLLAALKSGGVYVPFDPDHPTERLDFMLTDAAAHLVVTTRAAAQ
+                     RLAGHRVVTVDDDQLATAPATDLESPPRPHNLAYVIYTSGSTGRPKGVMIEHRSYVHHC
+                     RVISDAYGIGPDDRVVLLSALTFDVAMDQIAATLLAGATVVVSDPVFWTPSELPARLAE
+                     HGVTIMEITPAYYRELLEADVDRLSALRLMNVGSDVVTVADARRWAATGLPARFLCNYG
+                     PTEATVTCVLHPVAGLDADERDEAAMPIGRPVAGTRGYVLDAGLMPVPVGVPGELCLGG
+                     IRLARGYLNRPELTADRFVPDPHSGDPGARLYRTGDLVRWRPDGTIEFIGRIDQQVKVR
+                     "
+     CDS_motif       24762..24803
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0018"
+                     /evalue="1.90E-03"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1601"
+                     /protein_start="1587"
+                     /score="11.8"
+                     /tool="antismash"
+                     /translation="LAALKSGGVYVPFD"
+     CDS_motif       24984..25043
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0019"
+                     /evalue="1.90E-11"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1681"
+                     /protein_start="1661"
+                     /score="35.6"
+                     /tool="antismash"
+                     /translation="AYVIYTSGSTGRPKGVMIEH"
+     CDS_motif       25158..25190
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0020"
+                     /evalue="4.20E+01"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1730"
+                     /protein_start="1719"
+                     /score="-1.2"
+                     /tool="antismash"
+                     /translation="ATLLAGATVVV"
+     misc_feature    25287..25289
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     CDS_motif       25410..25442
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0021"
+                     /evalue="3.80E-03"
+                     /label="NRPS-A_a5"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1814"
+                     /protein_start="1803"
+                     /score="9.9"
+                     /tool="antismash"
+                     /translation="NYGPTEATVTC"
+     CDS_motif       25560..25649
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0022"
+                     /evalue="2.20E-17"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1883"
+                     /protein_start="1853"
+                     /score="55.1"
+                     /tool="antismash"
+                     /translation="PVGVPGELCLGGIRLARGYLNRPELTADRF"
+     CDS_motif       25737..25802
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0023"
+                     /evalue="1.10E-11"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1934"
+                     /protein_start="1912"
+                     /score="36.7"
+                     /tool="antismash"
+                     /translation="FIGRIDQQVKVRGFRIELGEIE"
+     CDS_motif       25839..25895
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101295_0024"
+                     /evalue="7.40E+00"
+                     /label="C5_LCL_267-296"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="1965"
+                     /protein_start="1946"
+                     /score="-0.7"
+                     /tool="antismash"
+                     /translation="VVTVREVGPGEKQLVGYVV"
+     aSDomain        26097..26288
+                     /aSDomain="PCP"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101295_PCP.2"
+                     /evalue="3.80E-28"
+                     /label="B170_RS0101295_PCP.2"
+                     /locus_tag="B170_RS0101295"
+                     /protein_end="2096"
+                     /protein_start="2032"
+                     /score="89.3"
+                     /tool="antismash"
+                     /translation="EAALAGIWAEVLDVEQVGIHDNFFELGGHSLLATRVLARIRTAFA
+                     VDLPLRRLFEATTVAELAI"
+     gene            26375..33427
+                     /locus_tag="B170_RS0101300"
+     CDS             26375..33427
+                     /NRPS_PKS="Domain: Condensation_LCL (37-328). E-value:
+                     1.5e-100. Score: 327.8. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_Condensation_LCL.1"
+                     /NRPS_PKS="Domain: AMP-binding (494-869). E-value:
+                     3.5e-117. Score: 383.2. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_AMP-binding.1"
+                     /NRPS_PKS="Domain: PCP (970-1034). E-value: 5e-18. Score:
+                     56.9. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_PCP.1"
+                     /NRPS_PKS="Domain: Condensation_DCL (1063-1362). E-value:
+                     3.4e-53. Score: 172.4. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_Condensation_DCL.1"
+                     /NRPS_PKS="Domain: AMP-binding (1513-1896). E-value:
+                     1.6e-105. Score: 344.8. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_AMP-binding.2"
+                     /NRPS_PKS="Domain: PCP (2005-2073). E-value: 9.5e-24.
+                     Score: 75.2. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_PCP.2"
+                     /NRPS_PKS="Domain: Thioesterase (2090-2332). E-value:
+                     3.2e-32. Score: 104.5. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101300_Thioesterase.1"
+                     /NRPS_PKS="type: NRPS"
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     AMP-binding"
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     Condensation"
+                     /gene_functions="biosynthetic-additional
+                     (rule-based-clusters) PP-binding"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1127:condensation domain-containing protein (Score:
+                     185; E-value: 4.7e-56)"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019532350.1"
+                     /locus_tag="B170_RS0101300"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="non-ribosomal peptide synthetase"
+                     /protein_id="WP_027654914.1"
+                     /sec_met_domain="Condensation (E-value: 2e-67, bitscore:
+                     222.0, seeds: 42, tool: rule-based-clusters)"
+                     /sec_met_domain="AMP-binding (E-value: 3.5e-116, bitscore:
+                     382.7, seeds: 400, tool: rule-based-clusters)"
+                     /sec_met_domain="PP-binding (E-value: 5.2e-15, bitscore:
+                     50.3, seeds: 164, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MTRTIDRAALRTALLRKRLSGQAGASPEGAPARVSRDGHLPLSSA
+                     QRRLWILDRLRPGSPEYLMTTALRIRGQLCRPALQTALDGLVARHEVLRTRYVDVNGEP
+                     AQVIDDPTPVTLHRRDGLDALDAVLSTELPNIDLAAGPVFRPTLVFLGEDDHALVLTLH
+                     HIAGDAWSEEVMVRELGERYTAASAGREPEFAELPVQYVDFAVWQRDRSSGQALAGDLA
+                     YWRERLAGLNPLELPTDRPRPPVRDGAGALVQVDVSAPIATRFGRLARDHGVTPFTAFL
+                     AAFKVLLARYTGQTDIAVGTPVAGRARPETQDLVGLFLNTLALRTDLSGSPSFRDVLDR
+                     VRETVLDGQSHQELPFEQIVDELAPVRDPSRSPLFSTMFLMTDRVTEAPSFGDLTVTAL
+                     PVGEVAAKFDLTLSVIERANGTLGVGVNYATALFEPETMSRLAGHYAHLLQSIVSDPDT
+                     PVRQLALLSAAERKQVVTSWNDTAVDQPSATLPGLIADQVRRTPQREAVRFDGSSLTYA
+                     ELAARSNQLAHHLRSLGVGPESIVGVCLPRSLDLVVALLAVQKAGGAYLPLDPDHPAER
+                     LRYLREDSGATAMIDTDTFAALAGYPTVDPGVAVRPEHPAYVIYTSGSTGRPKGVVVEH
+                     RGIVNRLRWMQHAYGLDATDRVLQKTPASFDVSVWELFWPLITGATLVVARPDGHRDPA
+                     YLARLIDSERITTLHFVPSMLRAFLTEPFAGLPSLRRVICSGEALTSDLVAAVHDRIGC
+                     ELHNLYGPTEASVDVTAARCRPGEPVTIGTPIANTRAYILDQDLQPVPVGVPGELMLAG
+                     VQLARGYLHRPVLTADRFVPDPFTPGGRLYRTGDLARHRPDGQIDYLGRLDHQVKINGI
+                     RVELGEVEHALTENPAVRAAAVTVDDGQLVAHLVGDVDLATLPDFLRAQLPEAMVPAHW
+                     LTYPALPLTTSGKVDRNALSAPDRNRTTTGGYVAPRTPLEHMIAGAIADALDIDNVGIE
+                     DRFFAIGGDSMRAIRVVGALRAAGVELAVHDLFTHQTVAGLAGLAGAATTEDTLVERFA
+                     QLSEADRQLLPNGLVDAYPLAETQAGMVYEMLAAPDRTVYLNVSCYRVHDELPFDLNTL
+                     RAATAILVGRHEILRTSFDLSTYSETMQLVHATAELPVAHTNLTGLASQAQRAAVDEWL
+                     VAERGRPFDIAQPPLLRYHVHEISADEWWLTHTECHAILDGWSHTSVVNELVSIYRRLR
+                     TGHQPDLAPPPEVRFADFVAAEKRALATSTDHGFWATAIGRYDKLELPDGWASERRDDK
+                     ATIIDVPWADLAPGLRRLAAAAGASMKSVLHAAHLKAISIVTGRRQFFGGLVCNGRPEE
+                     LRGDEVFGMYLNTVPFAADVTAATWRDFVADVFAGEAELWPHRRYPMPAMRREWSPGSP
+                     LIDVAFGYLDFHVLDWEADTVGMIDDFSPSELPLEVWTFPGLLRLGGRPSRIGRENLEL
+                     LGRTYRRVLEAMSLDPDASTDVTLAPVDHDHALHLGGDSTRDYPTEELVHQLVEHQATA
+                     APDAVAVRQADHTLTYAELDAAANRLAHRLRALGAGPGTLVGLFLTRGPDLVVGMLATL
+                     RAGAAFLPLDPAYPAERLRYLITDAEVGLLLTEPDLPLPTGVTATVEIVADYPDLPSAR
+                     PAVAPSLEDLAYVIYTSGSTGRPKGVGVPHRGALNLRHAQREHLDVRPGDRVLQFASPS
+                     FDASVWELLMSLTNGAELVLPPRGTDPGDLRQQAGLVTHMTLPPSLLERLSPEDFPHLR
+                     VLVSAGEACPVDQVARWSGQARFINAYGPTETSVCATLTEVAPTVTAPPSIGSTIGGVS
+                     AYVLDPDLRPLSVGVRGELYVGGAGLARGYLGRPGLTAERFVPNPYGPVGARMYRTGDV
+                     VSRNPDGTIQYHGRTDHQVKVRGHRIELGEIEAALSGHPAVASAVAAVHRSGTTDAALV
+                     AYTRAVDVPPTPAELREYLRACLPGHLLPTHWIAVEDFALTPAGKVDRAVLPGPDGSRP
+                     ELDSAYVAPSDETERALAAAWREALGVDRVGVHDDFFELGGHSLAMMRVIATLRARDGI
+                     ELTFRSFITHRTIAALATTVTDEPAGKAMMWLRRSGSATPLFCVHPGGGSAHWYLRLVP
+                     HLAPDIPVAAFEWPATHNEVPTAEQMAERYLAELRAAQPRGPYRLFSWCGGSSIATEMA
+                     RRLTDAGETVTFMLLDPGLDAHTRAEGWQELNYIRRLEALVEQIVADPRADTAERRAEI
+                     LALLEHLVDDVDPAVGITLPARGVGDVWPRSVRIWREVMELDLAYRHTPYSGQLHLIVS
+                     DELERGEHEVAAGQAFDGYVARWRELTAGGVTVHRVPGDHFGVMKPPHVADLGALLSRL
+                     TDRS"
+     aSDomain        26486..27358
+                     /aSDomain="Condensation"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_Condensation_LCL.
+                     1"
+                     /domain_subtype="Condensation_LCL"
+                     /evalue="1.50E-100"
+                     /label="B170_RS0101300_Condensation_LCL.1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="328"
+                     /protein_start="37"
+                     /score="327.8"
+                     /tool="antismash"
+                     /translation="GHLPLSSAQRRLWILDRLRPGSPEYLMTTALRIRGQLCRPALQTA
+                     LDGLVARHEVLRTRYVDVNGEPAQVIDDPTPVTLHRRDGLDALDAVLSTELPNIDLAAG
+                     PVFRPTLVFLGEDDHALVLTLHHIAGDAWSEEVMVRELGERYTAASAGREPEFAELPVQ
+                     YVDFAVWQRDRSSGQALAGDLAYWRERLAGLNPLELPTDRPRPPVRDGAGALVQVDVSA
+                     PIATRFGRLARDHGVTPFTAFLAAFKVLLARYTGQTDIAVGTPVAGRARPETQDLVGLF
+                     LNTLALRTDL"
+     aSModule        26486..29476
+                     /complete
+                     /domains="nrpspksdomains_B170_RS0101300_Condensation_LCL.1"
+                     /domains="nrpspksdomains_B170_RS0101300_AMP-binding.1"
+                     /domains="nrpspksdomains_B170_RS0101300_PCP.1"
+                     /locus_tags="B170_RS0101300"
+                     /monomer_pairings="ser -> ser"
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       26558..26668
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0001"
+                     /evalue="1.40E-15"
+                     /label="C2_LCL_024-062"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="98"
+                     /protein_start="61"
+                     /score="49.7"
+                     /tool="antismash"
+                     /translation="YLMTTALRIRGQLCRPALQTALDGLVARHEVLRTRYV"
+     CDS_motif       26858..26923
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0002"
+                     /evalue="1.20E-07"
+                     /label="C3_LCL_132-143"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="183"
+                     /protein_start="161"
+                     /score="24.3"
+                     /tool="antismash"
+                     /translation="LHHIAGDAWSEEVMVRELGERY"
+     CDS_motif       26972..27007
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0003"
+                     /evalue="1.30E-04"
+                     /label="C4_LCL_164-176"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="211"
+                     /protein_start="199"
+                     /score="14.6"
+                     /tool="antismash"
+                     /translation="QYVDFAVWQRDR"
+     CDS_motif       27260..27349
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0004"
+                     /evalue="2.80E-15"
+                     /label="C5_LCL_267-296"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="325"
+                     /protein_start="295"
+                     /score="48.6"
+                     /tool="antismash"
+                     /translation="DIAVGTPVAGRARPETQDLVGLFLNTLALR"
+     CDS_motif       27398..27514
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0005"
+                     /evalue="4.90E-20"
+                     /label="C67_LCL_14fromHMM"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="380"
+                     /protein_start="341"
+                     /score="63.9"
+                     /tool="antismash"
+                     /translation="RETVLDGQSHQELPFEQIVDELAPVRDPSRSPLFSTMFL"
+     aSDomain        27857..28981
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_AMP-binding.1"
+                     /evalue="3.50E-117"
+                     /label="B170_RS0101300_AMP-binding.1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="869"
+                     /protein_start="494"
+                     /score="383.2"
+                     /specificity="consensus: ser"
+                     /tool="antismash"
+                     /translation="ADQVRRTPQREAVRFDGSSLTYAELAARSNQLAHHLRSLGVGPES
+                     IVGVCLPRSLDLVVALLAVQKAGGAYLPLDPDHPAERLRYLREDSGATAMIDTDTFAAL
+                     AGYPTVDPGVAVRPEHPAYVIYTSGSTGRPKGVVVEHRGIVNRLRWMQHAYGLDATDRV
+                     LQKTPASFDVSVWELFWPLITGATLVVARPDGHRDPAYLARLIDSERITTLHFVPSMLR
+                     AFLTEPFAGLPSLRRVICSGEALTSDLVAAVHDRIGCELHNLYGPTEASVDVTAARCRP
+                     GEPVTIGTPIANTRAYILDQDLQPVPVGVPGELMLAGVQLARGYLHRPVLTADRFVPDP
+                     FTPGGRLYRTGDLARHRPDGQIDYLGRLDHQVKIN"
+     CDS_motif       28040..28081
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0006"
+                     /evalue="1.50E-04"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="569"
+                     /protein_start="555"
+                     /score="15.1"
+                     /tool="antismash"
+                     /translation="LAVQKAGGAYLPLD"
+     CDS_motif       28220..28279
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0007"
+                     /evalue="4.50E-11"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="635"
+                     /protein_start="615"
+                     /score="34.4"
+                     /tool="antismash"
+                     /translation="AYVIYTSGSTGRPKGVVVEH"
+     CDS_motif       28649..28672
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0008"
+                     /evalue="4.20E-01"
+                     /label="NRPS-A_a5"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="766"
+                     /protein_start="758"
+                     /score="4.2"
+                     /tool="antismash"
+                     /translation="YGPTEASV"
+     CDS_motif       28775..28864
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0009"
+                     /evalue="4.40E-15"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="830"
+                     /protein_start="800"
+                     /score="47.7"
+                     /tool="antismash"
+                     /translation="PVGVPGELMLAGVQLARGYLHRPVLTADRF"
+     CDS_motif       28946..29011
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0010"
+                     /evalue="2.20E-10"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="879"
+                     /protein_start="857"
+                     /score="32.6"
+                     /tool="antismash"
+                     /translation="YLGRLDHQVKINGIRVELGEVE"
+     misc_feature    29180..29182
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     aSDomain        29285..29476
+                     /aSDomain="PCP"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_PCP.1"
+                     /evalue="5.00E-18"
+                     /label="B170_RS0101300_PCP.1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1034"
+                     /protein_start="970"
+                     /score="56.9"
+                     /tool="antismash"
+                     /translation="HMIAGAIADALDIDNVGIEDRFFAIGGDSMRAIRVVGALRAAGVE
+                     LAVHDLFTHQTVAGLAGLA"
+     aSDomain        29564..30460
+                     /aSDomain="Condensation"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_Condensation_DCL.
+                     1"
+                     /domain_subtype="Condensation_DCL"
+                     /evalue="3.40E-53"
+                     /label="B170_RS0101300_Condensation_DCL.1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1362"
+                     /protein_start="1063"
+                     /score="172.4"
+                     /tool="antismash"
+                     /translation="DAYPLAETQAGMVYEMLAAPDRTVYLNVSCYRVHDELPFDLNTLR
+                     AATAILVGRHEILRTSFDLSTYSETMQLVHATAELPVAHTNLTGLASQAQRAAVDEWLV
+                     AERGRPFDIAQPPLLRYHVHEISADEWWLTHTECHAILDGWSHTSVVNELVSIYRRLRT
+                     GHQPDLAPPPEVRFADFVAAEKRALATSTDHGFWATAIGRYDKLELPDGWASERRDDKA
+                     TIIDVPWADLAPGLRRLAAAAGASMKSVLHAAHLKAISIVTGRRQFFGGLVCNGRPEEL
+                     RGDEVFGMYLNTVPFAAD"
+     aSModule        29564..33370
+                     /complete
+                     /domains="nrpspksdomains_B170_RS0101300_Condensation_DCL.1"
+                     /domains="nrpspksdomains_B170_RS0101300_AMP-binding.2"
+                     /domains="nrpspksdomains_B170_RS0101300_PCP.2"
+                     /domains="nrpspksdomains_B170_RS0101300_Thioesterase.1"
+                     /final_module
+                     /locus_tags="B170_RS0101300"
+                     /monomer_pairings="phe -> phe"
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       29675..29749
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0011"
+                     /evalue="8.10E-07"
+                     /label="C2_LCL_024-062"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1125"
+                     /protein_start="1100"
+                     /score="21.5"
+                     /tool="antismash"
+                     /translation="PFDLNTLRAATAILVGRHEILRTSF"
+     CDS_motif       29978..30037
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0012"
+                     /evalue="7.30E-05"
+                     /label="C3_DCL_135-156"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1221"
+                     /protein_start="1201"
+                     /score="15.4"
+                     /tool="antismash"
+                     /translation="HAILDGWSHTSVVNELVSIY"
+     CDS_motif       30374..30451
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0013"
+                     /evalue="1.50E-02"
+                     /label="C5_DCL_263-294"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1359"
+                     /protein_start="1333"
+                     /score="7.9"
+                     /tool="antismash"
+                     /translation="GLVCNGRPEELRGDEVFGMYLNTVPF"
+     aSDomain        30914..32062
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_AMP-binding.2"
+                     /evalue="1.60E-105"
+                     /label="B170_RS0101300_AMP-binding.2"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1896"
+                     /protein_start="1513"
+                     /score="344.8"
+                     /specificity="consensus: phe"
+                     /tool="antismash"
+                     /translation="VEHQATAAPDAVAVRQADHTLTYAELDAAANRLAHRLRALGAGPG
+                     TLVGLFLTRGPDLVVGMLATLRAGAAFLPLDPAYPAERLRYLITDAEVGLLLTEPDLPL
+                     PTGVTATVEIVADYPDLPSARPAVAPSLEDLAYVIYTSGSTGRPKGVGVPHRGALNLRH
+                     AQREHLDVRPGDRVLQFASPSFDASVWELLMSLTNGAELVLPPRGTDPGDLRQQAGLVT
+                     HMTLPPSLLERLSPEDFPHLRVLVSAGEACPVDQVARWSGQARFINAYGPTETSVCATL
+                     TEVAPTVTAPPSIGSTIGGVSAYVLDPDLRPLSVGVRGELYVGGAGLARGYLGRPGLTA
+                     ERFVPNPYGPVGARMYRTGDVVSRNPDGTIQYHGRTDHQVKVR"
+     CDS_motif       31100..31141
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0014"
+                     /evalue="8.70E-04"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1589"
+                     /protein_start="1575"
+                     /score="12.8"
+                     /tool="antismash"
+                     /translation="LATLRAGAAFLPLD"
+     CDS_motif       31319..31378
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0015"
+                     /evalue="1.60E-09"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1668"
+                     /protein_start="1648"
+                     /score="29.8"
+                     /tool="antismash"
+                     /translation="AYVIYTSGSTGRPKGVGVPH"
+     CDS_motif       31721..31747
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0016"
+                     /evalue="4.40E-02"
+                     /label="NRPS-A_a5"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1791"
+                     /protein_start="1782"
+                     /score="6.9"
+                     /tool="antismash"
+                     /translation="YGPTETSVC"
+     CDS_motif       31856..31942
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0017"
+                     /evalue="4.80E-16"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1856"
+                     /protein_start="1827"
+                     /score="50.8"
+                     /tool="antismash"
+                     /translation="VGVRGELYVGGAGLARGYLGRPGLTAERF"
+     CDS_motif       32027..32092
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0018"
+                     /evalue="1.30E-11"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="1906"
+                     /protein_start="1884"
+                     /score="36.4"
+                     /tool="antismash"
+                     /translation="YHGRTDHQVKVRGHRIELGEIE"
+     aSDomain        32390..32593
+                     /aSDomain="PCP"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_PCP.2"
+                     /evalue="9.50E-24"
+                     /label="B170_RS0101300_PCP.2"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="2073"
+                     /protein_start="2005"
+                     /score="75.2"
+                     /tool="antismash"
+                     /translation="ERALAAAWREALGVDRVGVHDDFFELGGHSLAMMRVIATLRARDG
+                     IELTFRSFITHRTIAALATTVTD"
+     CDS_motif       32645..32674
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0019"
+                     /evalue="1.90E-03"
+                     /label="NRPS-beforete1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="2100"
+                     /protein_start="2090"
+                     /score="11.2"
+                     /tool="antismash"
+                     /translation="PLFCVHPGGG"
+     aSDomain        32645..33370
+                     /ASF="active site serine inconclusive"
+                     /aSDomain="Thioesterase"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101300_Thioesterase.1"
+                     /evalue="3.20E-32"
+                     /label="B170_RS0101300_Thioesterase.1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="2332"
+                     /protein_start="2090"
+                     /score="104.5"
+                     /tool="antismash"
+                     /translation="PLFCVHPGGGSAHWYLRLVPHLAPDIPVAAFEWPATHNEVPTAEQ
+                     MAERYLAELRAAQPRGPYRLFSWCGGSSIATEMARRLTDAGETVTFMLLDPGLDAHTRA
+                     EGWQELNYIRRLEALVEQIVADPRADTAERRAEILALLEHLVDDVDPAVGITLPARGVG
+                     DVWPRSVRIWREVMELDLAYRHTPYSGQLHLIVSDELERGEHEVAAGQAFDGYVARWRE
+                     LTAGGVTVHRVPGDHFGVMK"
+     CDS_motif       32816..32890
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101300_0020"
+                     /evalue="5.40E-07"
+                     /label="NRPS-te1"
+                     /locus_tag="B170_RS0101300"
+                     /protein_end="2172"
+                     /protein_start="2147"
+                     /score="22.1"
+                     /tool="antismash"
+                     /translation="QPRGPYRLFSWCGGSSIATEMARRL"
+     gene            33433..33948
+                     /locus_tag="B170_RS0101305"
+     CDS             33433..33948
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018730267.1"
+                     /locus_tag="B170_RS0101305"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027654915.1"
+                     /transl_table=11
+                     /translation="MERAVVWEVYTSHTESTVTVGGLSTCSAALARVFAAVARLGVEPT
+                     TVAGSGAGVTLVVPRPRGQAVAASLAAAGTRVQLSNAVARVGVRGIGLRADSAVAATFC
+                     QTVVAAGVTLSAVSVESTDISVMCPEHRAEAAAGALAKAFGTATHDIGRDLDPRRGPTL
+                     VVAGGGPL"
+     gene            complement(34035..36245)
+                     /locus_tag="B170_RS0101310"
+     CDS             complement(34035..36245)
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters)
+                     lanthipeptide: Lant_dehydr_N"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018792069.1"
+                     /locus_tag="B170_RS0101310"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="lantibiotic dehydratase"
+                     /protein_id="WP_027654916.1"
+                     /sec_met_domain="Lant_dehydr_N (E-value: 9.4e-18, bitscore:
+                     58.1, seeds: 73, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MDDTSVPLGANWRLWSQFALRGPGFPASGVLRLAPAGLGEAADKF
+                     SADEALSGAAWTAFEELYADAAVATASELQRVAALPAFQTAVAWQNRPLLNSGIAPFLA
+                     WTPSAAGRTSMPRQREELVAHYWQRFCVKNDTIGFFGPVGWGHWDTSTSGIAVTSGVGL
+                     VESSEVYFASWAVDAVARLVNADPELRPWIAPRLVPFVRVNHNSVLVPGRPPQVLPPEL
+                     IELLSRCDGVRPAREVGPAVQLEELVRRRIVLWRLDVPADARPEKWMRHWLESVGAPGG
+                     RAAELLEVLVHGRSRVAAAPGPEELKAALTDLESQFVALTDETAVREKNAKTAPCRTLV
+                     YSDARRSARVRLGADLLDALAPLNLLLTAGRWLTSTVAERVMARVREVFDGPMDLATFW
+                     FACMPVLHGEAAGIAVQVQEEFRRRWRSVLPPLTGSRIQVDAAEIAGAVREAFAAADAG
+                     WTAARYLSPDVLVSPGGELVLGELHVATNTLGASLFVNQHPDPESLLAQTARDHPEPRL
+                     LPLLPKEHRARLSARIRHTLVRPEDYYVALVDQTADPARPRTVRSADVTVRAQGDRLVA
+                     VLPDGAEFGIVDVFSHVLTTLVMDMFRLIPEADHTPRVTMDRMVVARESWRFPTAALPF
+                     IEEKSEAGRFVRARRWREQAELPRFVFVVSPTEPRPFFVDFDSPVYVNILAKSARRLHR
+                     QGDPEARLVITEMLPTPEQTWLMDDQGERYTAELRFVAVDNS"
+     misc_feature    complement(36153..36155)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(36257..36490)
+                     /locus_tag="B170_RS0101315"
+     CDS             complement(36257..36490)
+                     /NRPS_PKS="Domain: PP-binding (9-72). E-value: 1.3e-18.
+                     Score: 59.1. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101315_PP-binding.1"
+                     /NRPS_PKS="type: other"
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional
+                     (rule-based-clusters) PP-binding"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018800091.1"
+                     /locus_tag="B170_RS0101315"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="acyl carrier protein"
+                     /protein_id="WP_026323325.1"
+                     /sec_met_domain="PP-binding (E-value: 9.6e-18, bitscore:
+                     59.1, seeds: 164, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MTTTIDVSELIVSIYRETLHDETLDANSDFFEAGGDSLTAFQITA
+                     RLQATLDIEVPVALVFAYPSPADLAEVVAADF"
+     aSDomain        complement(36275..36463)
+                     /aSDomain="PP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101315_PP-binding.1"
+                     /evalue="1.30E-18"
+                     /label="B170_RS0101315_PP-binding.1"
+                     /locus_tag="B170_RS0101315"
+                     /protein_end="72"
+                     /protein_start="9"
+                     /score="59.1"
+                     /tool="antismash"
+                     /translation="LIVSIYRETLHDETLDANSDFFEAGGDSLTAFQITARLQATLDIE
+                     VPVALVFAYPSPADLAEV"
+     aSModule        36275..36463
+                     /domains="nrpspksdomains_B170_RS0101315_PP-binding.1"
+                     /incomplete
+                     /locus_tags="B170_RS0101315"
+                     /tool="antismash"
+                     /type="unknown"
+     CDS_motif       complement(36377..36406)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101315_0001"
+                     /evalue="2.20E-03"
+                     /label="PCP_mC"
+                     /locus_tag="B170_RS0101315"
+                     /protein_end="38"
+                     /protein_start="28"
+                     /score="11.3"
+                     /tool="antismash"
+                     /translation="DFFEAGGDSL"
+     gene            complement(36465..37442)
+                     /locus_tag="B170_RS0101320"
+     CDS             complement(36465..37442)
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1081:cysteine synthase (Score: 71.4; E-value:
+                     9.8e-22)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018730270.1"
+                     /locus_tag="B170_RS0101320"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="pyridoxal-phosphate dependent enzyme"
+                     /protein_id="WP_019870461.1"
+                     /transl_table=11
+                     /translation="MTTIGSATRSGLGIADVRVAAERISGLVRRTPLLALGSNLLVKGE
+                     HRQHGGSFKLRGAANAMVVLRPAAVVTGSSGNHGIAVATIGAACDIPVTVVMAAGTSEA
+                     KARAIRARGARVVHIEGGVAERERRARSIADRTGAVYLPSSDHELVVAGAGTVGLEVAE
+                     DAPDITTIFVPTGGGGLLAGVCLAVDAFDNPVRVVGVEPVHTRRYAISIAAGGPVELPP
+                     SSTIADGLRGQRPGAVPLPIIRRRVDELIGVTDDAIVHALGVLRVAGVAAEPSGAVALA
+                     GAMQAGCGGHAVAVVSGGNTSEVLSAAPWTFDERKHNDYNYRRV"
+     gene            complement(37442..38914)
+                     /locus_tag="B170_RS0101325"
+     CDS             complement(37442..38914)
+                     /NRPS_PKS="Domain: AMP-binding (10-398). E-value: 9e-87.
+                     Score: 283.0. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101325_AMP-binding.1"
+                     /NRPS_PKS="type: NRPS-like protein"
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     AMP-binding"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1002:AMP-dependent synthetase and ligase (Score:
+                     345.1; E-value: 8.9e-105)"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019870460.1"
+                     /locus_tag="B170_RS0101325"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="amino acid adenylation domain-containing protein"
+                     /protein_id="WP_027654917.1"
+                     /sec_met_domain="AMP-binding (E-value: 3.5e-94, bitscore:
+                     310.2, seeds: 400, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MTTFLDQLVAQGRDRPAAPAIVTPDTVVTYGELVARVDRLARVLV
+                     ARGVGPEQVCAIAVDRGPEAVIAMAAALRAGAAFLTLDVELPGPRLATMIRSGQARCLV
+                     TTSALAGQLDLAFGGLRVHTDEPDPGATVRLPPIATRSLAYVSHTSGSTGTPNAVLVEH
+                     RGLDNYLRCVVSDYDLGTETVVLQLAPLGYDASIRDTFAPLMAGSQLVMVARSALLRVD
+                     EFTATLRGFGVDTILSATPTFLTFVSGHDVPLLRLTVSSGESLRPFLTAGGRERLRGRL
+                     VNQYGPTEATMTSTRFVVPPDPDTTMDLVGTPIEGVTVYVLDDDLNPVPAGAVGQMWVG
+                     GIGVTRGYGGRPDLTAERFVPDPFNGPGNRMYRTGDLARLRGGVLEYLGRVDRQIKIRG
+                     YRVDPAEIEGALLNHPAVDGAAVTAATDDRGRVFLVAHVAGELAEVTDAALRAGLAATL
+                     PPYMLPRRFTRIARLPTTASGKVDHRALTAGP"
+     CDS_motif       complement(37691..37756)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101325_0004"
+                     /evalue="2.20E-11"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101325"
+                     /protein_end="408"
+                     /protein_start="386"
+                     /score="35.7"
+                     /tool="antismash"
+                     /translation="YLGRVDRQIKIRGYRVDPAEIE"
+     aSDomain        complement(37721..38884)
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101325_AMP-binding.1"
+                     /evalue="9.00E-87"
+                     /label="B170_RS0101325_AMP-binding.1"
+                     /locus_tag="B170_RS0101325"
+                     /protein_end="398"
+                     /protein_start="10"
+                     /score="283.0"
+                     /specificity="consensus: X"
+                     /tool="antismash"
+                     /translation="QGRDRPAAPAIVTPDTVVTYGELVARVDRLARVLVARGVGPEQVC
+                     AIAVDRGPEAVIAMAAALRAGAAFLTLDVELPGPRLATMIRSGQARCLVTTSALAGQLD
+                     LAFGGLRVHTDEPDPGATVRLPPIATRSLAYVSHTSGSTGTPNAVLVEHRGLDNYLRCV
+                     VSDYDLGTETVVLQLAPLGYDASIRDTFAPLMAGSQLVMVARSALLRVDEFTATLRGFG
+                     VDTILSATPTFLTFVSGHDVPLLRLTVSSGESLRPFLTAGGRERLRGRLVNQYGPTEAT
+                     MTSTRFVVPPDPDTTMDLVGTPIEGVTVYVLDDDLNPVPAGAVGQMWVGGIGVTRGYGG
+                     RPDLTAERFVPDPFNGPGNRMYRTGDLARLRGGVLEYLGRVDRQIKIR"
+     aSModule        37721..38884
+                     /domains="nrpspksdomains_B170_RS0101325_AMP-binding.1"
+                     /incomplete
+                     /locus_tags="B170_RS0101325"
+                     /starter_module
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       complement(37838..37927)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101325_0003"
+                     /evalue="1.90E-13"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101325"
+                     /protein_end="359"
+                     /protein_start="329"
+                     /score="42.5"
+                     /tool="antismash"
+                     /translation="PAGAVGQMWVGGIGVTRGYGGRPDLTAERF"
+     CDS_motif       complement(38036..38065)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101325_0002"
+                     /evalue="7.50E-03"
+                     /label="NRPS-A_a5"
+                     /locus_tag="B170_RS0101325"
+                     /protein_end="293"
+                     /protein_start="283"
+                     /score="9.1"
+                     /tool="antismash"
+                     /translation="QYGPTEATMT"
+     CDS_motif       complement(38426..38485)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101325_0001"
+                     /evalue="3.70E-07"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101325"
+                     /protein_end="163"
+                     /protein_start="143"
+                     /score="22.6"
+                     /tool="antismash"
+                     /translation="AYVSHTSGSTGTPNAVLVEH"
+     gene            complement(38911..41265)
+                     /locus_tag="B170_RS0101330"
+     CDS             complement(38911..41265)
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters)
+                     lanthipeptide: Lant_dehydr_N"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018733757.1"
+                     /locus_tag="B170_RS0101330"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="lantibiotic dehydratase"
+                     /protein_id="WP_027654918.1"
+                     /sec_met_domain="Lant_dehydr_N (E-value: 1.3e-48, bitscore:
+                     160.1, seeds: 73, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MSEHVELPVGGWRLWSQFALRGPGFPAAGVLALAPAGLAEHADKF
+                     DAGIVPSGAEWAAFEQDFDEAMVATAQELQRIAALPMFRAALAWQNRQLLDSGITPFLA
+                     WTPSAAGRTSMPRQREELVAHYWQRFCVKNDTIGFFGPVGWGRWDLSTSGIVVEPGTGL
+                     VDAARVYFSSWAIDHVARAIEADSAVRPWVPPRRLSFVRRVGHTVAMPGRPPQQILRFH
+                     GDVLDLCDGVRTAAEIAELLTVPVSAIEEALTELLRRRWIVRRLEVPTSAYPERWLRSA
+                     VERVTDDPVRARALAKLAVVERARDRVHAAGMDADALAGALADLETDFATVTEQAAARA
+                     KGARVAPCRSLLYGDARRSATATIGTAIRDELTPLGLFLTAARWMTNRFADRVGARIRA
+                     AYERLRDEHGSVDLGALWFACLPVPHPESAADVAAVQAELRARWAELVDAPAGTRRVQL
+                     RSADIAGRVYELFAEPGNGWNIARYVSPDLLVCAEDPEAVDRGEFELVLGELHVAMNTV
+                     GASLFVMQHPDVDSLLAETSRDFPGPRLMPMLPKEQPPRWSARSRPALVRPEDYVVALV
+                     DHTGDPSRPRNLLAADIRVEEHAGRLVLVLPDGAEFDVLDVFGNALTNRVMDRFTLRGD
+                     SPHAPRITIDRTVVARESWRVPAADVRFAHDKSEARRFVYARGWRAELGLPRFVFVVMP
+                     TEPRPFYVDFDSPVYVNILAKAIRRLGRKDPEARFTVTEMLPTPEQAWLTDDAGDRYTA
+                     ELRFVAVDQTVAATEGVAATDAVAATVGGSR"
+     gene            complement(41267..42217)
+                     /locus_tag="B170_RS0101335"
+     CDS             complement(41267..42217)
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1114:ornithine carbamoyltransferase (Score: 386.2;
+                     E-value: 1.5e-117)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019870458.1"
+                     /locus_tag="B170_RS0101335"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="ornithine carbamoyltransferase"
+                     /protein_id="WP_027654919.1"
+                     /transl_table=11
+                     /translation="MANRRHLISIDDLTDTDLREIVRRGTEFAAGAAEDARSLADLVVG
+                     VLFRKTSTRTRTAFSAGSLRLGARLITYGPGDLQENTGETAEDTAAVLSRMIDVLVART
+                     AGPEEELRAYAKQHRMAVVNAMSAAEHPTQALADLTTLTRHFGQVEGLRVLYLGEGNNT
+                     AAALALALARYTDTQLHLRTPPGYGVHPSVLERAQAAAKRSGAVVEQRHDPTDLPSVDV
+                     VYTTRWQTTGTTKPTPDWRREFTPYQVDEALMAACPGAVFMHDLPAHRGEEVTAAVLDG
+                     PTSITFAQAENKYHSARAVLEWCTGNTPNWRIAGG"
+     misc_feature    complement(41681..41683)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(42275..43567)
+                     /gene="ectB"
+                     /locus_tag="B170_RS0101340"
+     CDS             complement(42275..43567)
+                     /EC_number="2.6.1.76"
+                     /NRPS_PKS="Domain: Aminotran_3 (38-370). E-value: 2.9e-73.
+                     Score: 238.6. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101340_Aminotran_3.1"
+                     /NRPS_PKS="type: other"
+                     /codon_start=1
+                     /gene="ectB"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1013:aminotransferase class-III (Score: 386.6;
+                     E-value: 2.3e-117)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018736296.1"
+                     /locus_tag="B170_RS0101340"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="diaminobutyrate--2-oxoglutarate transaminase"
+                     /protein_id="WP_027654920.1"
+                     /transl_table=11
+                     /translation="MTITVDSTSVLEATTPFAAFESLESEVRSYCRKFPAVFHRARGAE
+                     LYSEDGKRFIDFFAGAGTLNYGHNNPFIKRRLLDYLNSDGVVHGLDMYTVAKREFLTAF
+                     NKTVLQPRGLDFKVQFCGPTGTDAVEAALKLARKATGRSGVIAFSGAYHGMSRGSLAVT
+                     GSRRARRAGGIGGGDVTFVPYEDGPQGPFDSIALIERMLDDPSSGMEIPAAVIVEPMQM
+                     EGGVYPASADWLRRLRTLTEQHGILLVVDEIQAGCGRTGTFFCFEHSGVVPDVVTVSKS
+                     IGGYGLPLSMSLFRRELDVWEPGEHTGTFRGNQLAFVAATAACELWGDPKFRTDIAVAS
+                     RRLERFRAELTSVDAGLVVRGRGMALGIDLGRVGGPDRAERLQRYAFDHGVIVERCGRH
+                     DEVIKVLPPIAIDIVRLDRGLEVLRDGLLAV"
+     aSDomain        complement(42458..43453)
+                     /aSDomain="Aminotran_3"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101340_Aminotran_3.1"
+                     /evalue="2.90E-73"
+                     /label="B170_RS0101340_Aminotran_3.1"
+                     /locus_tag="B170_RS0101340"
+                     /protein_end="370"
+                     /protein_start="38"
+                     /score="238.6"
+                     /tool="antismash"
+                     /translation="HRARGAELYSEDGKRFIDFFAGAGTLNYGHNNPFIKRRLLDYLNS
+                     DGVVHGLDMYTVAKREFLTAFNKTVLQPRGLDFKVQFCGPTGTDAVEAALKLARKATGR
+                     SGVIAFSGAYHGMSRGSLAVTGSRRARRAGGIGGGDVTFVPYEDGPQGPFDSIALIERM
+                     LDDPSSGMEIPAAVIVEPMQMEGGVYPASADWLRRLRTLTEQHGILLVVDEIQAGCGRT
+                     GTFFCFEHSGVVPDVVTVSKSIGGYGLPLSMSLFRRELDVWEPGEHTGTFRGNQLAFVA
+                     ATAACELWGDPKFRTDIAVASRRLERFRAELTSVDAGLVVRGRGMALGIDL"
+     gene            complement(43579..46716)
+                     /locus_tag="B170_RS0101345"
+     CDS             complement(43579..46716)
+                     /NRPS_PKS="Domain: Condensation_LCL (5-285). E-value:
+                     4e-96. Score: 313.3. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101345_Condensation_LCL.1"
+                     /NRPS_PKS="Domain: AMP-binding (455-847). E-value:
+                     1.9e-108. Score: 354.4. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101345_AMP-binding.1"
+                     /NRPS_PKS="Domain: PCP (954-1021). E-value: 3.5e-24. Score:
+                     76.6. Matches aSDomain:
+                     nrpspksdomains_B170_RS0101345_PCP.1"
+                     /NRPS_PKS="type: NRPS"
+                     /codon_start=1
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     AMP-binding"
+                     /gene_functions="biosynthetic (rule-based-clusters) NRPS:
+                     Condensation"
+                     /gene_functions="biosynthetic-additional
+                     (rule-based-clusters) PP-binding"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1127:condensation domain-containing protein (Score:
+                     394.5; E-value: 1.2e-119)"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018584311.1"
+                     /locus_tag="B170_RS0101345"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="non-ribosomal peptide synthase"
+                     /protein_id="WP_027654921.1"
+                     /sec_met_domain="Condensation (E-value: 6.2e-68, bitscore:
+                     223.6, seeds: 42, tool: rule-based-clusters)"
+                     /sec_met_domain="AMP-binding (E-value: 4.7e-117, bitscore:
+                     385.6, seeds: 400, tool: rule-based-clusters)"
+                     /sec_met_domain="PP-binding (E-value: 2.9e-18, bitscore:
+                     60.7, seeds: 164, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MDSVGEVSFAQERLWFLDQLRPGTPDYLLPLALRIRGPLDVTALT
+                     TALQAIVDRHDVLRTRYVEVDGRPVAHVDPYATVTIAHTTDHRVLERELARPIDIARDL
+                     PFRLSLARLGDDHLLVFVVHHIAFDGWSWGVLARELAAGYAGRTTEVSGLSAQYADFAR
+                     RQRERFTDERSRRQLDYWRAQLAGVPAIELPTDRRRPRTWDGAGDVVRVDLPATLLREV
+                     DAVARSRRVTRFMVLLAAFQIVLARASGQTDFAIGTPVAGRTRVADEDLIGLFVNSVVL
+                     RADLAGAPTFEELLTRVRDNALGAFSHADTPFERIVTDLAPERDLSRNPIFQVSFSLLD
+                     VRAPMSLPGLDVEVVEPPLTGSPFDLFLDVNVRPDGTATARLQYATALFDHARVERLAG
+                     GFADLLRAVVVEPATSVSELAARLELGPRGERDRLLYGWNRTAADFPDQTVDQLVSAQV
+                     RATPDAVAVWTTTEEITYGELDMRVNRLAHHLRALGVRPGSLVAVLLDRGPDLLIALLA
+                     VLRAGGAYVPIDPEYPDARIAFIVADSAAAVVITRSALVDRVGDTGGQHVLVDRDRAVV
+                     AARPSAAVPATATGEQLAYLIYTSGSTGTPKGVMVHHRALTNFVTSIVRRPGLTAGQSV
+                     VALTTISFDPSLLELYVPLLVGATVVLADTEQARDPQRLIDLVALTRPAVLQATPAMLR
+                     ALLEVGWVPPATITVLSGGEKLPTELARRLAAEGAPVWDLYGPTETTVWVTSARLDPTG
+                     AVVDWSPQANCTVHLLDRYAEPVPIGTVGELYIGGSCVALGYRGQPALTAERYVPDPYS
+                     TTPGGRLYRTGDLARRSQDGSVEILGRADRQVKIRGHRMEPSEIEAALLGHDDIRAVAV
+                     HPTATPTGEEQLTAYLVARADTAPPVEELRRFLLRTLPDYMLPAAYVPMEALPLTPNSK
+                     VDYAALPEPATRVAVARVAPRTAEERVVADIWREVLGTGATIDMDDNFFEIGGHSLLAT
+                     RVAVRLRAQLGVDVPVRGLFDHSTVASLAAALPDYPRISQRTTMPTLTARRRHKTR"
+     aSDomain        complement(43654..43854)
+                     /aSDomain="PCP"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101345_PCP.1"
+                     /evalue="3.50E-24"
+                     /label="B170_RS0101345_PCP.1"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="1021"
+                     /protein_start="954"
+                     /score="76.6"
+                     /tool="antismash"
+                     /translation="ERVVADIWREVLGTGATIDMDDNFFEIGGHSLLATRVAVRLRAQL
+                     GVDVPVRGLFDHSTVASLAAAL"
+     aSModule        43654..46701
+                     /complete
+                     /domains="nrpspksdomains_B170_RS0101345_Condensation_LCL.1"
+                     /domains="nrpspksdomains_B170_RS0101345_AMP-binding.1"
+                     /domains="nrpspksdomains_B170_RS0101345_PCP.1"
+                     /locus_tags="B170_RS0101345"
+                     /monomer_pairings="gly -> gly"
+                     /tool="antismash"
+                     /type="nrps"
+     CDS_motif       complement(44146..44208)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0010"
+                     /evalue="1.90E-10"
+                     /label="NRPS-A_a8"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="857"
+                     /protein_start="836"
+                     /score="32.8"
+                     /tool="antismash"
+                     /translation="LGRADRQVKIRGHRMEPSEIE"
+     aSDomain        complement(44176..45351)
+                     /aSDomain="AMP-binding"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101345_AMP-binding.1"
+                     /evalue="1.90E-108"
+                     /label="B170_RS0101345_AMP-binding.1"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="847"
+                     /protein_start="455"
+                     /score="354.4"
+                     /specificity="consensus: gly"
+                     /tool="antismash"
+                     /translation="AQVRATPDAVAVWTTTEEITYGELDMRVNRLAHHLRALGVRPGSL
+                     VAVLLDRGPDLLIALLAVLRAGGAYVPIDPEYPDARIAFIVADSAAAVVITRSALVDRV
+                     GDTGGQHVLVDRDRAVVAARPSAAVPATATGEQLAYLIYTSGSTGTPKGVMVHHRALTN
+                     FVTSIVRRPGLTAGQSVVALTTISFDPSLLELYVPLLVGATVVLADTEQARDPQRLIDL
+                     VALTRPAVLQATPAMLRALLEVGWVPPATITVLSGGEKLPTELARRLAAEGAPVWDLYG
+                     PTETTVWVTSARLDPTGAVVDWSPQANCTVHLLDRYAEPVPIGTVGELYIGGSCVALGY
+                     RGQPALTAERYVPDPYSTTPGGRLYRTGDLARRSQDGSVEILGRADRQVKIR"
+     CDS_motif       complement(44302..44388)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0009"
+                     /evalue="2.30E-14"
+                     /label="NRPS-A_a6"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="805"
+                     /protein_start="776"
+                     /score="45.5"
+                     /tool="antismash"
+                     /translation="PIGTVGELYIGGSCVALGYRGQPALTAER"
+     CDS_motif       complement(44878..44937)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0008"
+                     /evalue="1.40E-10"
+                     /label="NRPS-A_a3"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="613"
+                     /protein_start="593"
+                     /score="33.0"
+                     /tool="antismash"
+                     /translation="AYLIYTSGSTGTPKGVMVHH"
+     CDS_motif       complement(45130..45171)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0007"
+                     /evalue="9.70E-06"
+                     /label="NRPS-A_a2"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="529"
+                     /protein_start="515"
+                     /score="18.7"
+                     /tool="antismash"
+                     /translation="LAVLRAGGAYVPID"
+     CDS_motif       complement(45703..45822)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0006"
+                     /evalue="5.20E-20"
+                     /label="C67_LCL_14fromHMM"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="338"
+                     /protein_start="298"
+                     /score="63.9"
+                     /tool="antismash"
+                     /translation="RDNALGAFSHADTPFERIVTDLAPERDLSRNPIFQVSFSL"
+     aSDomain        complement(45862..46701)
+                     /aSDomain="Condensation"
+                     /aSTool="nrps_pks_domains"
+                     /database="nrpspksdomains.hmm"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksdomains_B170_RS0101345_Condensation_LCL.
+                     1"
+                     /domain_subtype="Condensation_LCL"
+                     /evalue="4.00E-96"
+                     /label="B170_RS0101345_Condensation_LCL.1"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="285"
+                     /protein_start="5"
+                     /score="313.3"
+                     /tool="antismash"
+                     /translation="EVSFAQERLWFLDQLRPGTPDYLLPLALRIRGPLDVTALTTALQA
+                     IVDRHDVLRTRYVEVDGRPVAHVDPYATVTIAHTTDHRVLERELARPIDIARDLPFRLS
+                     LARLGDDHLLVFVVHHIAFDGWSWGVLARELAAGYAGRTTEVSGLSAQYADFARRQRER
+                     FTDERSRRQLDYWRAQLAGVPAIELPTDRRRPRTWDGAGDVVRVDLPATLLREVDAVAR
+                     SRRVTRFMVLLAAFQIVLARASGQTDFAIGTPVAGRTRVADEDLIGLFVNSVVLRADL"
+     CDS_motif       complement(45871..45960)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0005"
+                     /evalue="7.30E-14"
+                     /label="C5_LCL_267-296"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="282"
+                     /protein_start="252"
+                     /score="44.1"
+                     /tool="antismash"
+                     /translation="DFAIGTPVAGRTRVADEDLIGLFVNSVVLR"
+     CDS_motif       complement(45970..46026)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0004"
+                     /evalue="7.90E-03"
+                     /label="Cy4"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="249"
+                     /protein_start="230"
+                     /score="9.4"
+                     /tool="antismash"
+                     /translation="VTRFMVLLAAFQIVLARAS"
+     CDS_motif       complement(46285..46350)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0003"
+                     /evalue="1.50E-11"
+                     /label="C3_LCL_132-143"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="144"
+                     /protein_start="122"
+                     /score="36.6"
+                     /tool="antismash"
+                     /translation="VHHIAFDGWSWGVLARELAAGY"
+     CDS_motif       complement(46528..46638)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0002"
+                     /evalue="1.20E-17"
+                     /label="C2_LCL_024-062"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="63"
+                     /protein_start="26"
+                     /score="56.3"
+                     /tool="antismash"
+                     /translation="YLLPLALRIRGPLDVTALTTALQAIVDRHDVLRTRYV"
+     CDS_motif       complement(46663..46695)
+                     /aSTool="nrps_pks_domains"
+                     /database="abmotifs"
+                     /detection="hmmscan"
+                     /domain_id="nrpspksmotif_B170_RS0101345_0001"
+                     /evalue="2.90E-03"
+                     /label="C1_LCL_004-017"
+                     /locus_tag="B170_RS0101345"
+                     /protein_end="18"
+                     /protein_start="7"
+                     /score="10.2"
+                     /tool="antismash"
+                     /translation="SFAQERLWFLD"
+     gene            46901..47092
+                     /locus_tag="B170_RS0101350"
+     CDS             46901..47092
+                     /codon_start=1
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1009:mbtH-like protein (Score: 87.1; E-value: 8e-27)"
+                     /gene_kind="biosynthetic-additional"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018726420.1"
+                     /locus_tag="B170_RS0101350"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="MbtH family NRPS accessory protein"
+                     /protein_id="WP_019870455.1"
+                     /transl_table=11
+                     /translation="MTDEGVYRVVLNDEEQYSIWWADRELPLGWRAEGTAGSKQECLER
+                     IQQVWTDMRPRSLREQMA"
+     gene            complement(47276..47863)
+                     /locus_tag="B170_RS0101355"
+     CDS             complement(47276..47863)
+                     /codon_start=1
+                     /gene_functions="regulatory (smcogs) SMCOG1016:LuxR family
+                     DNA-binding response regulator (Score: 88.4; E-value:
+                     6.5e-27)"
+                     /gene_kind="regulatory"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018739978.1"
+                     /locus_tag="B170_RS0101355"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="response regulator transcription factor"
+                     /protein_id="WP_019870454.1"
+                     /transl_table=11
+                     /translation="MKVQVEAADSTLRATVATKLRLVGIKIVEQPFQVPVVVAAAETVG
+                     RALRSCPQPYLTGDYRLLVLADAFDPAEVRSALRAGVRAMLSTTSAPAKLASAVWATKQ
+                     GESRIPREILLKLLRDRAGGGPDSAPNPSPLTPRQTAVLALMAEGYPNTAIAKNLSCSE
+                     HTVKNVIYDMMTRLQVNNRAHAVARAIRAGHI"
+     gene            complement(47860..48471)
+                     /locus_tag="B170_RS0101360"
+     CDS             complement(47860..48471)
+                     /codon_start=1
+                     /gene_functions="regulatory (smcogs) SMCOG1016:LuxR family
+                     DNA-binding response regulator (Score: 72.3; E-value:
+                     5.5e-22)"
+                     /gene_kind="regulatory"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018584309.1"
+                     /locus_tag="B170_RS0101360"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="response regulator transcription factor"
+                     /protein_id="WP_027654922.1"
+                     /transl_table=11
+                     /translation="MGEPVRVSVTALDPMLEVGATTSLRSSPDVEVVSGPERAQAAVIV
+                     VDTVDEYVLGIVRETRASATCPEVVLVATDLESCAALQAIVAGARGVMRRREADPARLA
+                     RVVVAVADGDCTLPLDILDQLPERGARPLSATSSTDSPLSERERAVLRLVADGHETGEI
+                     ARQLCYSTRTVTSVVHDITRRFRLRNRAHAVAYTLRAGLL"
+     misc_feature    complement(48400..48402)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            48816..51782
+                     /gene="lanM"
+                     /locus_tag="B170_RS0101365"
+     CDS             48816..51782
+                     /codon_start=1
+                     /gene="lanM"
+                     /gene_functions="biosynthetic (rule-based-clusters)
+                     lanthipeptide: LANC_like"
+                     /gene_functions="biosynthetic (rule-based-clusters)
+                     lanthipeptide: DUF4135"
+                     /gene_functions="biosynthetic-additional (smcogs)
+                     SMCOG1070:lanthionine synthetase C family protein (Score:
+                     831.7; E-value: 1.4e-251)"
+                     /gene_kind="biosynthetic"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018730279.1"
+                     /locus_tag="B170_RS0101365"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="type 2 lantipeptide synthetase LanM"
+                     /protein_id="WP_027654923.1"
+                     /sec_met_domain="LANC_like (E-value: 6.5e-32, bitscore:
+                     105.2, seeds: 47, tool: rule-based-clusters)"
+                     /sec_met_domain="DUF4135 (E-value: 2.6e-99, bitscore:
+                     327.4, seeds: 79, tool: rule-based-clusters)"
+                     /transl_table=11
+                     /translation="MPVAGGEAETEPGFAARLADLGMPHDPHFGALTTQLRRPAWAVLV
+                     EDVLATARPLTSDAQPVADWRAAFARVLAPFVNAALVQIRRHGSRHVDLDRVTAAVSGT
+                     LGPRLVDIAARTLVTELHRWRAEGRLTGGDGPARFHDFVRQLTAPAGLGEVLARYPVLA
+                     RLLAQDTATTADATVELLNRLGHDRDALIATLLGGIDPGPVTSVLAAQGDRHAGGRAVS
+                     FVDFADGRRLVYKPRDLTPYIKLTAILDHLSSAAAGVFPRTPRVLSRTGYGWTEHIAAL
+                     PLLNWEDAELFYRRQGALLALLHLVRATDVHYENLIAHGDQPILVDIETLFHPELAPGG
+                     LGDPAADALAESVHRTALLPLVFVGEQGIADLSGAGGDVSTSPLTVVDWLDAGTDQMRL
+                     TRRAAEFAGAANRPILNGRPVEPHEHDRAIVGGFRQAYDTFIAHRDKLTALVRDCADLE
+                     VRVIVRATWMYKTLLDETTHPDVLRDAVDRDRALSVLYHGRTEQPLLAQLLRSEIATLW
+                     AGDIPMFTASVGTGRIRAVSGTEFTEPLPQTGLTAALSTLASLDEVNRRGQEWIISATL
+                     ASRSRVAPHPEAVPIAAQPEGVVAHPDELLAAACAVADQLVAEAKAGGGRVNWLGLEAV
+                     EDQRWLVLPLGASLGSGYLGVALFFAQLAAVTGICRYADQARAATADLPQLVAALDKRP
+                     DLVAVIGCGGLDGLGGIAYGLTRIGTLLDDHTLTDAAARSIRLAALAATSEAPAGWSTG
+                     LAGCLAALATVQTDLNLPEAGDVARRCADLLIAPLVGSGNPPGHRAATSPDRPGGSGPT
+                     SGGFAEGLAGIGWALTTAGPDEHHQAAGRRVATLLGDRSEPAASGWCRGTAGTVLARAS
+                     LSTDADPRYLTGCVEALADAPVRRDLSLCHGELGVTEVLTQLAGSDRHTFATRALRRRT
+                     GLVLDVLRRHGSLSGVPGGVRSPGLLTGLAGIGYGLLRHAAPQQVPSVLLLQGSSATH"
+     misc_feature    50340..50342
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     misc_feature    50475..50477
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     misc_feature    51756..51758
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            51817..52044
+                     /locus_tag="B170_RS0101370"
+     CDS             51817..52044
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018736302.1"
+                     /locus_tag="B170_RS0101370"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027644637.1"
+                     /transl_table=11
+                     /translation="MSEMIPNTAEEAATAPAGRLRLLPTAVTFADRAAALARVGLPVAM
+                     LAASIAAPALGASAGEATAMNTTCCPDRPM"
+     gene            52165..55161
+                     /locus_tag="B170_RS24695"
+     CDS             52165..55161
+                     /codon_start=1
+                     /gene_functions="regulatory (smcogs) SMCOG1149:LuxR family
+                     transcriptional regulator (Score: 111.7; E-value: 5.3e-34)"
+                     /gene_kind="regulatory"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018739981.1"
+                     /locus_tag="B170_RS24695"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="LuxR family transcriptional regulator"
+                     /protein_id="WP_033664102.1"
+                     /transl_table=11
+                     /translation="MRHFSASLVGRDRVLHALTAGLTAARNGRGNAVFVTGESGIGKSR
+                     LTAAVTELAFTSGMSLMRGRASAVGPTPPFRPLTEAILSHLRIEPVDPAKLGPYGPILG
+                     RLVPEWSAPENSHDSESLVVLAEAVLRLIGLVGRDRGCLLNLDDLHEADPETLAVLEYL
+                     IDNVELQPMLLLGALRDEGPVLSLVRAAARRGACQLIDLDRLSRAELAQLAGACLDVEP
+                     NLVPTSAVDLLWAGSSGNPLVAKELLSTMVDDGILVGDAQGWQINSRPEAPVSAGLARP
+                     LARRVAQLGTRVRELLSVAAVFGQQFPLRVVQHVTGLADRDLLGLLQNDVAGRFVAPDE
+                     QTADWYAFHHQLSREAVLAQLDQDAHARLADMLASAVEAIYPGLPREWCEVAARLRADA
+                     GDPTTAGTLFTEVGRRALALGAANSAVAVLDRALEYIPHDDVATRTGTLELLLQALAEA
+                     GLVERALESVSELDQAGWLTPSRRAALHARLAWAATVAGRTLDGLAQVETARALLGSEG
+                     SAEDLAPIDMVAAHLLLDAGGPDQLAAAENLARQAATVAESVPLPVVACQAWQLVGGLA
+                     RHRDPQEATSVLERARTLAVRHDLPICEIHALIRLGNDDALLRGDLTRLQRASAQATRM
+                     GAVTAQYQAEASIALHTVLHGDFTAAASLTDQVFAATSRLNLLETTQYVLLTRAVLAGH
+                     RGDRNQMESELARFTQWGGDLTLHGPRAHGLAAAFCALLEEDLPRARSDLARAVAAEEH
+                     GSSVYFLSGRRGLHVLLRALAGQAEWPDLEAVTVNPASTLRWDRQFTFFARAVLDGRSG
+                     QRGRASRAVTDALAAGEPYPTSRYLGLRLVSEAALTDGWGEPVTWLRSAEEHFHRTGVN
+                     AVAGACRALLRRAGATVRQRRDGTAGIPNELRSAGVTAREYEVLGLVVKRLGNREIATR
+                     LHLSPRTVERHVHGLMTKTGLPNRIALAKFGAGFVDNPPAAAGTDSPAPSSHTTTDWRS
+                     RPPASGSTT"
+     misc_feature    54313..54315
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(55588..56133)
+                     /locus_tag="B170_RS0101385"
+     CDS             complement(55588..56133)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019870449.1"
+                     /locus_tag="B170_RS0101385"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027654925.1"
+                     /transl_table=11
+                     /translation="MGSSVAFAPEDVQRIAELSEVTAAEGNSTAYSVTARHAGTGKEHE
+                     AMVVTAAVDQQLRSLEVVSGTYPANAGEACVDDQVAASLGWTTGDQLALSRQSGLVEVV
+                     VTGECVRPAGDEFGASELIVAVPLADITSITGSSGADEVMIRLTTPESASTLYDSVSLS
+                     LGRDVAMIYGDHLRGVLE"
+     misc_feature    complement(55834..55836)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(56274..56969)
+                     /locus_tag="B170_RS0101390"
+     CDS             complement(56274..56969)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_019870448.1"
+                     /locus_tag="B170_RS0101390"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027654926.1"
+                     /transl_table=11
+                     /translation="MAQEPDDDFDHLRFDLRTFGPVDEQEARRSGFGKDAPAQIARIVS
+                     FDANYDQEVERCELAASKKIGPEAQEVSVSYGELGNTLMGEFGKEYERLIGPQLSELRT
+                     SLRDCLAEAGFQAEDPEDFAREPYPEKLGVRFGAHETIAEEAWSPERKEGTIQIGPAIP
+                     AKKYVPTEEEVELAVAWSKCTQRLEFKERLMPLVISAQQTVYERHEEQLAEHADKTVDL
+                     AKKAADLKW"
+     gene            complement(58291..59037)
+                     /locus_tag="B170_RS24700"
+     CDS             complement(58291..59037)
+                     /codon_start=1
+                     /gene_functions="other (smcogs) SMCOG1286:Pentapeptide
+                     repeat protein (Score: 115.6; E-value: 3.3e-35)"
+                     /gene_kind="other"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018814660.1"
+                     /locus_tag="B170_RS24700"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="pentapeptide repeat-containing protein"
+                     /protein_id="WP_027654927.1"
+                     /transl_table=11
+                     /translation="MNDLAGAELNNRDLREVDLVGVNLARANFAGVDLTGANLAGVDLR
+                     GADLTDVDLTGANLAGVDLRGADLTDVNLTGALLIGANLAGANLAGVDLTAANLRGVDL
+                     AGVDLAGVELTAANLTAADLTRADLTGALLIGADLTGVDLAGANLAGIDLRGVNLTGVD
+                     LTSADLREANLDRANLTGVNLCEANLYGAVLTSTKLAGARWDWATIWPPERAAEIWFRS
+                     AERPDQPGVYVVLPEAGGRDRQSVVV"
+     gene            complement(59237..59662)
+                     /locus_tag="B170_RS0101400"
+     CDS             complement(59237..59662)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018831255.1"
+                     /locus_tag="B170_RS0101400"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_019870445.1"
+                     /transl_table=11
+                     /translation="MPFEPLSTMESALWGLLGSFIVEALELGAALRRAKTLPWKRPDEP
+                     GLPAYLASVVLRLAAGAGLAALIGADGRLASPLAAGLLGITAPLLIEKVLRQVDLASTE
+                     VDTPHHHSTLPLSRSVPPPLATDQKLASGDADSSDVD"
+     misc_feature    complement(59321..59323)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     misc_feature    complement(59429..59431)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(60267..61097)
+                     /locus_tag="B170_RS0101405"
+     CDS             complement(60267..61097)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018744910.1"
+                     /locus_tag="B170_RS0101405"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="ETX/MTX2 family pore-forming toxin"
+                     /protein_id="WP_027654928.1"
+                     /transl_table=11
+                     /translation="MRLKRTRALLAMSIGTAAAVLMTASPAQAATITDITTLLEDMSSH
+                     AYPPFGFEVTATPILITESDAVPVGSAKVVSSAPFYLGCASLTNSTSSDQTLWSHSFSK
+                     AFTNTVSTTVTTGVSSTSKVSGTFSLSKVVGLGLEESVTVSYQDSETQSESIKETHTAP
+                     SQRVLVPAQTTRYVVSSLTQSTYTGELALNANFTGGFTAKSLNGPLPPVLNIYDTLSRA
+                     EDRGGQLPTGFSLNSSTKRLDFQGTGTYTVKAGANFRVEVLETLPGGLKTSQCS"
+     misc_feature    complement(61089..61091)
+                     /note="tta leucine codon, possible target for bldA
+                     regulation"
+                     /tool="antismash"
+     gene            complement(61809..62048)
+                     /locus_tag="B170_RS0101410"
+     CDS             complement(61809..62048)
+                     /codon_start=1
+                     /gene_functions="regulatory (smcogs) SMCOG1136:GntR family
+                     transcriptional regulator (Score: 79; E-value: 6.6e-24)"
+                     /gene_kind="regulatory"
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018818411.1"
+                     /locus_tag="B170_RS0101410"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="winged helix-turn-helix transcriptional
+                     regulator"
+                     /protein_id="WP_018254638.1"
+                     /transl_table=11
+                     /translation="MPATPDYIRISDEIIDDIRSGRYKAGDKLPSIAQLCERYHVSPST
+                     IQLVNVRLEALEVINRHQGKGVFVTDPKTWLRKP"
+     gene            62242..62646
+                     /locus_tag="B170_RS0101420"
+     CDS             62242..62646
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018733754.1"
+                     /locus_tag="B170_RS0101420"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="DivIVA domain-containing protein"
+                     /protein_id="WP_027654929.1"
+                     /transl_table=11
+                     /translation="MVDVRNPFRRFRHWRGRPAPSHPTARTGSLIGANIGRPAGTDSDA
+                     DRHRSFAGNAGGHHRSATRWPLTPDQVRQRQFPRVRRGLDASEVELFLYRVAADLSALQ
+                     TELRSTRDENIRIKRALRDWQSRTTPGVRA"
+     gene            62643..62829
+                     /locus_tag="B170_RS25845"
+                     /pseudo=""
+     CDS             62643..62829
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018730289.1"
+                     /locus_tag="B170_RS25845"
+                     /note="frameshifted; Derived by automated computational
+                     analysis using gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /pseudo=""
+                     /transl_table=11
+                     /translation="MTVTGLDERPRFVVHLTLHADDLAGARLLARSVARSLGFLPELAQ
+                     RRPRPTRPDDCGPQPEV"
+     gene            complement(62857..63192)
+                     /locus_tag="B170_RS0101425"
+     CDS             complement(62857..63192)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_012180697.1"
+                     /locus_tag="B170_RS0101425"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="DUF1416 domain-containing protein"
+                     /protein_id="WP_027654930.1"
+                     /transl_table=11
+                     /translation="MNVVTASTAAGCAAPDQAAPLPASLDLEKETVITGVVRDAAGEPV
+                     TGAYVRLLDSTDEFTAEVVTSSAGQFRFFAAPGTWRLRALSRHGNGDLVITASRGVNEA
+                     IVPVVVD"
+     gene            complement(63189..64037)
+                     /locus_tag="B170_RS0101430"
+     CDS             complement(63189..64037)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_016814851.1"
+                     /locus_tag="B170_RS0101430"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="sulfurtransferase"
+                     /protein_id="WP_027654931.1"
+                     /transl_table=11
+                     /translation="MSRDTALVSADWAEKNLETPGVVFVEVDEDTSAYDTGHLPGAIKL
+                     DWRTDLQDQVRRDFVNKDQFAALLSERGIANDDTVVLYGGNNNWFAAYAYWYFALYGHR
+                     EVRLLDGGRKKWELDARPLTTELVSRPATRYVAQEPDHTIRAFRDEVVAAIGTKNLVDV
+                     RSPDEYAGRLLAPAHLPQEQAQRAGHVPTALSVPWSKAANEDGTFKSDQELREIYAAAG
+                     LDDSRETIAYCRIGERSSHTWFVLQELLGHQNVKNYDGSWTEYGSLVGVPVALGDEPGK
+                     E"
+     gene            complement(64394..65185)
+                     /locus_tag="B170_RS0101440"
+     CDS             complement(64394..65185)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018254643.1"
+                     /locus_tag="B170_RS0101440"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="DUF2993 domain-containing protein"
+                     /protein_id="WP_027654932.1"
+                     /transl_table=11
+                     /translation="MTTEERPQQDERPRRQRGRRILVVLLVLLLVLVGLLVVADRVAAG
+                     VAERALTDQVREELAKEGVQAGPPEVEIGGFPFVTQVLDGRYERISIGLNEVRGSVQGD
+                     VLALPTLDIDAYDVTAPLDTLRSGRGGVIAGSVTGTGTISYDSIAARLDREGLQLGERD
+                     GQLVVTAPVELLGERVPVSGTADITVDQGQVSLRFTDLTPDGVPNGSLVRALLSSFAEG
+                     ISVDVPLPVLPFDLTVSEVRPLPEGLQVTAEAAEVPLHAAS"
+     gene            complement(65265..66296)
+                     /locus_tag="B170_RS0101445"
+     CDS             complement(65265..66296)
+                     /codon_start=1
+                     /inference="COORDINATES: similar to AA
+                     sequence:RefSeq:WP_018726406.1"
+                     /locus_tag="B170_RS0101445"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /product="hypothetical protein"
+                     /protein_id="WP_027654933.1"
+                     /transl_table=11
+                     /translation="MLPSSRPETGREPWPEQPSSGPPAPRAGGDDGRSERGGPRRARRD
+                     GESGRRPAGDPGDGHDQDVEEVPPVEVRRTLALAVAGFAVLLGMGLVLAAQTSGPGHRL
+                     PFTAVIFGVQALSVLTWTMAFRPPALMTVAGVGAVAAIVADTVAVRSDPARLMPLVQVL
+                     LVGLVAAVVGQFVRRVDRAQVLESLRGTVLIVAGVVAFPTMIVLTRIPMGTQVITVCLA
+                     AAGVALAVARITDAFAAWPRLAPQVPRGAAGVVGGAMIGTMVSALLGSYLVTPFTPTRA
+                     AIIGLVAAVVAVLADLAVGFAEAGREMAGEPTAGWAIQHIQGPLTGLALAAPAAYALCK
+                     LVL"
+ORIGIN
+        1 cactgcaaac acccacaccc gggattcctc ccacggcagg accaacaccg cgcgggtcac
+       61 cggagcccac cgggctactc gttgagaaag gcggagatgc gctcccgcag gtcagcacgc
+      121 ttggcccaga ggacgccagg ccggtcgtac acgtgcaggg tggcctgggg caacgcggcg
+      181 gcgagccgct cggcgaccgc aaccggatgc agctcatcgc ccacacaccc gatcaccaga
+      241 gccggcgccg tgacctcggc gagttcagcg gcgtcgcgga ccggcactga ttcgggcagg
+      301 ccaaccagtc ccgaggcgag accgtcccgc atgagctgat caaggcgctg ccggaggtat
+      361 gcccagccgg ccggcgtgtt ccggatggcc ggtggaagct ccagctggac cacctccgcg
+      421 agctgaccga catcaccact gccgagcgcg tcgagtagcg ctgtcagccg gcgacgggcg
+      481 gcatcgcccc gcggctggtc cagcaccgcc ggcagataaa agaccagccg gtcgaagcgc
+      541 gtcgggttgt cggcgagtag ccggcagagc gcacccgcgc cgaggctcgc gccgaacgcc
+      601 cgggtagcgc gcccccggtc ggcgaccgac cgcaggtcgc gcgcgagatc gcggtaggtc
+      661 catggcccgg tcggtgcggc ggagcggcca tgcccacgga actggaagaa gagtctgcga
+      721 ccggtgacgc cactaccgaa gggacgggtg gtggcgatgc cgctgcccag accgtgcgcg
+      781 aagacggtga ccgggtcacc cgcgccggtg accaactgct ccaggtggac gccgtgcggg
+      841 gtggcgacca gctcggtctc cggctccggc agtgccggcc gaccggtgcg gggagcactc
+      901 ggcccggggc cccaggtgcg ggggccgcca tccggtgggg gcggccaccg gaagcctctc
+      961 accaggagtt cccccggccg ccccggaggt cccgcagacc agtccggacg tcaagcagat
+     1021 agatcaaccc agcggcgata ccgaccaggc caaagaggct gatcgggccg aagccaagca
+     1081 gggtgagcac cagacagacg gcgaggatcg ccgcccatgc acccttcgga agggtgccga
+     1141 ccgcggcgaa cgcgtcggac cgctgggtga tgacgtggac cagggcgact ccctgcacga
+     1201 tgagtgcgaa gacgagcagg atcagctcta taacgtagcg aacctcaaaa gcgaacggcg
+     1261 cggcgatggc catgccggca agcatatgcc gaagaccccg gaggcgtccg tcaggccgct
+     1321 tccggggtct tcggcatcac cggacactca cccgtcgcgg gaggtcagtc gcgggccggc
+     1381 ggggtccgct tcgtcgcgcg cggtgacttg gtcgccgagg aggccggctt gccggcggcc
+     1441 ttggtggcac gcttcgtgac ggccgccggc ttgacctcag cggcctcggc gagctgcgcc
+     1501 ggagtgggcg ccggcggctg ctcggtcgtc tcgatgtcgg tgttcaccgt gtcggcggcc
+     1561 tcgagcacgc cagcgccgac gacccgctcc ccgtggccga cgagcgcgcc gtaggtggtg
+     1621 accgcccgct cctgcgcggc ctgcgcactg gcgaccacaa cggctgcgtt gcgggtggcg
+     1681 gtctcccgaa gccgactgag gtccaggtcg ctggcggccc gccggcgcag gttctcagcg
+     1741 gtagcggtcg ccgtacgcaa tgtctcggtg gccttctggc gcagctcggc cccgttaacc
+     1801 gtgccgaggt cggccgcgac ccggttgcgc agctcggtca cggccgcggg aagctttcgc
+     1861 agctgctggt acgccagatc gccggcgccg gcggcggcgt agaggggggc agggatacga
+     1921 ctggttttcg gctgactagt catcatttct cctctttggc cgcgtcggcg gcttcggggt
+     1981 cacccttcgg gcggactgct gcactggcgt cgggacggga atggagtcgg ggtcgatggc
+     2041 gatgcgactc acgcaccacc ggtcggcgtg cccccggtcg tcgttgggcc ggtgaccgcg
+     2101 atgttcgcca ggtcggcgga ggtcccggac ggctgggccg ggcccggctc cggttcggtg
+     2161 gtgggcgaac cggcgaccga ttcggtggtg accgtgccgg tcgtgacttc ggtggtggac
+     2221 ggggcggcga ccgattcggt ggtgaccggg ccggtcgcgg cctcggccga cgccgcatcg
+     2281 gcggcggcgg tggcctccgc gagccgcgcg ttctctcgac ggaacgtctc gtaaatctgg
+     2341 gtgagcgact gcttctgtgc catggtcagg tcggggtcca cggctatcgc ggcgagcacg
+     2401 ccctgcccct cacggtcgtc cagcagcccg gcccgtaggt acatcgccgg agtggagacc
+     2461 cgcagcgcgc tggcgagctg ctgaagcacc tccgcgctgg gcttgcgcag cccgcgctcg
+     2521 atctgactca gatacgggtt actgacaccc gcctgctcgg acagctgccg gagggagatc
+     2581 ttcgcactcc ggcgcaggtc acgaatgaac ccgccgatgt tgggaaggtc tttaccactg
+     2641 gccataactc aacgctagct cgcggtgcta actcctgcaa gcaaaacgct agccagagtt
+     2701 agcacagggg tgtgccccgc cgtccgggtg ctggccaccg agccgcagcc agcaccacac
+     2761 caaatcacct ttcgtcagag cgggtcacca gagcgaccgg atggcgccta ccggccgccc
+     2821 accgccgagg agtgggacct cggcgaacac cgccaacgcc ggtgcggtca ccccgagccg
+     2881 gcgcaacgcg gagaccagca ccggcatccg ggcccggccg gcaccatcgt cgatcttcaa
+     2941 cgcgatcgcg ccgacgccgg ggaccgccgc ggcgatgacc ccctccaccc cgatcttcgc
+     3001 gagtagcccc ggcacagccc gcatcatccg gctgtcgtcg gcccgcgtac cgccgacaat
+     3061 ctccggatgg gcccgcatcg agtccgccac cgcccgctcc ggcgagcccg gctccgcctg
+     3121 caccagccgc aggtacgcca gcgcgaggcc ggacaacgac acggccagca ccggtgcgcc
+     3181 acagccgtcg atcccgaccg ccgccgccgg ctcgtcggtg aactcctcaa ccgctgcccg
+     3241 caaccgctcc tgcaacggat gctcgctgcg ccagtacccc tccccgggcc aacccgccgc
+     3301 ctggcaggtc agcagcattc cggtgtgttt tccggagcaa ttcatctgga tccgggtcgg
+     3361 gccaccgccg gcgcgcaaca ccgccgccct cgcctcctcg tccgccggca ggtccggcgg
+     3421 gcagtgcaac gcggactcgt cgagcccggc ccgcgccagc aacccaccga cccgggcccg
+     3481 gtggaattcc tccccctcgt ggctggccga gaccagggcg aggtcagccg agtcggccag
+     3541 ccgcaggccc gcacggatca tcccgaccgt ctgcaacggc ttgttcgacg atcggggaaa
+     3601 gatcggcgac gtcacatccc ctgccttcgc caccgccgcg ccagtcgcgt cgagcgccac
+     3661 caccgaccca cgatgcacgc cctcaacgaa acctgaccgg accacctcag cgagcggcac
+     3721 gccgccctcg tacgtctttc ccacggcgtg gacgttaccg cccttcggga acgtccagcc
+     3781 gaggggtgac cagggaattg ggaacacaac gtcagggggc gacccccaac gcaccactta
+     3841 ccggcgaggg gcgggcacgc cgagcagttc ccgggcctcg gcggtggtga gcggagggcg
+     3901 ctgagcgagc tgggcaaagc cgaccgcgcg ggccacgagc tgcatattgg actcgaccgg
+     3961 ctgtcccttg gcataggtca ccgtgtcctc catgcccacc cggaggtgtc cgcccgccga
+     4021 gagcgaagcc agcaggaccg ggatcgtgct acgaccgacg ccggtcgccg agaaggtggt
+     4081 gccggctggt aggtcccgca gcatctgctc ggcggccacc agggccgcgg gagtgccggg
+     4141 cattccgccg ggcacgccca tgacgaggtc aacgtgcaca tgcccgccgg ccggcaggcc
+     4201 gtacttgccg aggaggcgtt gtagggcggt gaggtgcccc aggtcgaaaa tctcgtactc
+     4261 cgggacgatg ccgcgctcct gcatccgggt gtgcagctca acgatgaatt cccaccggtt
+     4321 gagaaacacg tcggtgccga agttgaccgt gcccatcgtg caggaggcca tgtcaggggc
+     4381 ggcatcaagc acagcgagcc ggtcggcctc cgggtcactg accgcaccac ccgaggagag
+     4441 ctgcacgacc aggtcggtgc tctcgcgaag cgccgccacg gtctcgcgca gccgccgctg
+     4501 gtcgagggtc ggctgcgccg cgccgtcccg gatgtggacg tggaccacgg cggcgcccag
+     4561 cgcctcgcac tccttcgcgg tcagcagcag ctcatcaagg gtgaccggca gcgccggcac
+     4621 ctcaaccttg gccgactcgg ccccggtcgg ggcaaccgtg atcaacgtcc ctgtcgtcat
+     4681 gtccggatcc tagtcgcccg accgatgacc gtccggccgg aattcttccg gcatgccggc
+     4741 tgtcaagcct gaacccttcc gctgtcggca gcctcagacc gggttccttc cctagctatc
+     4801 gatcatcgcg gcggtctccc cgaccagcag ccgggcgtcg tcgggcacgt tgcgcttgac
+     4861 caccgccagg gcgacctggc ccagctcgtg gtggtgcacg gcggtgccga cgaagccgac
+     4921 cgcccgcccg tcccgagtca ccggagtgcc ggccgatggt ggctggtccg tggtcacccc
+     4981 atccagatgc aggaggacga gccgacgcgg cggtcgaccc atgttgtgca cccgggccac
+     5041 cgtctcctgc ccgcggtagc agcccttctc caggtgtacg gccggcccga ccaggccaac
+     5101 ctcggccgga atactccggt ggtcggtatc cagcccgacc cggggccgac gggcggccac
+     5161 ccgcaccgcc tcgtacgccc agagcccggc gaccggcacg cccgcgtcgc tcagctcagc
+     5221 caccacccga cccatggcct cccgagccac cagcaggtca acgccgagcg ggccgcggcg
+     5281 ggcccagccc ccgaccggta gcgcacgaac gtcgtaacgc accgtcgacc ggggcggtac
+     5341 cgagccggcc cggaacttcg ggccgggcac ctcgagcagg tccggctcgg ccaggccgga
+     5401 gacgccgagc gtcgccacgg cgtccaccgc cgccggcccg accagcgaga gcagggcgtg
+     5461 gtccggcgtc acgtcgcgcg gttccacctt gctgaaaaag cgcatccgct ccagataccc
+     5521 gagcagccca gcggtgtcgc ccggctcggt gtccagccag gtcgtaccgc cctcctcggc
+     5581 caccatcgcg tgctgctcga catgcccgtg cggggagagc accagcaact cggtgccctg
+     5641 cccggcgggc aggtccgcca ggtgctgggt ggtgagcgtg tgcagccagc cgaggcgatc
+     5701 ctcgcccggc accgcgatca ccccccggtg cgaacggtcg accaggccga cccccgtctc
+     5761 cagggtgcgc tgctcgcgca gcggatcccc gtagtgcgcc gccaccgagc ggacccccgc
+     5821 cgcggcgtgc gccggctccg gctgatcccg gctgccctcg tcaatgctct cgacggagac
+     5881 cgccccagca atatcgatca ttcctgcgcc ccgttctcac agcgatcaca gcggccgaag
+     5941 agggagacat ggccgacgtc cacccggaac ccccgctgct cggcaagctg gtcagccaag
+     6001 gggcgcagca gggcaggatc gatctcgtcg atcgcgccgc actcccggca gaccaggtgc
+     6061 acgtgctggt cctcgccggc cgcgtggaag gtcggcgagc cgtgcgagag atgggtgtgc
+     6121 gtcaccaggc cgagccgctc cagcagctcc agcgtgcgat agatagtagt gatgttgacg
+     6181 cctgcggcca cctcccggac agccgtgtgg acctgctccg gggtcgcgtg ccccagctcc
+     6241 aacaccgcct ggaggacgag ctgccgctgc gccgtcaagc gcagcccacg ggcccggagc
+     6301 agttccgcga gggaggattc ggacaccgtc caagcatagt tcgctcgggc cgaacagcac
+     6361 tctcccgtcc taccggcccc gttctgccga cgcccgtgtc ggtggtgccg ggccggacgg
+     6421 tacccgacgc ggcccggctg ggccctatgc tcggcggcca tgacgacggc gaggatcgcg
+     6481 gtgctcgggc ggggccgggt gccggtcaca gagccagtgc tgcgcggcga cgacctgggc
+     6541 gtcctacacg gtgacggcct cttcgaaacg atgcacctgc gggcgggtcg gccctggctg
+     6601 cgggaggcac acctggaacg gatgacgagg gcggccccgg tgctgggtct gaccctgccg
+     6661 ccggccgatg ccctggtcgc gctgctcgag gagatctgcg ccgactggcc caccgaggtt
+     6721 gagggggcgc tgcggctggt ctgcacccgc ggcgtggccg acggcgaggc cccgaccgcg
+     6781 tacgccacgc tggccccggt gccgccgtcg gcccgggcgg ctcgccggga cgggatcacc
+     6841 gtggcgacat tgccgctggg cgtgccggcc aacggccgcg ccggcctgga ctggttgccc
+     6901 accggcagca agaccacgtc gtacgcggtg cacaacgccg cccgtcggtg ggcgtcccgc
+     6961 aacggcgtca acgacgcgct ctggacctcc accgacgggt acgtcctgga ggggccgacc
+     7021 gccaacgtcc tctggctcac cggcggggcg ctgcgcacgg tgcctgccgc ggccggcatc
+     7081 ctgcccggca ccaccgccgc gtggctgctg gccaacgccg aacaggtggg gctggccgca
+     7141 tacgagcagc tggcggcccc ggccgagttg cacgccgcgg acgcggtctg gttcagctcg
+     7201 tcggtccggg gcctggtcga ggtccgtgtc ctcgacggca tcggccgacc gcggtcgacc
+     7261 tacacccggc ggctgcaggc cctactcggc ttccccgttc cgcccgacga cgaccaatcg
+     7321 gactgacctc cgccgtcgcg gatcaaccgc actgacctac gccgcgaatc agccggatca
+     7381 gccggactga tctcagccgc ccacccggat cagccgggcg gacaggtgcg gggtgaggcc
+     7441 gtggccgacc gcggccatct cctgcgcgta gagcagggcg ccctccacga tgccgaagag
+     7501 gcggtgaccg gcggtcacct ccttcgcggt gggggtgcgc accaccgcgt cggtggcgaa
+     7561 ctcgagctgg gtgccggtgc gcttgccgag gtgcagctcc atcacgccgg tgggcgtgct
+     7621 catcagcgcc tcccactcgt tggtcgcccg gtcgtcaccg tcgagcaccg gccgccacca
+     7681 acccatctcc cgcccggccg ggcggaccgg gcggctctgc tcgtccagca gccacgcccg
+     7741 cgactcgtag cagaggaacg gtcggccgtc gtggctgatc cggatctcct gggcgtagtc
+     7801 gaaatcctcg atggtggggt agccgccccg gccccgaccc cgccacaccc cgatgtacgg
+     7861 cagcaggccg tccagagtgg ggtgcaattt cggcccggta cgcaggtcgt ggctctcctc
+     7921 gtaggggtac gggtccaccg gaggcgcgtt cagccacggc ggctgaagcg gattctcgtc
+     7981 actcactaat gccctctcga aatgcgtacg gcgaggtaga ccaagccgcc ggcgagccca
+     8041 cccagcgcgg cgaccagcaa acttacgaac cctatctcgg tgaccatcgg cgactatcct
+     8101 atgctggcgc tcgtgggccg aaacctcgtc gtcaaggtca ccgccggagc ggattccccg
+     8161 gagcggtgcg cgcaggcctt cacggttgcg gccaccgcgg ccgccgccgg agttgacgtc
+     8221 tcgctctggc tgaccggcga ggcgacctgg ttcgcgctgc ccggccgggc gcaggagttc
+     8281 gagctgccgc actcggcccc gctgggcgag ctactgcacg tgatcctgac gacgggccgg
+     8341 gtgaccgcct gcacacagtg cgcggcccgc cgggacatcg ggaccggcga cgtgctgccc
+     8401 ggcgtccgga tcgccggctc ggcggtcttc gtcgaagagg tcatggccga ggagagccgc
+     8461 gcgctcgtct actagcgctc cacgacaccg tcccaccgca ggacgccatc ctttggcgcg
+     8521 ggcggaagcc tcggctactg gccacggcga gccggctcag tcgaccgaat gggtggcacc
+     8581 ggggacggcg tggtcgatgg ggccatcgaa ccgagtcgag gcacgtgcca ccgcctgttc
+     8641 tggggtgagg aacctcccga tgtgcgtgac gatcaggcgc cccaccccgg ccgctcgagc
+     8701 agtctcaccg gcatcctccg gtgtgtggtg aacccgttct cccgcgctcg ggacctgcgc
+     8761 gctctcggcc tcacacagca gcacatcgct gccctcggcc agactcgtca ggccagagca
+     8821 gggggctgtg tccccggagt acaccaacga ccgcccccca atatcgacac gcaatgcgaa
+     8881 ggcggggata ccgtgcgcca ccgaacggct ggtcaacgtg agcgcgccga ccgccacccg
+     8941 atccccgtcg tgtagctccc ccacggcgaa ggcggattcg atcgggctgc gggtcgcggt
+     9001 gttggtcaga aagtgcgcca atcggtcggc gatgccaggc gggccgtaca acgggatcgg
+     9061 agccgcaagc tggatatcgg cgtacagcgc cccgtagtag gcggtcagga ggtcggcgct
+     9121 gtgatcagcg tgcaggtgcg agatccagat cgcgtccagt tcgtccagcc ggacatgtcg
+     9181 ttgcagctga gccagcgtcc cgctgcccgc gtccacccac acccgagcac cgccacccga
+     9241 caccaggtag ccggaacagg gattgtccac actcgggtag ggcgttgcac aacccagaac
+     9301 cgtgaattgg agcttctcgc tggtcatccg cgaaaggcta ggagactcgg ccgacacatg
+     9361 gggacgattt ctccctcctc agtcagcgca cccggtcgag aacgccaggt gcagctggtc
+     9421 accggtggcg tcggcgacga tcaggtcggc gccgcgccgg taggcgtacg cctcgggtgt
+     9481 gtcgaccacg acggcgccgg ccgccaacgg ggccagggcg ctcaacgacg ccggcccggc
+     9541 gccggcagct acccgctggg tccatgcctt cgcacccccg gggcaggggg ccacgacctc
+     9601 gtccgagtgc tcgggaaccg ggcggcccaa cgcctgcaac gcggcgcgca gcgccggttc
+     9661 gggcgggttc ccaagcagcc gatcgccgga cccggcgtcg gtcgggcgac agccggtcag
+     9721 tacctcaagc cgaacccggc ccggactcgt tgactccccc tcgaccagga cgaactcacc
+     9781 ggcatcggcg cgcagcagcg ggccctcggc ggcgtcccga acgccggccc gccagcgtgc
+     9841 cggcagcgcc tcggtgacct ggctgagcag ctcgcgctcg cctccctcgg cgaccaggac
+     9901 gtcgatccca cgggtcagtt cggcgcccgt gctgaccggg gttacccggc agccccgctc
+     9961 cacgcgggac ggggtcatcg cccacgccgt gccgtcgagc gccgcgacga gttggccgac
+    10021 cgccgcgctg accaccggcg ccgcctgctc aatcgtgcgc tgctcccgca ctgtcggctc
+    10081 gtcggtgcgg gccgaccacc aggccagccc cgccagcagc accgcccagg ccatcgtgcc
+    10141 cgcaatcagt aggcgtcggg cccacggccg ggacggcggg cgatcaggcc cggagggtgg
+    10201 ggcatacccc ggatggacgg cgctcaccgc gccatcgtgt catgtcccgg accggggtca
+    10261 gccgccgccg ggacggccgc actagccgcc cgcgtcgtcg gagcccagga cgagccggta
+    10321 gccgaccccg cgcacggtca gcacccgtgg gccaccggag agcaggcgca gcttgcgccg
+    10381 gagccgcttg atcgccgagt gcaggatcgc ggtgtcgccg aggtaggcgc cgccccagac
+    10441 cgcggcgaag agtcgctcgt agctccagag ccggaccggc ggggtcacca gccgggtcaa
+    10501 caagcgccgc tcggtacggg tcagcgccag tggatgtccc cgccaggtaa ccaggtgccc
+    10561 cggcgggtca accaccagct cgccgtagcg gaccggggca ttcggtggac cggtaccccg
+    10621 ctcctcggtg acggatggtt caggaaagag catcgcccgc agctccgcaa gatcggcaca
+    10681 gctcagcacc ggccccaccc cgtcgagccg acgcaacacg cgctcgcgca cggccatatc
+    10741 ggaactcacg cagaccacga tcggaccttt cccctcagac acacagcctc cccaggcacc
+    10801 cgcgtggacg tgaccagcat cacctccgtc gagatgatgt ccggccgaac accgagtcag
+    10861 cgtacggcca gaaacgcgcc cagtcactga tcgaatactg accgagacaa tttattgatc
+    10921 agcgtcggta ctttcacgag catggctggc gcgggctcgg aacagcccgg gcccgcggac
+    10981 gtggggagga cacgtgttcg tacgaccatc cgcgcggtca cgcctggggc gtctggccgt
+    11041 cgcgttcggg gcgctggtac tggggttgag cgcccagccc gcgctcgccg cgtcgccgcc
+    11101 cggcgcatcg gagcgggcaa ccgtcgcgtc cgagctgctg gagaccagcg acagcaccag
+    11161 tttcctggtc tacctacggg aaaccgcacc gctcgccagc accgcgaccc tgcaagcgcc
+    11221 cgatgaccgg gcccgtgcgg tccaccaact cctgaccaac accgccgacc gcacccaagc
+    11281 cgacctgctg cggctgcttg aggcgcggaa ggcggagcac acctcctatt ggatcgccaa
+    11341 cgccatccag gtccacggcg accgggccct gatcgacgag atcgcgaacc ggcccgaggt
+    11401 cgagcggatc gagccgatcc gcagtcgcca gctgatcgag ccgacgcccg ccgaggccga
+    11461 ggcccgcacc gacgccatcg agtggggcgt cgccgagatc ggcgcccccc aggtgtggga
+    11521 cgagttcggc gaccgcggcg aaggcatcgt gatcgccaac atcgacaccg gcgtgcagta
+    11581 cgaccacccc gccctcgtca actcctaccg gggcaacctc ggcggcggca gcttcgacca
+    11641 cgcctacaac tggttcgacc cgacgggcat ctgctccgac tcggagccct gcgacaacaa
+    11701 cgaccacggc acgcacacga tgggcacgat ggtcggtgac gacggggccg acaaccagat
+    11761 cggtgtcgca ccgggtgccc ggtggatagc ggcgaagggc tgcgaggtca gcacctgctc
+    11821 ggacgccgcg ctcctcgcct ccggccagtg gatcctggcc ccgaccgacg ccaacggcga
+    11881 gaacccccgc ccggagctgc gccccgacat cgtcaacaac tcgtggggcg gcggtggcaa
+    11941 cgacccctgg taccagcaga ccgtcgacgc gtggcgggcc gccgggatcc tcccggtctt
+    12001 ctccaacggc aacagcggcc cgggctgcgg caccgccggt tctcccgggg actacgagag
+    12061 ctcctacgcc gtcggcgcgt acggctcgaa cggcgccatc gccggcttct ccagccgtgg
+    12121 ctccggcacc gatctgatca agccgaacat cgccgcgcca ggggtggccg tgcgctccag
+    12181 cgtccccggc ggcgggtacg ccgcgttcaa cggcacctcg atggcagccc cacacgtcgc
+    12241 cgccactgcc gctctgatct ggtcggtcgc ccccagcctc cgcggggacc tgccggcgac
+    12301 cgaggcgctg ctggaccgta ccgcccgcga tgtcgatgac accacctgcg gcgggaccgc
+    12361 ggccgacaac aacgtgttcg gcgaaggccg gctcgacgcg tacgcggcgg tcaacgaggc
+    12421 cccccgcggc ccggtcgggc gggtcaccgg caccgtgacc gcagccgagg acggcgagcc
+    12481 gctcgccggg gtgaccatcg acgacggcac ccgcgacacc accaccggcg ccgacggccg
+    12541 gtactcgctg accgttccgt ccggtgagac cacggtgacg gccaccctgt acggctacga
+    12601 gtcgcagtcg gacaccttca ccgtggacga gggcggggcg gtgacccggg acttcgcact
+    12661 cgtcgagagc cccatggtca cggtgagcgg tcaggtgacc gacggctccg gacagggctg
+    12721 gccgctctac gcgaaaatca acatcgccgg caagcccggc gacccggtct tcaccgaccc
+    12781 ggtaacggga gagtggtcgg ccactgtcgc cggtgacaac acctactcaa tcaccgccac
+    12841 cccgcagtac ccggactacc ggacggtgac ccgggaggta ccggtcggta gcgatgccac
+    12901 caccgtcgac atggctgttc agatcgcgga atcctgcacg gcggccggct acaatgccag
+    12961 ctacgacgac ccgctcctga cggaggactt cgccgacagc accacgccgg aaggctggtc
+    13021 ggtggtcaac cgcaccgatg agggcggttg gaccttcgag gacctcggcg gacggggcaa
+    13081 cctgaccggc ggcagcggcg gcttcgcgat catcgacagc gacgatctcg gcctcggcaa
+    13141 cagtcaggac accgacctgg tgagcccgac ggtggatctc tccgggaccc ccgcgccggt
+    13201 gctgcggttc aacactgact ggcgggcaat cggcgtcacc gacagcgccg acatcgacgt
+    13261 caccaccgac ggcggcgcga cctggaccaa cgtctggcac cagaccagca gcctgcgcgg
+    13321 gccgcgggtc gaggaggtgc cgttgacgcc ggcagccggc gcgtcggagg ttcaggtgcg
+    13381 gttccgcttc gccggctcct tcgactggtg gtggcaggtc gacgatgtca tgctggccaa
+    13441 ccggaactgc accccggcgc ccggtggcct ggtggtcggc acgaccagcg accagaacac
+    13501 cgacgcagcc ctcaacggcg tcgcggtgac cagcgtggat cagcccgaag ataacgctgt
+    13561 ctcggccggc acggacgacc cggcggagtc gaagggcttc tactggctct tctccagcct
+    13621 caccggaacg cacccgttca ccgcggagcg ggcaccgtac ccggtggcta cccaggacgt
+    13681 gaccgtcgtc gccaacgacg tgcgacgggc cgacttcgcg ctcgccgccg gaaagctcac
+    13741 ggtcaccccg accgaggtgg agtcacacca gccgtacggc agcacccgga gcacccaggt
+    13801 gacggtgaag aacaccggca ccgccccggc cgacgtcgag gtgttggaac ggtccggcgc
+    13861 gtttgatctg ttggcggcgc cgggggcccc gctgcgcgag gtcacgatga agggcatcag
+    13921 cacggcccgg accgggacca cgttcggtgg agcaccggcc gaggccgaag agtcgacgga
+    13981 caacagctgg acccgggtcg cggacctccc atcgaatgcc ttcgacaact ccgccgccat
+    14041 cctggacggc aaggtgtatt cgatcggcgg cggtagcgcc accggcaacg aacgcgcgac
+    14101 ctgggcctac gacccgggca ccgattcctg gtcggagctg ccgccgctac ccacctcccg
+    14161 gtcgaagccg ggcgtcgcgg cggtcggcgg caagatctac gtgaccggcg ggtggggcaa
+    14221 cgagatcgac ccggacgcca cggttaatgt cttcgatccg gccagcgaaa cctggagcac
+    14281 tctggacggg gtcaccaacc ccgcgccgac cgctgccccc ggaaccgccg tcgttgacgg
+    14341 caagatctac ctggtgggtg gctgcgccaa ctcgagctgc accgcgaccg acgacacggt
+    14401 ggtcttcgac ccgagggccg cgaccttcgc caccgttgcc ccctacccgc agcaggtctc
+    14461 ctggatgagc tgcggtggcg tcggcaccca gatgtactgc gccggtggct cgggcgccga
+    14521 caccgccgcc cacaagtacg acccggcgac ggacacctgg actccgatcg cggacatgcc
+    14581 gctggacctg tggggttcgt cgtccgccgc ggccggcggg atgctcgtgc tggccggcgg
+    14641 gatcaccaac ggctccacca cggtgacgaa ccagacgatc gcctacgacc cggcggccgg
+    14701 aacctggcag gacctgccga acgccgagtt cgcccggtac cggggggccg gcgcgtgtgg
+    14761 ggcctaccgg atcggcggct catttgaccc gttcctcgga acggcggagg tcgaacagct
+    14821 cagcgggctg gagttgtgcg tccaggagac ggagctgccg tggctgagca ccgcaccggc
+    14881 cagcttcacc ctggagccgg gcgagtcccg caaggtgcag ctgaccctca cggccaccgc
+    14941 tgaggccggg gttgagcagc ccggtcgcta cagcggcgag ctggccttcg cggccgacgt
+    15001 gccgtacccg accacgccgg tgaaggtgga gatgaacgtg tctccgccga agagctgggg
+    15061 caagctccag ggcacggtca ccggggttac ctgcggcggg gagaccgtcg gcgtaccggc
+    15121 caccgtccgg gtgaacgcga ccggcagcgg cgccggctac accctgacgg cggacaactc
+    15181 cggcacgtac acggtctggc tgcccaaggg ccgctacgac gtgatcgtcg ccaaggacgg
+    15241 ttgggttccg gagttcgacc gcaccaaggt tgaggcaggg ttcgtcgcga ccctcgactt
+    15301 cagcctggaa ccatcgtcgg actgcacgaa agcaagcggc atctgagtag gtcggtggcc
+    15361 ggcgacccga aagggtcgcc ggccactacc gttcccaccc gccgaggagt gtcgttccca
+    15421 ggcgacccga cggtcgtcgc ctgggagcgg tcaagggcag taggggatgg cgtccgtgcg
+    15481 tcaggcctcc cccacggaca tgaagcccgg cagggtcgtg cccaggccac gctcctcggc
+    15541 tttccgccgg accatcgccg ccactgccag atccaggcag cccaggccga acggagagaa
+    15601 gaccgtcagc gagctgtcgt cgcggctgta gcgatcgccg gccacgagga gctcgccgag
+    15661 tgaggcagcg atgaagtcac gcccgccgga ctgctgctcg gcgaggtgca gcgaggtggc
+    15721 ggcgcggcac acgtggtccg cgtcgtccac gatgttgata ctggtctgga tcgtctcggc
+    15781 gctgaggtca cgcagcgaca ggtgcaggac caacgcgcca gggcgcaagt gctccccggc
+    15841 gagatgtggc acgctcgcgg tggtcgccaa cgtgacgagc gggtgcgcgg cgagagcctc
+    15901 ctcgacccgc gcggcgacct ccaccttgag tctcggccac ctcgcgttca cccgggcggc
+    15961 gaaggactcc gcgcgcgctc ggtcgagatc gtacagggtg atctggtcca gttccggctt
+    16021 gacgagctgc agataccgca gcacctcgaa gccgatcggg ccgcacccga tctgcgacac
+    16081 gcccgactcg ggatgcgacg agcccagggt taccgccgcg agcgcggcgc tcgcggcggt
+    16141 gcgctgtgcg gaaatggcgg cggcctccat gaaaacctcg ggaaaaccgg tccgcgggca
+    16201 gttcaagatc atggatgccg atgctcggtc ctgacccagc cggaggttac ccgggaagga
+    16261 cgcgacccac ttgacgccgg ccaccggggt ccgggttccc aggtaggccg ggagcgcgat
+    16321 aatgcggttc tgcagatcgg ccgggaaacg caggaagacc gagtgcggca ccgccgtacg
+    16381 ccccagagcg tgcagctcgt acgcctctcg caccgctgcc agcacgtccg attccgcgcc
+    16441 gtccagaacc aggttcacct cacttttacc caacatcagc atgacatcgc ctccatctcg
+    16501 ggttccttcc acaggtgggc tacatcaccg aaatgcatgg cgacccaatc gtcgttataa
+    16561 atcgtgtcga gataccgctc accccgatcg ggaaagacca gcgcgcacgt cgagcccggc
+    16621 ggaatccgat cgcgcacgac gtccagggcc gacaccaccg ccccggacga accaccagcc
+    16681 aggatcgcct cgcgggcggc caagcggcga cacccgacga tggcgtcgag gtcgtgaacg
+    16741 cggatcactt ggtcggcgag gccgtcggcg tacaggctcg ggcggaccga cgcgccatga
+    16801 cctggaatca gccggccccc gacgggaggc ccgaaaatcg cgctacccag tgcgtcgacc
+    16861 gcgacgacct gagccggcag ttgatgacgg cgcaggtact ccgcgcagcc ccgcagggtg
+    16921 ccgcaggagc tggtggcaca gaacacaaag tccagcgtcg ggagtgcgtc caggatctcc
+    16981 cgcacggtgc tgtggtgcgc ccgcgggttg agtgggttgg cgtactggtt ggggcagtag
+    17041 gcgtgcgtga tgctctcgac gagctcacga acccgacgaa tccgcaccgg gaggtactca
+    17101 ccagaaactg ggtcgacgtc ggtcaccact tcgacctcag cgccgtacgc acgcataatt
+    17161 gctatgttct gacggttggt cctggggtcc accacgcaga tgaagcgaat tccgtgatag
+    17221 gcgcagatct gggcaaggcc aatgccgagg ttgccggagc tggactcgat gacagtagat
+    17281 tttccgggca caagtcggcc atcccggatc cgctcctgga gcatctccag ggcggaacga
+    17341 tccttgatac tgccaccggg gttgtgtgac tcgagtttcg cgaagatcct gaccgaactg
+    17401 ttggggtcta gtttggtcaa ctcgacgatc ggtgtcgcac cgatcgtcga tagcactccg
+    17461 gacacggagc ttcctccttg gtcgacggga ccgatcaacg aacggtgggt tcggcgtcgg
+    17521 ggacggtggg ggtctcgaca ggtacgaccg gcctgcggag tgcgggggcg aacgtcgcga
+    17581 caagggccag caggcccatc cagccggcga gcaccagtgc ggcggcgcgg gcgtcgaacc
+    17641 attccagcag caggccaccg atcagggcgc cgatcggcaa cgcgccgctg gcgagcaggc
+    17701 ccatcgcgcc aaggacccga ccccgcagtc gatccggggt gattcgaagt tggtgggtgg
+    17761 cgacggcgac gttccacaac gggccgacaa accacattcc ggcatacgca gcggttagta
+    17821 ggtacaggtt gtcggcgaca acgatcgcgc ccatcagcag ggcccagatc cagtttgccc
+    17881 caaccaccag ggccggcagt ggtacccagc gttgacacca gccggcagcg agggagccga
+    17941 gcaccccgcc ggccccggcg accccgagca acaccccgac tgccgccggc gacgccccga
+    18001 catcggttgc catcaccacg acaacaagaa acagtgcacg gaacaggagg ttgctgccgg
+    18061 cgacgagtag tgcggccgtg cgcaggaacg gctggcgcca caaccagcgc atcccctcgc
+    18121 cgacctcggc gagcagcccg gtggttcggg tacgcgctgg ttgtcgacgc tggaagtccg
+    18181 cacgaatgaa cagcaacgtg accagcgaga tcacgtgagt gacggcgtgc agcagaaacg
+    18241 gcatgatgcg gctcagccca aacaggaccc cgccaagagt ggtgccgagc atggtcgccg
+    18301 cccgggaacg cgcctcgttt cgggacagcg cggccgacag atggtccgga tgcacgatgt
+    18361 tgggcacggc ggcgtgtgcc gccaggttga agaacaccga catcgtgccc tcgacgaagc
+    18421 ccaccaccac cacgtgcgcc accgtcaact cgtcgagagc caacgcaagg actacgctcg
+    18481 cggccccggc cgctcgaacc acgtcacacc agatcatcag ccgacgtcgg tcccaccggt
+    18541 caaccaacac cccggccggt agttggaaca gcagtgccgg aagtagcgaa aagaagccaa
+    18601 cgacaccagc tgcggctttc gatccggtag ccgccagaat caacaatgga taggcgaccg
+    18661 tagatacagt taggccgacc agggataccg cggtcccgct ccagagcaac aaaaagtcac
+    18721 ggttgtgacg caacttggaa accggcgcac caggccgggg ttgcgcggtc gtggtcatcg
+    18781 gtccgctcca tcgatgcgat cgtctgggcc cacaggtcgg gccgacaccc gtccagtggc
+    18841 aacgtcacgc cggggaccca tcgagagcgt gccgcgcctt cccgtgcccg atgcagagaa
+    18901 gaacgcgcac agatgccagc agcaggcatg cgaacggagc tgccagttgt tctctgcagc
+    18961 cgggctgccc caccaggaac cctgaatagc atgaagacga gccctcttcc tcagcctctg
+    19021 cggactccct cggacgctga gccggcgctc ccgtatgtcg tgacggcacc ggccccagag
+    19081 acaacggcca cgtcgtttct cgcgacgtcc cgcgaccagg tacgccaacg gttgcgcgag
+    19141 cacggcgcgg tgctgctgcg tggcttcgat gtcgacggtg tcgacggctt cgaccagatc
+    19201 gtgcgctcgg tatccggcac cccactcagc tacgccgagc gatcctcgcc ccgtagcacg
+    19261 atcaagggcc gggtctacac ctcaaccgac taccccccgg gcgaggagat cttcctgcac
+    19321 aacgagaact cctaccaggc gacctggccc atgacactct tcttttactg catcacccca
+    19381 ccggagaccc ttggggccac cccgctggcc gacacccggc aggtcctccg atcgatcgat
+    19441 ccggccgtac gcgacgagtt cgcccgccgt ggctggaccg tggtgcgcaa cttctccgac
+    19501 ggtctgggcg tgccgtggca gcaggcgttc aataccgaca agcccgccga ggtcgaggcc
+    19561 tactgcgccg gcaacggcgt cgaggtggag tgggtcggcc gcaacggcct tcgcaccacc
+    19621 gggcggcgtc aggccgttca ccggcatccg gcaaccggcg cggaggtgtg gttcaaccac
+    19681 ctcaccttct ttcacgtgac gaccctggcc gaggagatgt gcgccggcct tcgggagatg
+    19741 ttcgacgagg tggacctacc gacgaacacc tactacggcg acggcgagcg cgtgcccgac
+    19801 gaggtggtcg cgcacctgcg cgactgctac cgcgcagccc agcgccgctt cgactggcaa
+    19861 cgcgacgacg tcctgctcgt cgacaacatg ctcgccgcac acggccgcga gccgttcacc
+    19921 ggaccacgca agatcgcagt cgcgatggcc gaaccgttcc gcaccgctta gaccagagcc
+    19981 cagcacaggg aggcagatcg atggcaaccg gtgatggcgg catctcgctg tcgttcacac
+    20041 aggagcagct gtggttcctc gaccagctgc gatccggagc tgccacggag tacctactgc
+    20101 acgaggcgtt tcaggtacgg ggccccgtgg acgtcgacgc gctcgcgacc gcgttcaccc
+    20161 gggtgtccga gcgccacgag gtgctgcgca cccggtacga gaccgtggac gacaccgcgc
+    20221 ttcaggtggt tgacgatccg gtcgccgtgc cggtggaggt catcgacctg accgcggtgg
+    20281 cggacgccga caccgagcta cagcggatcc ggctggacca gcggactccg attgacctcc
+    20341 gcaccgagcc accgtggcgg gtgacgctgg tccggctcga ccggtccgac tcggtgctgc
+    20401 tgatcacggt gcaccacatc gccttcgacg gctggtcctg gggcgtgctg gcccgcgagc
+    20461 tcggcgagct gtacggggag ctcaccggcg gtaccgccgc gggactggcc gagccgcccg
+    20521 ttcagtacgg cgactacgcc gactggcagc gcgagtggtg ggcctccgcc gaggaggtac
+    20581 gaagcaaaca gctcggctac tggcggaaca cgctcgccgg actggcaccg ctggacctgc
+    20641 cgaccgatcg tccccgcccc tcgcactgga actccgccgg ggacaacttc gacttcactg
+    20701 ttccggttgc cgtcgccaac gaggtcaccc tgctcgcgcg ggcggctggt gccaccccgt
+    20761 tcatggtgta tctgtcggcg tttcagctgc tcctcggacg ctacgccggt cagcgcgacg
+    20821 tcgccgtcgg ggtgtcgttg gcagggcgca acgacgtcca gttggagccg ctcatcggcg
+    20881 cgttcgtcaa caccatcgtc ctacggacga acctcgccgg agcaccgtca ttcgcggaat
+    20941 tgctggcccg cgtccgggaa accacgctgg atgcgtacgg ccaccaggac gtccccttcg
+    21001 accgggtggt acacgatctc gcccccgacc gggacccgtc gcgcaacccg gtgttccagg
+    21061 tgggcttcgc gatgcacaac gccgaacgag tccggctcag cctgcccggc ctggaagtga
+    21121 cgaagctgcc ggccgcctgg accaactccg cgttcgacct gtcgctacac ctctccgagc
+    21181 ggccggacgg gaccgtacac gcgcgcctga tgtacgtcac cgccctgttc gatcgggcgc
+    21241 ggatcgaacg gatggccgcc aactacctgc ggctgctgtc ccgcgcactc gcggagccca
+    21301 cccgcccggt gacccgcctc agcctggtgg cggagccaga gctacaccaa ctccacgagt
+    21361 ggaaccacac gaacgcaccc acgtcgcggc tgctcctgcc cgagctattc ctggcgcagg
+    21421 cccggcgtac tccggacgcc gtcgccgtag ccggcgcgga cggggacctg acctacgccg
+    21481 aactagccgc ccgggtcacc gcgctgacca gctatctgtt gtcccgcggg gtgaccacag
+    21541 aaagacccgt cggagtttcg ctgcatcccg gcgccgacct ggtgacgacc ctactggccg
+    21601 tgctcgccgc cggcggcgtg tacgtgccgc tgccacccga gcaccctgcc gagcgactgg
+    21661 cgatgatggt cgccgacgcc ggcgtggaac tcatcgtcac caactccgcg ctacgggacc
+    21721 agttgcccac ggcgcagctc atcgccctcg attccgacca ggccctgatc gcctcggcac
+    21781 cgaccgccgt accgccggtc atccaccccg gcaacgccgc gtacgtgatg tacacgtccg
+    21841 ggtccaccgg gcggcccaag ggggtcacca tcacccacgg cggcatccgc aaccgggtgc
+    21901 tgtggtcggt tcaccggtac gggatggccc cgggagaccg ggtactgcag aagaccacga
+    21961 tcggcttcga cgcctccgtg tgggagttcc tgtcaccgct ggtatccggt ggggccgtgg
+    22021 tgacgccacc agccggcgta caccgggatc ccgccgcgat ggtcgaagcg gtcgccaccc
+    22081 acggtgtgac ggtgttgcag ctcgtgccgt cggtgctgcg tctcctggtg gaggtgcccc
+    22141 acctggcagg ctgttccgcg ctgcggctgc tctgctcggc aggcgaaccc ctacccgtcg
+    22201 ccctgtgcga acggctactc gacaccctcg acgtcgagat aatgaacacg tacggcccga
+    22261 ccgagtgcgc gatcgactcg accgcggcct ggttccgccg cggcgagcag ggtgagaccg
+    22321 taccgatcgg caccccgctg cagaacatgc gtgcgtacgt cgtggatgcc tcggacgagc
+    22381 tcgtgccgct cggggttccg ggtgagctgt gtgtgtcggg cgtcgggctg gcccgcggct
+    22441 acgtggggcg tggcgacctg accgcggaac ggttccgtcc caatccgtac gcgcgggtgc
+    22501 ccggggaacg ctggtatcgc accggcgacc tggtccgttg gcgcgacgac ggggtcctgg
+    22561 agttcatcgg gcgggtggac gagcaggtca agattcgggg ggtacgggtc gaaccagccg
+    22621 aggtggaggc ggccgtgcgc acccaccccg acgtgggcga ggccgtggtg accgcgcgcc
+    22681 gtggcgagtt gggcgacctc gaactggtcg cctacaccgt gccggcgaac ggcaccccgg
+    22741 tttccctgga gacgttggcc gcgcacctcg ccgaggtgtt gccggctccg atgattccct
+    22801 cgaaccacgt cggcctcgac gtgttgccgt tgacctcgaa cggcaaggtc gaccgcgcgg
+    22861 cgctaccgga gcccgggacg ctacccgcgt ccccgacgga cgaacacgtc agccccagga
+    22921 cgcccaccga acgggcggtc gcggcgttga tggaggaggt actcggcatc gagcgggtcg
+    22981 gggcggagga cgacttcttc acctacgggc actcattgct cgcgatccgg ttcgtgctca
+    23041 ggctacgccg caccttcgat atcgaactga ccgttggcga tctgttcgcc gcacgcaccg
+    23101 tcgccgcgct cgccgcacat atcgatgtcg ccgccgccga cggtccggtg atcccaccgg
+    23161 tgccccggga cggggtactc cccctgtcct tcgcgcagca gcgcatgtgg ttcctcgacc
+    23221 agctcgaacc cggcagcgtc gagtacctcg tcccgctggc gctgcggcta cgggggccgc
+    23281 tagacaccga ggcgctccgc cgtgccatgg acgccgtcgc cgcccggcac gagatgctgc
+    23341 gcacgcgtta cgtcagtgcg ggtgacagtc cggtacaggt gatcgatccg cccggcccgg
+    23401 tatggttcga ggtggttgac ctgaccggtg cgtccgacgc ggcggtgcag gcgctcgttg
+    23461 accgttcctg ctcccagccg ttcgacctct cccaggagcg tccgctccgg gtcaccgtgg
+    23521 tgcgccgggg ggccgaggac cacctggtcg ctgtcagcct gcaccacgtg gccttcgacg
+    23581 cctggtcgat ggacctgttc atgcgggatc tacggaccgc ctacgcggct atccgtggtg
+    23641 gcgctgacgt accactggcg cccccgacgg tgcagtacgc cgacttcgcc gcctggcaac
+    23701 ggagccgcga ggcagagctg ggtgaccagc tcgactactg gcgggagcgg ctcaccggcc
+    23761 tcgatccggt ggagctgccc actgaccggc ctcgaccggc ggtgcgcgac ccccgtggcg
+    23821 gcaccgtctc cgtcgatgtg cccgatgagc tggcggcagg cctgcacgag ctggccggtc
+    23881 ggcacggggc cacccttttc atgacgctgc ttgccggatt ccaggtcctg ctggcccgct
+    23941 acaccgggcg aaccgacctg gccgtcggaa cgccggtcgc ggggcggact cggccggaga
+    24001 ccgaagaact tctcggcttc ttcgtgaaca cgctcgtcct gcggcatgac ctgagtggca
+    24061 accccacctt cgtcgaacta ctcgaccagg tacgccgtag ttccctggac gcgttcgcca
+    24121 accaggacgt gccgttcgaa cacctcgtgg acgcgctcgc cgccaaccgg gacatgtcgc
+    24181 gcaacccgct gttccagatc atgtttgagc tggcccacct ggaccagttc ccgaccaccc
+    24241 tcggtgaggc cgctatcgag ccggtgcacg cgggggtgcc ggttgccaag ttcgacctca
+    24301 ccctgacggt caagcagcgt tccagggggc ggctgcgatg cacgttcgag tacgcgaccg
+    24361 gcctgttcga ccggtcgacg gtcgagcggc tcgccggcca ctacctgaac ctgctgaccg
+    24421 cgatcgtcgg ttcccccacg gcccggctga actcgctccc cgtcctgtcc gacggcgagc
+    24481 gcgacgtgct ggtgcgggag tggcctgacc cggcgtccac ccggctgccg ctactcgacc
+    24541 cggtggacga gcgccaccgg acggtacccg agctgttcga gcgacaggcc aagcggacgc
+    24601 cggacgccgt ggccatggtc ttcggcgagc aggaggtgac ctaccgcgag ctcaacgagc
+    24661 gcgccaacca gctcgcccac cacctgcggt cgctgggtgt cggtccagag gtcgtcgtcg
+    24721 catcgtgcct ggaacgcggc cccgacgcgg tggtcgtact gctagccgcc ctcaagtcgg
+    24781 gtggggtgta cgtcccgttc gacccggacc atcccaccga gcgactggac ttcatgctca
+    24841 ccgacgcggc ggcgcacctg gtggtgacca cccgggccgc tgcccagcgg ctcgcgggcc
+    24901 atcgggtcgt gaccgttgac gacgaccagc tcgcgaccgc cccggcgact gacctggaga
+    24961 gcccaccgag gccacacaac ctggcctatg tcatctacac gtcggggtcc acgggccgcc
+    25021 ccaagggcgt gatgatcgag catcgttcct acgtccacca ctgccgagtg atcagcgacg
+    25081 cctacggcat cgggccggac gatcgggtgg tgctgctgtc cgcactgacg ttcgacgtgg
+    25141 caatggacca gatcgcggcg actctgctcg ccggcgcgac cgtggtagtc agtgatccgg
+    25201 tgttctggac gccgagcgaa ctaccggcac ggctcgccga gcacggcgta acaatcatgg
+    25261 agatcacccc ggcctactac cgggagttac ttgaggccga tgtcgacagg ttgtcggcgc
+    25321 tgcggctgat gaacgtcggc agtgacgtgg tgacggtcgc cgacgcccgc cgctgggccg
+    25381 cgaccggact gcccgcccgg ttcctgtgca actacggtcc gacggaggcg accgtcacct
+    25441 gcgtcctaca cccggtcgct gggctggacg ccgacgaacg ggacgaggca gcgatgccga
+    25501 tcgggcggcc ggtggccggc acccgcggct acgtgctgga cgccgggctg atgccggtgc
+    25561 ccgtgggggt ccccggtgag ttgtgcctgg gcgggatacg cctggcgcgc ggctacctca
+    25621 accggccgga gctgaccgct gaccgcttcg tccccgatcc gcactccggt gatcccggcg
+    25681 cgcggctgta ccgcaccggc gacctggtgc gctggcggcc ggacggcacg atcgagttca
+    25741 tcggcaggat cgaccaacag gtcaaggttc gggggttccg catcgaactg ggtgagatcg
+    25801 aggcggccct ggccgagcac ccggcagtgc acgcgagtgt cgtcaccgtc cgcgaggtcg
+    25861 ggccgggtga gaaacagctc gtgggctatg tggtcccccg tgaccgctcc cgaccggaca
+    25921 tcgcggaact ccgggcccac ctgcgcgacc gggtaccgga gtacatggtg ccggcccgct
+    25981 gggtcacgct cgacgcgctg ccgctgaccc cgagcaagaa ggtcgaccgc aaggcgctac
+    26041 ccgcaccgtc ggcccccgac ggggagcgca cgttgacctc gccgcgggac gagacggagg
+    26101 cagcgctcgc cgggatctgg gcggaggtgc tcgacgtgga acaggtcggg atccatgaca
+    26161 acttcttcga actcggcggg cactcgctgc tggccacccg ggtgctggcc cggattcgta
+    26221 cggcgttcgc cgtcgacctg ccgcttcgac ggctgttcga ggccacgacc gtcgccgaac
+    26281 tcgcgatcga ggttggcgcg gcggtggagg ccgacgtcgc cctgctcacc gacaccgaga
+    26341 tcgaagccct gctcgctgaa gaagaaggtg cacgatgacc aggacaatcg accgggcggc
+    26401 gctgcggacc gcgctgctgc gcaagcgcct gagcggacag gccggcgcct cccccgaagg
+    26461 cgcccccgcc cgcgtgtccc gcgacggtca cctgccactc tcctctgctc agcggcgact
+    26521 ctggatcctc gaccggctac gaccgggcag ccccgagtac ctgatgacca cagctctgcg
+    26581 tatccgcggc cagctgtgcc ggcccgcact gcagacggcg ctggacggct tggttgcccg
+    26641 ccacgaggtg ctgcggaccc gttacgtcga cgtcaacggc gaaccggcac aggtgatcga
+    26701 cgatccgacc ccggtcacgc tgcaccgcag agacggcctc gacgcactcg acgcggtgct
+    26761 gtccaccgaa ctacccaaca ttgacctcgc cgccggtccg gtcttccggc caacgttggt
+    26821 gttcctcggc gaggacgacc acgcgctggt gctgaccctg caccacatcg ccggtgatgc
+    26881 ctggtcggaa gaggtgatgg tgcgcgagct gggcgagcgg tacacggccg cgtctgccgg
+    26941 ccgtgaaccg gagttcgccg agctgcccgt ccagtacgtg gacttcgccg tgtggcagcg
+    27001 ggaccgctcc tccgggcagg cgctggccgg agatctggcg tactggcggg agcggctcgc
+    27061 cgggctgaac cccctggagc tgccgaccga ccggccccgc ccaccggtac gggacggggc
+    27121 gggcgcgctg gtgcaggtcg acgtgtcggc cccgatcgcc acccggttcg ggcggctcgc
+    27181 ccgcgaccac ggggtcaccc ccttcacggc gttcctggcg gcgttcaagg tgcttctcgc
+    27241 ccgctatacc ggtcagaccg acatcgccgt gggcaccccg gtggccggcc gggcacggcc
+    27301 ggagacccag gacctggtgg gcctgttcct caacaccctg gcgctgcgaa ccgacctttc
+    27361 cggttcgccg tcctttcgcg acgtgttgga tcgggttcgg gaaaccgtcc tggacgggca
+    27421 gtcgcaccag gagctgccct tcgaacagat cgttgacgag cttgccccgg tccgggaccc
+    27481 gtcacgcagc ccgctcttct cgacgatgtt cctgatgacc gatcgggtca ccgaggcgcc
+    27541 ctccttcggg gacctgacgg tgacggccct gccggtcggc gaggtcgcgg cgaagtttga
+    27601 cctgacgttg tcggtgatcg agcgcgccaa cggcacgctc ggggtggggg tgaactacgc
+    27661 gaccgcgctc tttgagccgg agaccatgag ccggttggcg gggcactacg cccacctgct
+    27721 ccagtcgatc gtgtcggacc cggacacacc ggtccgccag ctggcgttgc tgtcggcggc
+    27781 ggagcgaaag caggtggtca ccagctggaa cgacaccgcc gtcgaccagc ccagcgccac
+    27841 cctgccgggg ctcatcgcgg accaggtgcg gcgcaccccg cagcgcgagg ccgtccggtt
+    27901 cgacggcagt tcgctgacgt acgccgagtt ggctgcccgg tcgaatcaac tcgcccacca
+    27961 cctgcgctca ctcggcgtcg gtccggagtc gatcgtcggc gtctgcctgc cccggagcct
+    28021 ggatttggtc gtcgcgctgc tggccgtaca gaaggccggc ggggcctacc tgccgctcga
+    28081 tcccgatcac ccggcggagc gcctgcgcta tctgcgggag gactccggcg ccaccgcgat
+    28141 gatcgatacc gacacgttcg ccgctctcgc cggctatccg acggtggacc cgggggtagc
+    28201 ggtccgcccg gaacacccgg cgtacgtgat ctatacctcc ggatccaccg gacgccccaa
+    28261 gggagtcgtg gtggaacacc ggggcatcgt caaccggctg cgctggatgc agcacgccta
+    28321 cgggcttgac gcgaccgacc gcgtgttgca gaagactccg gccagcttcg acgtctccgt
+    28381 ctgggagctc ttctggccgc tgatcacggg cgccaccctg gtcgtcgccc ggccggacgg
+    28441 gcaccgcgac cccgcctacc tggcccgatt gatcgacagc gaacgcatca ccactctgca
+    28501 tttcgttccc tcgatgctgc gcgcgttcct taccgaaccc ttcgccgggc tgccgtcgct
+    28561 acgccgcgtg atctgcagcg gtgaggcact cacctccgac ctcgtcgccg ccgtgcacga
+    28621 ccggatcggc tgcgagctac acaacctcta cgggcccacc gaggcctccg tcgacgtcac
+    28681 cgcggcgcgt tgtcgtcctg gtgagccggt cacgatcggg acccccatcg cgaacacccg
+    28741 cgcctacatc ctggaccagg atctgcagcc cgttccggtc ggcgtcccgg gcgagttgat
+    28801 gctggccggt gttcagctcg cccgcggcta cctgcaccgg cctgtcctga ccgccgaccg
+    28861 gttcgtgccg gaccccttca ctccgggagg aaggctgtac cgcacgggtg acctcgcccg
+    28921 tcaccgcccc gacggccaga tcgactacct gggccggctc gaccaccaag tgaagatcaa
+    28981 cggaattcgg gtggagttgg gggaggtgga gcacgccctg accgaaaacc cagccgtccg
+    29041 cgccgccgcc gtcaccgtcg acgatgggca actcgtcgcc cacctggtcg gcgacgtcga
+    29101 cctggcgacg ctgcccgact tcctccgtgc gcaactaccc gaggccatgg tccccgcaca
+    29161 ctggctcacg tatccggcgt taccgctgac caccagcggc aaagtcgacc gcaacgccct
+    29221 gtcggctccc gaccgcaacc ggaccacgac tggcgggtac gtcgcgccac gtaccccgct
+    29281 cgaacacatg atcgccggcg cgatcgccga tgcgctggac atcgacaacg tcggcattga
+    29341 ggaccggttc ttcgccatcg gcggggactc catgcgggcg atccgggtgg tcggagccct
+    29401 ccgtgcggcc ggcgtcgagc tggccgtgca tgacctgttc acccaccaga ccgtcgccgg
+    29461 actcgccgga ctcgccggag cggcgaccac ggaggacacc ctcgtcgaac ggttcgccca
+    29521 actgtccgag gccgaccgac agctactgcc gaacggcctg gttgacgcct atccgctcgc
+    29581 cgagacccag gccggcatgg tctacgagat gttggccgcc cccgaccgca ccgtctacct
+    29641 caacgtctct tgctaccggg tacacgacga actgccgttc gacctgaaca ccctgcgtgc
+    29701 cgcgaccgcg atcctggtgg gccggcacga gatcctgcgc acctcattcg acctctccac
+    29761 ctactccgag acgatgcaac tggtgcacgc cacggccgag ttgcccgtgg cccacaccaa
+    29821 cctcaccggt ctcgcctcgc aggctcagcg cgccgcggtc gacgagtggc tcgtggccga
+    29881 acgggggcgt ccgttcgaca tcgcccagcc gccgttgctg cgctaccacg tacacgagat
+    29941 cagtgcggac gagtggtggc tcacccacac ggagtgccac gccatcctcg acggatggag
+    30001 ccacacgtcc gtggtcaacg aactcgtctc gatctaccgg aggctccgca ccggccacca
+    30061 gcccgacctc gcgcctccac cggaggtccg cttcgccgac ttcgtcgccg ccgagaagcg
+    30121 tgctctggcg accagcaccg accacgggtt ctgggccacg gcgatcggcc gctacgacaa
+    30181 gctggagctg ccggacggtt gggccagcga acgacgagac gacaaagcca cgatcatcga
+    30241 cgtgccgtgg gccgacctcg cgcccggcct gcgtcgactc gccgcggccg ccggggcgtc
+    30301 gatgaagagc gtgctgcatg ccgcccatct gaaagcgatc agcatcgtca ccggcaggcg
+    30361 tcagttcttc gggggcctgg tctgcaacgg tcgtccggag gagctgcgcg gcgacgaggt
+    30421 tttcggcatg tacctgaaca cggtgccttt cgccgccgac gtgaccgccg cgacctggcg
+    30481 cgactttgtc gccgacgtgt tcgccggcga ggcggaactg tggccgcacc gccgctaccc
+    30541 gatgcccgcc atgcgccggg agtggagtcc cggcagtccg ctgatcgacg tcgccttcgg
+    30601 atacctcgat ttccacgtcc tggactggga ggccgacacg gtcggcatga tcgatgactt
+    30661 cagcccgagc gagctgccgt tggaggtgtg gacctttccc ggcctactgc gcctgggcgg
+    30721 gcggccgagc cggatcggtc gcgagaacct ggaactgctc ggcagaacct accggcgggt
+    30781 gctcgaggcg atgtccctcg atcccgatgc cagcaccgac gtcacgctcg cccccgtcga
+    30841 ccacgaccac gccctgcacc tcggcgggga cagcacccgc gactacccca ccgaggagtt
+    30901 ggtgcaccag ctcgtcgagc accaggcaac cgccgctccc gacgcggtcg cggtgcgcca
+    30961 ggccgaccac acgctcacct acgccgagct ggacgccgcc gccaaccggc tcgcacaccg
+    31021 cctgcgggca ctcggcgctg gccccggcac gctcgtgggc ctgttcctca cgcgcggccc
+    31081 agatctggtc gtcggcatgc tcgccacgct tcgggcggga gcggcgttcc tgccgctgga
+    31141 ccccgcctat cccgccgaac gactgcgcta cctgatcact gacgccgagg tcgggctgct
+    31201 gctcaccgaa ccggacctgc cgcttccgac cggggtcacg gccaccgtcg aaatcgtcgc
+    31261 tgactatccg gacctgccct ccgcccggcc ggcggtggcg cccagcctgg aagatctggc
+    31321 gtacgtgatc tacacctccg gatcgaccgg ccgtcccaag ggggtggggg tgccgcaccg
+    31381 aggtgcgctg aacctccggc acgcccaacg ggagcacctc gacgttcgac ccggcgaccg
+    31441 ggtgctgcag ttcgcctcac cgagctttga cgcgtcggtg tgggagctgt tgatgtcgct
+    31501 gaccaacggc gccgaactgg tgctgccacc ccgtggcacc gaccctggtg acctacgcca
+    31561 gcaggcaggg ctggtgaccc acatgacgtt gccaccgtcg ctgctggaac ggctctcgcc
+    31621 ggaggacttt ccccacctcc gggtactggt gtcagccggt gaggcgtgcc ccgtcgacca
+    31681 ggtcgcgcgg tggagtgggc aggcccggtt catcaacgcc tacgggccga ccgaaacgtc
+    31741 ggtgtgcgcg acgctgaccg aggtcgcgcc gacggtgacc gccccgccgt cgatcggcag
+    31801 cacgatcggt ggcgtctccg cctacgtgct cgaccccgat ctgcgtccac tgtcggtggg
+    31861 cgtccgcggc gagctgtacg tcggcggagc cggacttgcc cggggctatc tggggcgtcc
+    31921 cgggctgacc gccgaacggt tcgtgccgaa cccgtacgga cccgtcggcg cacgcatgta
+    31981 ccggaccggg gacgtggtgt cccgtaaccc tgacggcacg atccagtacc acggccgaac
+    32041 cgaccaccaa gtaaaggtac gcggccaccg gatcgagctg ggcgagatcg aagcggcatt
+    32101 gagcgggcac ccggcggtcg cgtcggcggt cgccgccgta caccgctccg gcaccaccga
+    32161 cgccgccctg gtcgcctaca cccgtgccgt tgacgtaccg ccgaccccgg cggagctccg
+    32221 ggagtacctg cgtgcctgcc tgcccggtca cctcctgccc acgcactgga tcgcggtcga
+    32281 ggacttcgcc ctgacccctg caggcaaggt ggatcgggca gtactgcccg gaccggacgg
+    32341 ctctcggccc gagctggact cggcgtacgt cgcgccgtcg gacgagaccg agcgggcgct
+    32401 ggccgcggcg tggcgtgagg cgttgggggt ggaccgggtc ggagtgcacg acgacttctt
+    32461 cgaactgggc ggtcattcgc tggcgatgat gcgagtgatt gcgacgctac gggcccgcga
+    32521 cggcatcgag ctgacgttcc ggtcgttcat cacgcaccgt acgatcgctg ctctcgccac
+    32581 gacggtcacg gacgagccgg ctggcaaggc gatgatgtgg ctgcgccgga gcggctcggc
+    32641 caccccgctg ttctgcgtgc accccggtgg cggcagcgcg cactggtacc tacggctggt
+    32701 accccacctg gcgcccgaca tcccggtcgc ggctttcgag tggccggcga cacacaacga
+    32761 ggttccgacc gcggaacaga tggccgagcg ctacctggcc gagctgcggg ccgcccagcc
+    32821 gcggggtccg taccggctgt tcagctggtg tggcggcagc agcattgcca ccgagatggc
+    32881 gcggcgcttg accgacgccg gtgagacggt cacgtttatg ctgctcgacc ccggcctcga
+    32941 cgcccacact cgggccgagg gctggcagga gctgaactac attcggcggc tggaggcgct
+    33001 ggtcgagcag atcgtggccg acccccgggc cgacaccgcc gagcgtcgcg ccgagatcct
+    33061 cgccctcctt gagcatctgg tggacgacgt ggatccggcg gtcgggatca ccctgccggc
+    33121 ccggggcgtc ggcgacgtct ggccgaggtc ggtccggatc tggcgcgagg tgatggagct
+    33181 cgacctcgcc taccgtcaca ccccgtactc gggacagcta cacctgatcg tgagcgacga
+    33241 actcgagcgg ggcgagcacg aggtggcggc cggtcaggcg ttcgacgggt acgtggcacg
+    33301 gtggcgcgag ttgacggcgg ggggcgtgac cgtgcaccgg gtaccgggcg accacttcgg
+    33361 cgtgatgaaa ccgccgcacg tcgcggatct gggcgcgctg ctcagccgcc tgaccgaccg
+    33421 gagctgagcc taatggagcg ggcggtggtg tgggaggtgt acacctccca cacggaatcg
+    33481 acggtgacgg tcggcgggct gtcgacatgt tccgcggcac tggcgcgggt gttcgcggca
+    33541 gtggcgagac tgggtgtcga accgacgacg gtcgccggtt ccggggccgg ggtgacgttg
+    33601 gtggtgcccc ggccccgggg gcaggccgta gccgcctccc tagccgccgc gggcactcgg
+    33661 gttcagctgt cgaacgcggt ggcgcgggtc ggcgtccggg gcatcggtct gcgcgcggat
+    33721 tccgcggtcg cggcgacgtt ctgccaaacg gtggtcgcgg ctggcgtaac gctgtccgcc
+    33781 gtctccgtcg agtcgaccga catcagcgtc atgtgcccgg agcaccgggc ggaggccgcg
+    33841 gccggagcgc tggcgaaggc cttcggcacc gccacccacg acatcgggcg ggacctcgac
+    33901 ccccggcgtg gaccgacgct ggtcgtcgcg ggtggcggcc cgctctgacc agcggccgat
+    33961 ccaccgctgg cctgtttcac ggacgagtgg aactcagccg ggcgggtgga agctccgcgg
+    34021 acgcggcggt gggctcagga gttgtccacc gccacgaacc tcagctcggc cgtgtagcgc
+    34081 tcgccctggt cgtccatcaa ccaggtctgc tctggtgtcg gcagcatctc cgtgatcacc
+    34141 agccgtgcct ccgggtcgcc ctggcggtgc agccgtcgag ctgacttggc caggatgttc
+    34201 acgtacacgg gagagtcgaa gtcgacgaag aacggccgcg gttccgtcgg cgacacgacg
+    34261 aagacgaagc ggggaagctc ggcctgctcg cgccaccgtc gggcccggac gaaccgtccc
+    34321 gcctcgctct tctcctcgat gaacggcagc gcagccgtcg ggaagcgcca ggactcccgt
+    34381 gccaccacca tccggtccat cgtcacccgg ggagtgtggt cggcctctgg tatcaggcgg
+    34441 aacatatcca tcaccagcgt cgtcagcacg tgggagaaga cgtccacaat gccgaactcg
+    34501 gcgccgtcgg gcaggaccgc caccaggcgg tcgccctgcg cacgcaccgt gacgtccgcg
+    34561 ctccgtaccg tccggggccg cgccggatca gcggtctgat cgaccaacgc cacgtagtag
+    34621 tcctccggcc gcaccagcgt gtgtcgaatc cgcgccgaca acctcgctcg gtgttccttg
+    34681 ggcaacaacg gcagcaacct cggttccgga tggtcacgcg cggtctgcgc cagcagcgac
+    34741 tccgggtccg gatgctggtt gacaaacagc gaggcaccca gcgtgttggt cgccacgtgt
+    34801 agctcgccca ggaccagttc tcccccggga gacaccaaca cgtcggggct gagataccgg
+    34861 gcagccgtcc agcctgcgtc cgccgcggcg aaggcctctc gtaccgctcc cgcgatctcc
+    34921 gcggcgtcga cctggatccg ggaaccggtc agcggcggca gcaccgaccg ccaccgacgc
+    34981 cggaactcct cctggacctg gacggcgatt cccgcggcct caccatgcag caccggcata
+    35041 cacgcgaacc agaatgtcgc cagatccatc gggccgtcga acacctcccg cacccgcgcc
+    35101 atcacccgct cggcgacggt cgacgtgagc catcgacccg cggtcagtag gagattgagt
+    35161 ggcgccaacg cgtcgagcag gtcagcgccg agccgcaccc gcgcggatcg gcgggcgtcg
+    35221 gagtagacca gcgtccggca cggcgcggtc ttggcgttct tctcccgaac ggcggtctcg
+    35281 tcggtcaacg ccacgaactg ggactccagg tcggtcagag ccgccttcag ctcctcgggt
+    35341 ccgggcgcgg ccgcgacccg ggaacgcccg tgtacgagta cctccaacag ctccgccgcc
+    35401 cgaccaccgg gtgcgccgac cgactccagc cagtgccgca tccacttctc gggacgcgcg
+    35461 tccgccggta catccagtcg ccacaaaacg atgcgacggc gtaccagttc ctccagttgc
+    35521 acggccgggc cgacctcacg ggccggtcgg accccgtcgc agcgggacag cagttcgatc
+    35581 agctccggcg gcagcacctg cggcggacgc ccgggcacga gcaccgagtt gtggttgacc
+    35641 cgtacgaagg gcaccagccg gggggcgatc cacggccgca gctcggggtc cgcgttaacc
+    35701 agtcgggcca ccgcgtcaac cgcccagctg gcgaagtaca cctctgacga ctcgacgagt
+    35761 cccacgcccg aggtcaccgc gatccccgac gtagatgtgt cccagtgtcc ccagcccacc
+    35821 gggccgaaaa agccgatggt gtcgttcttg acgcagaacc gctgccagta gtgagcgacc
+    35881 agttcctcgc gctgccgcgg catgctggtc cggcccgcgg cgctcggcgt ccaggccagg
+    35941 aacggtgcga tgcccgagtt gagcaggggc cgattctgcc aggccaccgc agtttggaac
+    36001 gccggcagtg ccgcgactcg ctgcagctcg gacgcggtgg ccaccgccgc gtccgcgtag
+    36061 agctcctcaa aggccgtcca ggccgcgccg gacaacgcct cgtccgcact gaacttgtcg
+    36121 gcggcctccc ccagtccggc cggtgcgagg cgtaacacgc cggaggccgg aaagcccgga
+    36181 ccacggagcg cgaactggga ccagagccgc cagttcgcgc caaggggtac cgatgtgtcg
+    36241 tccacagtag tcgctcctag aagtcagcgg cgacgacctc ggcgaggtcg gccggcgacg
+    36301 ggtaggcgaa cacgagcgcg acgggaacct cgatatccag cgtcgcttgg agtcgcgcag
+    36361 tgatctggaa ggcggtcaac gaatcaccac cggcctcgaa gaagtcactg ttcgcgtcaa
+    36421 gcgtctcgtc atgcagcgtt tcccgataaa tcgatacgat aagttcagac acgtcgatag
+    36481 ttgtagtcat tgtgcttcct ttcatcgaat gtccacggcg ccgcggacag cacctcggat
+    36541 gtgttgccgc ccgacaccac cgccactgca tgaccaccac acccggcctg catcgctccg
+    36601 gccagcgcga ccgccccact cggctcagcg gcgactccgg ccacccgcaa cacgcccagc
+    36661 gcatggacga tggcgtcgtc ggtcacgcca atcaactcgt ctactcgacg gcgaatgatc
+    36721 ggcagtggca cagcccccgg ccgctggcca cgcaaaccat cggcgatcgt ggacgacggc
+    36781 ggcagctcga ccggtccacc cgcggcgatg gaaatcgcgt agcggcgggt gtgtaccggc
+    36841 tccacgccga ccacccgcac cgggttgtcg aacgcgtcaa cggccagaca caccccggcc
+    36901 aggagtccac ctccgccggt cgggacgaag atcgtggtga tgtcgggagc gtcctcggcc
+    36961 acctcaaggc cgacggtgcc ggctccggcc accacaagct catgatcaga tgagggcagg
+    37021 tacaccgcgc cggtccggtc cgcgatcgac cgcgcccgcc gctcccgctc cgccacgccg
+    37081 ccctcgatgt gtaccacccg cgcacctcga gcacggatcg cccgcgcctt ggcctcgctg
+    37141 gtgccggcgg ccatgaccac ggtcaccggg atatcgcacg cagcgccgat cgtggcgacg
+    37201 gcgataccgt gattgcccga cgatccggtg accaccgcgg ccggtcgcaa caccaccatc
+    37261 gcgttcgccg caccacgcag cttgaacgac ccaccgtgct ggcgatgctc gcccttgacc
+    37321 aacaggttcg aaccaagggc cagcaacggg gtacgccgca ccagcccgga aatccgctcc
+    37381 gcagccaccc gtacgtcggc tatccccaac ccggaccgcg tggcgctccc gatggtggtc
+    37441 atcacggtcc cgctgtcagg gcgcggtgat cgaccttgcc actggccgtg gtcggcaggc
+    37501 gtgcgatccg ggtgaacctg cggggcagca tgtacggcgg cagcgtcgcc gccagacccg
+    37561 ctcggagcgc cgcgtcggtc acctcagcca gttcaccggc gacgtgggcg accaggaaca
+    37621 cccggccacg gtcatcggtg gccgccgtta ccgccgcgcc atcgaccgcg gggtggttga
+    37681 gcagcgcacc ctcgatctcg gccggatcca cccggtagcc gcgaattttg atctgccggt
+    37741 ccacccggcc cagatattcg aggacgccgc cacggagtcg ggccaggtct ccggtgcggt
+    37801 acatgcggtt gccgggaccg ttgaacgggt cgggcacgaa cctctcggcg gtgagatccg
+    37861 ggcggccacc gtagccccgg gtgacaccga tcccaccaac ccacatctga ccaacggcac
+    37921 cagccggcac cgggttcaga tcatcgtcga gcacatagac ggtcactccc tcgatcggtg
+    37981 tgccgacaag gtccatcgtg gtgtccggat ccgggggcac cacaaagcgg gttgaggtca
+    38041 tcgtggcctc ggtcgggccg tactggttga ccaaccggcc acgcaaccgc tctcggcccc
+    38101 cggcggtcag aaacggccgt agggattcac cactcgacac ggtcagccgt agcaacggca
+    38161 cgtcgtggcc ggagacgaag gtgagaaagg tgggcgtggc gctgaggatg gtgtccactc
+    38221 cgaagccccg tagggtcgcg gtgaactcgt caacacgcag tagcgccgag cgggcgacca
+    38281 tcaccagttg actgccggcc atgagcggag cgaacgtgtc gcggatcgag gcgtcgtaac
+    38341 cgagcggggc gagctgcagg acgacggtct ccgtaccgag gtcgtagtcg cttacgacgc
+    38401 acctcagata gttgtccaac ccacggtgct ccaccagcac cgcgttgggg gtaccggtgg
+    38461 acccggaggt gtggctgaca taggccagcg accgcgtggc gatgggcggc aggcggaccg
+    38521 tggcaccggg atccggttcg tcggtgtgca cccggaggcc gccgaacgcc aggtcgagct
+    38581 gcccggccaa cgccgacgtg gtgaccaggc accgagcctg cccactacgg atcatggtcg
+    38641 ccagccgggg gccgggcagc tcgacgtcga gggtgaggaa ggccgcacca gctcgcaggg
+    38701 cggcagccat ggcgatgacg gcctccggtc cgcggtcgac cgcgatcgcg cacacctgtt
+    38761 ccgggccgac gccccgggcg accagcaccc gggcgagccg gtcgacacga gcgacgagtt
+    38821 cgccgtaggt gacgaccgtg tccggggtga cgatcgcggg tgcagcgggt cggtctcggc
+    38881 cctgggccac cagctggtcg aggaacgtgg tcaccggctg cccccgaccg tggcggccac
+    38941 cgcatccgtg gccgccaccc cttcggtggc cgccaccgtc tggtcgacgg cgacgaaccg
+    39001 gagctcagcg gtgtagcggt caccggcgtc gtcggtgagc caggcctgct cgggggtggg
+    39061 tagcatctcg gtgacggtga accgggcctc gggatccttg cggccaagcc gacggatggc
+    39121 cttggcgagg atgttcacgt aaacggggct gtcgaagtca acgtagaacg gccgtggctc
+    39181 ggtcggcatc accacaaaca cgaaccgggg cagccccagc tccgcccgcc acccccgcgc
+    39241 gtagacaaat ctacgggcct cactcttgtc gtgggcgaac cgcacgtcgg cggccggaac
+    39301 gcgccaggac tcgcgggcga cgacggtccg atcgatggtg atccgcggcg cgtgcgggga
+    39361 gtcgccacgc agtgtgaacc ggtccatcac ccggttggtc agcgcgttgc cgaaaacatc
+    39421 gagaacgtcg aactccgcgc cgtcgggcag taccagtacc agccgaccgg cgtgctcctc
+    39481 gactcggatg tccgcagcca ggaggttgcg gggacggctc gggtcgcccg tgtggtccac
+    39541 cagtgccacg acgtagtcct cgggccgcac cagggccggc cggctccggg ccgaccagcg
+    39601 cggcggttgt tccttgggca gcatcggcat caggcgcgga ccgggaaagt cccggctggt
+    39661 ttcggccaac agcgagtcga cgtccgggtg ctgcatcacg aacagggagg cgccgacagt
+    39721 gttcatcgcg acgtggagtt cgcccagcac cagttcgaac tcgccgcggt cgaccgcctc
+    39781 cgggtcctcg gcgcacacca gcaggtccgg gctgacatag cgggcgatgt tccagccatt
+    39841 tccgggctcg gcgaacagct cgtacacccg accggcgatg tcggcggaac gaagctgcac
+    39901 ccgtcgggtc ccggccggcg cgtcaacgag ctcggcccac cgtgcacgga gttcggcctg
+    39961 caccgccgcg acgtcggccg cggactccgg gtgcggcacc ggcaggcagg cgaaccagag
+    40021 cgcaccgaga tcaacactgc cgtgttcgtc gcgcagccgc tcataggctg cgcggattcg
+    40081 ggcaccgacc cggtcggcga accggttggt catccaacgg gcggcggtga ggaagagccc
+    40141 gagcggggtc agctcgtccc ggatcgcggt gccgatcgtc gcggtcgccg aacgacgggc
+    40201 gtccccgtac agcaatgatc ggcacggtgc gacccgggcg cccttcgccc tggcggcggc
+    40261 ctgctcggtc accgtggcga aatcggtctc cagatcggcg agcgcaccag ccagcgcgtc
+    40321 ggcgtccatt ccggccgcgt gtacccggtc ccgggcgcgt tcgacgacgg cgagcttcgc
+    40381 gagggcgcgg gcacgaaccg ggtcgtcggt gacccgctcc accgccgagc gcagccatcg
+    40441 ctccgggtag gcgctggtcg gaacctcgag ccgccgtacg atccagcggc gccggagcag
+    40501 ttcggtcagt gcctcctcga tggccgacac cggcacggtc aacagctccg cgatctcggc
+    40561 ggcagtgcgc accccgtcgc acaggtccag aacgtcaccg tggaaccgga ggatctgctg
+    40621 aggggggcgg cctggcatgg cgacggtgtg accgacgcgg cgtacgaacg acagcctgcg
+    40681 gggtgggacc cacggccgta cggcggagtc tgcctcgatc gcgcgggcta cgtggtcgat
+    40741 cgcccaactg gagaagtaga cccgtgcagc gtcgacgagc ccggtgccgg gttcaaccac
+    40801 gattccactg gtcgagagat cccaccgccc ccagcccacc gggccgaaaa agccgatggt
+    40861 gtcgttcttg acgcagaacc gctgccagta gtgggcgacc agttcctcgc gctgccgcgg
+    40921 catgctggtc cggcccgcgg cgctcggcgt ccaggcgagg aagggggtga tgccggagtc
+    40981 cagcaactgc cggttctgcc aggccagggc cgcccggaac atcggcagcg cggcgatccg
+    41041 ctgtagctcc tgcgcggtcg ctaccatcgc ctcgtcaaag tcctgttcga acgccgccca
+    41101 ttccgccccg gaggggacga tgccggcgtc gaacttgtcg gcgtgttcag ccaggccggc
+    41161 gggggccaac gccagcactc cggcagcggg aaatcccggc ccccgtagcg cgaactggct
+    41221 ccacagccgc caccccccga cgggcaactc gacgtgctcg gacatctcaa cctcccgcga
+    41281 tccgccagtt cggcgtgttc ccggtgcacc actccaggac ggcgcgcgca ctgtgatatt
+    41341 tgttctcggc ctgggcgaag gtgatgctcg tgggaccgtc gagtaccgcg gcggtgacct
+    41401 cctcgccccg gtgtgccggc aggtcgtgca tgaagactgc gcccgggcag gcggccatca
+    41461 gggcctcgtc aacctggtac ggggtgaatt cccgccgcca gtccggggtt ggcttggtgg
+    41521 taccggtggt ctgccagcgg gtggtgtaaa cgacatccac cgacggcagg tcggtggggt
+    41581 cgtgccgttg ttcgaccact gccccgctgc gtttagcggc ggcctgcgcc cgttcgagca
+    41641 cgctcgggtg caccccgtaa ccgggcgggg tacggaggtg taactgggtg tcggtgtagc
+    41701 gggcgagcgc gagcgccagc gcggcggcgg tgttgttgcc ctcgcccaga tacagcacgc
+    41761 gcagaccctc gacctggccg aagtgccggg tcagggtggt gaggtcggcg agggcctggg
+    41821 tgggatgctc ggccgcgctc atcgcgttga ccaccgccat ccggtgttgc ttcgcgtagg
+    41881 cgcgcagttc ctcctcgggc ccggcggtcc gggcgaccag cacatcgatc atccgggaca
+    41941 gcaccgcggc ggtgtcctcg gccgtctcgc cggtgttttc ctgtaggtcc cccggaccgt
+    42001 aggtgatcaa tcgggcgccc aggcgcagtg agccggcaga gaaggcggtc cgggtacggg
+    42061 tcgaggtctt ccggaacaac acgcccacga ccaggtcggc caaggatcgg gcgtcctcgg
+    42121 cggcaccggc ggcgaactcg gtgccgcgcc ggacgatctc gcgcaggtcg gtgtcggtga
+    42181 ggtcatcgat ggagatcagg tggcgtcggt tcgccatgac gggctctctt ccctgtccgg
+    42241 gccgggtggg gtcgggctga cttccggctg ctggtcagac cgcgagcagc ccgtcccgga
+    42301 gcacctcgag ccctcggtcg aggcggacga tgtcgatcgc tatcggcggc agcaccttga
+    42361 tgacctcgtc gtggcgcccg caccgctcga cgattacgcc atggtcaaag gcgtagcgct
+    42421 ggaggcgctc cgcgcgatcg gggccgccga cccgtccgag gtcaatgccg agggccatgc
+    42481 ctcggccccg cacgaccagt ccggcgtcaa cgctggtcag ctcggcccgg aagcgctcca
+    42541 accgccggga ggcaaccgcg atgtcggtgc gaaacttcgg atcaccccag agctcacagg
+    42601 cggcggtggc ggcgacgaag gcgagctggt tgccgcggaa ggtgccggtg tgctcccccg
+    42661 gctcccacac gtccagctcg cgccggaaga gcgacatcga caggggcagg ccgtagccac
+    42721 cgatggactt ggacaccgtg accacatccg gcacgacgcc ggaatgctca aaacagaaga
+    42781 aggtgccggt gcgcccacag ccggcctgga tctcgtcaac gaccagcaga atcccgtgtt
+    42841 gctcggtgag ggtgcgcagc cgccgcagcc agtccgcgga ggccgggtag accccgcctt
+    42901 ccatctgcat cggctcaacg atcaccgcgg cgggtatctc cataccggaa gatgggtcgt
+    42961 cgagcatgcg ctcgatgagt gctatcgagt cgaacggacc ctgcggtcca tcctcatagg
+    43021 gcacgaaggt gacatctccg ccgccgattc caccggcacg tcgggcgcgg cgactgccgg
+    43081 tgaccgccaa cgatccccga gacatgccgt ggtacgcgcc gctgaacgcg atcaccccgc
+    43141 tccggccggt cgccttgcgg gcgagcttga gcgcggcctc caccgcgtcg gtgccggtcg
+    43201 ggccgcagaa ctgcaccttg aagtcgaggc cccggggctg cagcacggtc ttgttgaacg
+    43261 cggtgaggaa ctcccgcttc gccacggtgt acatgtccag gccatggacg acaccgtcgc
+    43321 tgttcagata gtcgagcagg cgacgtttga taaaggggtt gttgtggccg tagttaagag
+    43381 tgccggcacc ggcgaagaag tcaatgaacc gtttgccgtc ctcgctgtag agctccgcgc
+    43441 cgcgagcacg atggaacaca gcagggaatt ttcggcagta cgaccgtacc tctgactcca
+    43501 ggctttcgaa ggcggcgaac ggcgtggtcg cctccagcac ggatgtcgaa tctacggtga
+    43561 ttgtcatggc aggtcctttc aacgcgtctt atgacgacgc cgggcggtca gcgtgggcat
+    43621 cgtggtgcgc tgggagattc gcggataatc agggagcgca gcggcgaggc tggccaccgt
+    43681 gctgtggtcg aacaggcccc gtaccggaac gtcgacaccc aactgggcgc ggaggcgcac
+    43741 cgcgacccgg gtggcgagca acgagtgccc gccgatctcg aagaagttgt cgtccatgtc
+    43801 gatggtggcg ccggtcccca gaacctcccg ccagatgtcg gccacgacgc gttcctcggc
+    43861 ggtacgcggg gccactcgcg ctaccgcgac ccgagtcgcc ggttccggca gtgccgcgta
+    43921 gtcgaccttg ctgttcggcg tcaacggaag agcctccatc ggcacgtacg ccgcggggag
+    43981 catgtagtcg ggcagggtcc gcagcaggaa cctccgcagc tcctcaaccg gcggtgcggt
+    44041 gtccgccctg gcgacgaggt aggcggtcag ctgctcttcc ccggtggggg tggccgtggg
+    44101 gtggacggcg accgcacgaa tgtcgtcgtg gccgagcagt gccgcctcga tctcgctggg
+    44161 ctccatacga tggccgcgaa tcttgacctg ccgatcggca cgtccgagga tctccaccga
+    44221 gccgtcctgg ctacggcggg ccaggtcgcc ggttcggtac aggcgtccgc cgggcgtggt
+    44281 ggagtagggg tcgggtacgt accgctccgc ggtcagcgcg ggctgacccc ggtagccgag
+    44341 cgcgacgcaa ctgccaccga tgtacagctc accgaccgtg ccaatgggca ccggctcggc
+    44401 gtaccggtcg agcaggtgga ccgtgcagtt ggcctgcggc gaccagtcca ccaccgcgcc
+    44461 ggtcgggtcg agacgagccg aggtcaccca tacggtggtc tccgtcgggc cgtacaggtc
+    44521 ccacaccgga gccccttcag cggcgagccg ccgggccagc tcggtcggca gcttctcgcc
+    44581 cccggacagc acggtgatcg tggccggggg aacccaccca acctcgagca gcgcccgcag
+    44641 catcgccggg gtcgcctgca gcaccgcggg gcgggtgagc gccaccagat cgatcagccg
+    44701 ctgcgggtcg cgggcctgtt cggtatcggc gaggacgacc gtcgccccga cgagcagcgg
+    44761 tacgtacaac tccagcagcg acggatcgaa cgagatcgtg gtgagcgcga cgactgactg
+    44821 gccggccgtg agcccgggcc gccgcacgat cgaggtgacg aagttggtca gcgcccgatg
+    44881 gtggaccatg acccccttgg gcgtcccggt ggagccggac gtgtagatca ggtaggcaag
+    44941 ttgctcgccg gtcgccgtgg caggcacggc agcagagggc cgggctgcca caacggcccg
+    45001 gtcccggtcc accagtacgt gctgtccacc ggtgtcacca acccggtcga cgagcgcgga
+    45061 ccgggtgatc acgaccgccg cggcggagtc ggccacgatg aaggcgatcc gggcgtccgg
+    45121 gtactcggga tcgatcggta cgtaggcgcc tccggcccgg agcacggcga ggagtgcgat
+    45181 gagcaggtcg ggaccgcggt cgagcaggac ggcgacgagc gagccgggcc gaacgcccag
+    45241 cgcgcgcagg tggtgcgcga gccggttgac cctcatgtcc agttcgccgt aggtgatctc
+    45301 ctcggtggtc gtccacacgg ccacggcatc cggcgtggcc cgcacctgag cagaaaccaa
+    45361 ctgatcaact gtctggtcgg gaaagtccgc ggcggtgcgg ttccagccgt acagcagacg
+    45421 gtcgcgctcc ccgcgcgggc ccagctccag gcgcgcggcc agttcactga cgctggttgc
+    45481 cggctcgacg acgacggccc gcagcaggtc ggcgaaaccc ccggcgagcc gctccacccg
+    45541 ggcgtggtcg aacaacgcgg tcgcgtattg cagccgtgct gtcgccgtgc cgtccggccg
+    45601 cacgttgacg tcgaggaaaa ggtcgaacgg ggaacccgtc agtggcggct ccaccacttc
+    45661 gacgtccagc ccgggaagcg acatcggggc ccgcacgtcg agcaggctga acgacacctg
+    45721 gaagatcggg ttgcgggaca gatcccgctc cggagcaagg tccgtgacaa tgcgctcgaa
+    45781 cggggtgtcg gcatgggaga acgcaccgag cgcgttgtcc cggacgcggg tgagcagctc
+    45841 ctcgaaagtg ggtgcgccgg ccaggtcggc gcgcagcacc accgagttga cgaagagacc
+    45901 gatcaggtcc tcgtccgcaa cgcgggtccg cccggcgacc ggcgtgccga tggcgaagtc
+    45961 ggtttgaccg ctggcacgtg cgagcacgat ctggaaggca gcgagcagga ccatgaagcg
+    46021 ggtgacccgg cggctacggg ccaccgcgtc gacctctcgc agcagggtcg cgggcaggtc
+    46081 gacacggacg acgtcgcccg cgccgtccca ggtccggggc cgccgccggt cggtgggcag
+    46141 ttcgatggcg ggcacaccgg cgagttgagc ccgccagtag tcgagctgac ggcggctgcg
+    46201 ctcgtcggtg aaccgctcgc gttgccggcg ggcaaagtcg gcgtactgcg cggacagccc
+    46261 gctgacctcg gtggttcgac cggcgtagcc ggcggccagc tcacgggcga gcactcccca
+    46321 ggaccagccg tcgaaggcga tgtggtggac gacgaagacc aggaggtggt cgtcgccgag
+    46381 acgggccagc gagagccgga acggcagatc tcgggcgatg tcgatggggc gggcgagctc
+    46441 tcgctccagg acacggtggt ccgtcgtgtg cgcgatggtg accgtggcgt atgggtcgac
+    46501 gtgggccacc ggccggccgt cgacctcaac gtagcgggtg cgcaacacgt catggcgatc
+    46561 cacgatcgcc tgtagtgccg tggtgagggc ggtgacgtca agcggtccac ggatgcgcag
+    46621 cgcgagcggc agcaggtagt ccggcgttcc gggccgcagc tgatcgagga accaaagccg
+    46681 ctcctgcgcg aacgacacct ctccgacgct gtccaccggt acacctccgc tggctgtgtt
+    46741 catgccgagg tgttgagcat gcgcggctcg cgggtccgga gaacagggaa ggacccgcag
+    46801 ggcgcaggtg cagattttgc tgcgtattcg tcccttcccg tggcggagtg gctgcgacac
+    46861 gctcgacttc gccatggtcg tgtcgacagc gggaggaacg atgaccgacg agggtgtgta
+    46921 ccgcgttgtg ctcaacgatg aggagcagta ctcgatctgg tgggcggacc gggagctgcc
+    46981 gctgggatgg cgtgccgaag gaacagctgg ctcgaaacag gagtgcctgg agcgcattca
+    47041 gcaggtgtgg acggacatgc ggccccgcag tctgcgcgaa cagatggcct gaggctccgg
+    47101 aacggcaggc cgatcgtcga tcggctgccg ggtccggccg gcgcgacgag ggggcatact
+    47161 ccaccccacg agcccgtccc gacgacgtag gcctgtcggt ccgcccccgc tgcccgggtg
+    47221 aacgacagaa gtcagtccgt gcggtgtttg gggggtcagg gcgcgggcac ttcgatcaga
+    47281 tgtgcccggc ccggatcgct ctggcgaccg catgggcccg attgttgacc tgaagtctcg
+    47341 tcatcatgtc gtagataaca ttcttcaccg tgtgctccga gcaggacaga ttcttcgcga
+    47401 tcgccgtatt cgggtagccc tccgccatga gagccagtac cgctgtttgc cggggggtca
+    47461 ggggggacgg gttcggggcc gaatccggac ctcctcctgc cctgtcccgc aacaacttca
+    47521 gcaggatctc gcggggaatc ctgctctccc cctgcttggt ggcccacacc gctgaggcca
+    47581 gcttcgccgg ggccgaggtg gtcgatagca tcgctcgcac ccccgcccgc agggcggatc
+    47641 tgacctccgc cgggtcgaag gcgtcggcca ggaccagcag gcggtagtcg ccggtgagat
+    47701 acggctgcgg gcacgaccgg agcgcccgtc cgaccgtctc cgccgccgcc accacgaccg
+    47761 gcacctggaa cggctgctcc acgatcttga tcccgaccag acgcagcttc gtcgccacgg
+    47821 tggcgcggag cgtggaatcc gcggcctcga cctgcacctt cacagcagac ctgcgcggag
+    47881 cgtgtaggcc acggcgtggg cccggttccg gagccggaat cggcgggtga tgtcgtgcac
+    47941 gacgctggtc acggtccgag tcgagtagca gagctgtcgg gcgatctcac cggtttcgtg
+    48001 gccgtcagcg accagtcgca gcaccgctcg ctccctctca ctcaacggcg agtcggtgga
+    48061 ggatgtcgct gacagcggac gggcacctcg ctccggcaac tggtcgagaa tgtccagcgg
+    48121 aagggtgcag tccccatcgg ccacagccac cacgacgcgg gccaggcggg ccgggtcggc
+    48181 ctcccgccgc cgcatcacac cccgtgcccc ggcgacgatc gcctgcaggg cggcgcagga
+    48241 ctccaggtcc gtcgccacca agaccacctc ggggcaggta gcgctcgccc gtgtttcccg
+    48301 gacgatgccc aggacgtact cgtcgaccgt gtcgacgaca atcacggccg cctgcgcccg
+    48361 ttcgggtccc gacaccacct caacgtctgg ggaacttcgt aacgaggttg tggcgcccac
+    48421 ctcgagcatt gggtccaacg ctgtgacgct gacccgaact ggctcaccca cctgcactcc
+    48481 tcacggtcgt cggcctatcg cgcctcacgg tcgccggccc ctcacgacca gcctcgaccg
+    48541 gtgggtctct cggcacatcg ggcccggaca cgcacatttc tccaccggct gggcaccggt
+    48601 gcggggactc ccgaccgtgg cggtccacca ggtaggttcc gggcttacct gacctgctga
+    48661 tcagtgagct cggatgaatc tgggggtcga gcacccatga cctgaggccc ggccctggtt
+    48721 acgttcgggg tgtgagttca gcgagtttgg ctgcggccaa ccccttaccg gacccggcgt
+    48781 ggtgggccgc tggcctcgcc ctgcacgagc gggacgtgcc ggtcgcgggt ggcgaggccg
+    48841 agaccgagcc gggcttcgcc gcccgactcg ccgacctggg gatgccgcac gatccgcact
+    48901 tcggcgcgct caccactcaa ctccgtcggc ctgcctgggc cgtcctggtg gaggacgtcc
+    48961 tggccaccgc ccggccgctg acctccgacg cgcagccggt ggccgactgg cgagcggcgt
+    49021 tcgcccgggt tctcgcgccc ttcgtcaacg ccgcgttggt ccagattcgc cggcacggta
+    49081 gtcgacacgt ggacctggac cgggtcaccg ccgcggtcag cggcacgctc gggccgcgcc
+    49141 tggtcgacat cgcggcccga acgctggtca ccgagctaca ccggtggcgt gccgaaggcc
+    49201 gcttgaccgg tggggacggc ccggcacgct ttcatgactt cgtccgccag ctcaccgcgc
+    49261 ccgcggggct cggtgaggtc ctcgcccgct atccggtcct ggcccgtcta ctcgcccagg
+    49321 acactgccac caccgccgac gcgaccgtgg agctactcaa ccggctcggc cacgaccgcg
+    49381 acgcgctgat cgccaccctg ctcggcggta tcgacccggg tccggtcacc tcggtgctcg
+    49441 cggcgcaggg agaccgtcac gccggcggac gcgctgtgtc cttcgtggat ttcgcggacg
+    49501 gacggcgact cgtctacaag ccacgtgacc tgactccgta catcaagctg accgcgattc
+    49561 tggaccacct ctcctcggcc gccgccgggg tgttcccccg caccccgcga gttctctccc
+    49621 gaaccggtta cggctggact gagcacatcg ccgcgctacc gctgctcaac tgggaggacg
+    49681 cggaactctt ctaccgccgc caaggtgcgt tgctcgccct gttgcacctc gtccgtgcca
+    49741 ccgacgtgca ctacgaaaac ctcatcgccc acggtgacca gccaattctc gtcgacatcg
+    49801 agactctgtt ccatccggag ctcgcccccg gtggtctggg tgaccccgcc gccgacgcac
+    49861 tggccgaatc cgtgcaccgc accgccctat tgccgctggt cttcgtcggc gaacagggca
+    49921 tcgctgacct gtccggcgct ggcggcgacg tctcgacgtc cccgttgacc gtcgtcgact
+    49981 ggctggacgc gggtacggac cagatgcgcc tgacgcgccg ggccgccgag ttcgctggcg
+    50041 cggctaaccg gccgatcctc aacggtcgac cggtcgagcc acacgagcat gatcgcgcca
+    50101 tcgtcggtgg gttccgtcag gcgtacgaca cgttcatcgc ccaccgcgac aagctcaccg
+    50161 cgcttgtgcg ggactgcgcc gatctcgagg tccgcgtcat cgtcagggcg acctggatgt
+    50221 acaagacgct gctcgacgaa accacccacc ctgatgtcct ccgcgacgct gtcgaccggg
+    50281 accgggcact ctccgtgctc taccacggca ggaccgagca gccgctgctc gcacagctgt
+    50341 tacggtcgga gatcgcgacc ctgtgggcgg gggacatacc aatgttcacc gcctcggtcg
+    50401 gaaccggccg aatccgcgcc gtctccggta ccgagttcac cgaaccgctg ccacagaccg
+    50461 ggctcaccgc agcgttaagc actctcgcct cgctcgacga ggtgaaccga cgcggccagg
+    50521 aatggatcat ctccgcgacc ctggcgtccc gctcccgggt cgcccctcac cccgaggcag
+    50581 tcccgatcgc ggcccaaccc gagggcgtgg tggcgcaccc cgacgaactc ctggcggcgg
+    50641 cctgcgcggt cgccgaccag ctggtcgcgg aagcgaaggc cgggggcggg cgggtcaact
+    50701 ggctggggct ggaggccgtt gaggaccagc ggtggctggt gctgccgctt ggcgccagcc
+    50761 tcggtagtgg gtacctcggt gtggcgctgt tcttcgccca gctcgcggcg gtcaccggaa
+    50821 tctgccgcta cgccgaccaa gcccgcgccg ccaccgccga cctgccacag ctcgtcgctg
+    50881 cgctggacaa gcgacccgat ctcgtcgcgg tcatcggttg cggcgggctg gatgggttgg
+    50941 gcggcatcgc ctacggcctc acccgcatcg ggaccctact cgacgatcac accctcaccg
+    51001 atgccgctgc ccgcagcatt cggctcgccg cgctggcggc gacctccgag gcgccggctg
+    51061 gttggtccac cggactcgcc ggttgcctgg cggctctggc cacagtgcag accgacctga
+    51121 acctccccga agcgggtgat gttgcccgcc ggtgcgccga cctcctcatc gcaccgctag
+    51181 ttgggtccgg caacccaccc gggcaccgtg cggcgacgtc accggaccgg cccggtggct
+    51241 ccgggccaac atcgggcggg ttcgccgaag ggctggccgg gatcggatgg gcgttgacca
+    51301 ccgctgggcc cgacgagcac catcaggctg cgggccgtcg ggtggccacc ctgctcggcg
+    51361 accggagtga gccggcggcg tccgggtggt gtcgcggcac cgccggaacc gtactggccc
+    51421 gtgcgtcgct gtcgaccgac gctgaccctc gctacctgac cggctgcgtt gaggccctgg
+    51481 ccgacgcacc cgtacggcgg gatctgagtc tgtgtcacgg tgagctcggg gtgaccgagg
+    51541 tgttgaccca gctcgccggt tccgatcggc acacgttcgc gacccgggcc ctgcgccgcc
+    51601 gaactggact ggtcctcgat gtgctgcgtc ggcacggctc gctgagcggg gtgcccggcg
+    51661 gggtccgttc cccggggcta ctcaccgggc tggccggtat cggttacggc ctacttcggc
+    51721 acgccgcacc acagcaggtg ccctcggtgt tgctgttaca aggttcctcg gctactcact
+    51781 aacgttcctg ccccacgaga aaaggagatg cacgtcatgt cggaaatgat cccgaatacc
+    51841 gctgaagaag ctgctaccgc tccggccggc cgcctacgtc tgctgccaac cgcggtgacc
+    51901 ttcgccgacc gtgcggcagc gctggcgcgc gtcggtctgc cggtcgccat gctggccgca
+    51961 agcatcgccg cgccggcgct gggagccagt gcgggtgaag cgacggcgat gaacaccacg
+    52021 tgctgcccag atcgtccgat gtaagcaatt cgacagccac ccgaagcgtg gtgggcagcg
+    52081 gcccggtcgg agaaccccgg acctggccgc tgcctcccaa agcctgcgat tccatcgcag
+    52141 gtcgccgatg ataatgtcat tgttgtgcgg cacttttcgg caagtttggt aggccgggac
+    52201 agggtgctgc acgcgctgac ggccgggttg accgccgcca gaaacggccg cggtaacgcg
+    52261 gtttttgtga ccggcgagag cggcatcggc aagtcccggc tgaccgcagc cgtcaccgag
+    52321 ctcgccttca cctcgggcat gagcctgatg cgcggacggg cgagcgccgt cggccccacc
+    52381 ccgccgtttc gaccgctcac cgaggcgatt ctgtcgcacc tccgcatcga gcccgtcgac
+    52441 ccggcaaaac tcgggccgta cgggccgatc ctcggccgac tggtgccgga gtggagcgcc
+    52501 ccggagaaca gccacgacag cgagtcactg gtggtgctgg ccgaagccgt gctgaggttg
+    52561 atcgggcttg tcgggcgaga ccggggctgc ctgctcaacc tcgacgacct gcacgaagcc
+    52621 gatccggaga ccctcgccgt actcgagtac ctgattgaca atgtcgagtt gcagccgatg
+    52681 ctgctgctgg gcgcccttcg cgacgaggga ccggtgctgt cgctggtccg cgccgccgcc
+    52741 cgccgcggcg cctgtcaact catcgacttg gaccggctgt cccgggcgga actcgcacag
+    52801 ttggccggag cgtgcctgga cgtcgagccc aacctggtcc ccacctcggc agtcgaccta
+    52861 ctgtgggccg gaagctccgg gaacccgttg gtcgccaagg aactcctcag cacaatggtg
+    52921 gatgacggca tcctggtggg cgatgcgcag ggctggcaga tcaacagtcg ccccgaggca
+    52981 cccgtgtccg caggtctcgc ccgcccgctt gcccgccgcg tcgcccagct cgggacccgc
+    53041 gtccgcgagc tgctgtcggt cgccgcggtg tttggacagc agttcccgct ccgggtcgtt
+    53101 cagcacgtca ccgggctggc cgaccgggac ctgctcggtc ttctgcagaa cgatgtcgct
+    53161 gggcgctttg tcgcccccga cgagcagacc gccgactggt acgccttcca ccatcagctc
+    53221 agccgggagg cggtgctcgc ccagcttgac caggacgccc atgcgcgact cgcagacatg
+    53281 ttggcgtcgg cggtcgaggc gatctaccca ggacttccgc gggagtggtg cgaggtcgcc
+    53341 gcccggctac gggcggatgc cggggacccg accaccgccg ggacgctctt cacggaggtg
+    53401 gggcggcggg cgctggcact cggcgcagcc aactcggccg tcgcggtgct ggaccgggca
+    53461 ctggaataca tcccgcacga cgacgtggcg acccgcaccg gcacgttgga gttgttgctg
+    53521 caggcgctgg ccgaggcagg gctggtcgag cgggcgctcg agtcggtcag cgagttggac
+    53581 caggccggct ggctcacccc gagccggcgg gccgccctgc acgcccgact ggcctgggcc
+    53641 gcaacggtcg ctgggcgcac cttggacggg ctggcgcagg tggagaccgc ccgagcgctg
+    53701 ctgggctcgg agggctcagc cgaggatctg gcaccgatcg acatggtcgc cgcacacctg
+    53761 ctgttggacg ctggcggtcc ggaccaactc gccgccgccg agaacctcgc ccggcaggcc
+    53821 gcgaccgtag ccgaatcagt gccgctgccg gtggtggcgt gccaggcctg gcagctcgtc
+    53881 ggcggcctcg cccgccatcg ggacccgcag gaggcgacct ccgtgctgga acgggcacgc
+    53941 accctggccg tccgccacga cctgcccatc tgtgagatcc acgcgttgat ccggctgggc
+    54001 aacgacgacg cgttgctgcg cggcgacctc acccggctcc agcgcgccag cgcgcaggcg
+    54061 acccggatgg gtgcggtgac cgcccaatac caggcggagg cgagcatcgc gctgcacacc
+    54121 gtcctgcacg gcgacttcac cgcggccgcg tcgctcaccg accaggtctt cgcggcgacc
+    54181 agccggctaa atctactgga gacgacccag tacgtgctgc tgacccgcgc ggtgctcgcg
+    54241 gggcaccgag gcgaccgcaa ccagatggag tcggagctgg cgcggttcac gcagtggggt
+    54301 ggggacctga cgttacacgg gccgcgggcg cacgggctgg cggcggcgtt ctgcgccctc
+    54361 ctggaggagg atctaccgag ggcacggagc gatctggcgc gagcggtcgc cgccgaggaa
+    54421 cacgggtcga gtgtgtactt tctgtccggc cgacgtgggc tacacgtgtt gctgcgggcg
+    54481 ctcgccggcc aggcggagtg gcccgatctc gaggcggtga ccgtcaaccc ggcaagtacg
+    54541 ctgcgctggg accgccagtt cacgttcttc gcacgcgccg tcctggacgg ccggtcgggt
+    54601 caacgcggcc gcgccagccg ggctgtgacc gatgcgctgg cggcgggtga accgtatccg
+    54661 acgagccgat acctgggtct ccgcctggtc agcgaggcag cgctcaccga cggctggggc
+    54721 gagccggtga cctggctacg gagtgcggag gagcactttc accgtacggg cgtgaacgcc
+    54781 gtggccgggg cgtgccgggc cctactccgc agggccgggg caacggtgcg gcaacgccgg
+    54841 gacggtaccg cgggcattcc gaatgagctc cggtccgctg gcgtgacagc gcgggagtac
+    54901 gaggtgctgg gcctggtggt gaagcgcctg gggaaccgtg agatcgccac gcgcctgcac
+    54961 ctgtctcccc gaacagtgga gcggcacgtg catgggttga tgaccaagac tggactcccc
+    55021 aaccgaatcg cactggccaa gttcggcgcc gggttcgtcg acaacccacc ggctgcggca
+    55081 gggactgaca gcccggcccc gtccagtcac acgacaacgg attggcggtc tcggccgccg
+    55141 gcttctggta gcactacgta gacgcccggt tgatccggtc gttccgccga ccggaaccag
+    55201 tcaccaccga tggcgtcggc ggcgccgcat ctgcggccgc ctgctcgggt gagcgaagtt
+    55261 tggggcccaa ccagaacgac accccaacca acgcaccaac cagcacaaag atcccggcga
+    55321 tcgagagcgg ccggccaagt ttctgccgca atggtcgacc gcttcttcct gtggacttga
+    55381 gtcccaaatt cggggctccc ccacaaagca atcagctcga cgagccagtg tgtcaactct
+    55441 gaggttgcgg acagcgacct aaatcaggcg ttcgtcaatg caacgaatcg attcatttca
+    55501 gagctaacct cctcgtttgt gggtgaatag tgtcgacttt ctgagtcgcc gacttcaatc
+    55561 cgccagaccc tctatagctg ccgttggtca ttccaggacg ccacgtagat ggtcaccata
+    55621 aatcattgcg acgtcccgcc ctagcgagag actaactgaa tcgtaaagcg tggacgcgga
+    55681 ctcgggagta gtcagtcgga tcatcacctc gtcggcaccg ctactgccgg taatactcgt
+    55741 tatatccgcc agcggtacgg ccacgatcag ctcggaggca ccgaactcat cgcccgccgg
+    55801 ccgcacgcat tcaccagtta cgacgacctc gactaagcca ctctgcctcg acaacgcgag
+    55861 ttggtcaccc gtcgtccagc cgagcgaggc ggcgacttga tcgtccacac atgcctcgcc
+    55921 ggcgttggcg gggtaggtgc ccgataccac ctccagcgac cgcaactgtt ggtcaacagc
+    55981 ggccgtaacg accatggctt cgtgctcctt accagtgccc gcatgtcggg ccgtgacgct
+    56041 gtaggcggtg ctatttcctt ccgcggcggt aacctcggag agctcagcga tccgctgaac
+    56101 atcctccggc gcaaacgcaa ccgagctacc cacacttaca tcaacaggcc cggggagcgg
+    56161 gtgaaagcgc gttgcattcg cgtcgttccc actgccgcag gcgcccaacc cgattgtgga
+    56221 cgcggcgaat gccagcggca ggataccgcg atggaggatt aactgcgcac gtctcaccat
+    56281 ttaaggtcgg ctgccttctt agcgagatcg acagtcttat ccgcatgctc ggcaagctgt
+    56341 tcctcgtgcc gctcgtacac agtttgctgc gccgagatga ccagaggcat caggcgctcc
+    56401 ttgaactcta ggcgttgggt gcatttagac caggcaacgg ccagctcgac ctcctcctca
+    56461 gtaggaacat atttctttgc cggaattgct ggacctatct ggatagtgcc ctccttgcgc
+    56521 tccggcgacc acgcctcctc ggctattgtt tcgtgagcac cgaagcgcac tccgagcttt
+    56581 tccggatagg gttcccgggc gaaatcctcg gggtcttctg cctgaaagcc cgcctccgcg
+    56641 aggcaatctc gcagcgacgt acgcagctcg gacaactgag gacctattag cctttcgtat
+    56701 tcctttccga attcgcccat gagcgtgttg cccagctcgc cgtaactgac ggacacctcc
+    56761 tgcgcctccg gaccgatttt cttcgaagct gccagctcac atcgctccac ctcctggtcg
+    56821 taattcgcat cgaagctcac aatgcgagca atttgggctg gagcgtcttt cccgaatcct
+    56881 gaccggcgcg cctcttgctc gtcaaccgga ccaaacgttc gaaggtcgaa gcggaggtgg
+    56941 tcgaaatcgt catccggctc ctgtgccatg tgggtcaggt tctgcggata gccggcctcg
+    57001 gcgaggcact cgtttcgcag tttacggatc gagtggcgaa gaatgccaag ctcttcacct
+    57061 cgcaaagcgt cgaacggttg agcggtagag gcatcagagt cggctgacgc cgcattgtcg
+    57121 gtcgacgccc ggtcgtcgaa tgagcaaccg gcgatgaggc cggctacaag cagcgctgca
+    57181 gagctcactc ggagtagagg cgccggaaaa gtctgtctca ttgctgcagt tcaccttgca
+    57241 ttctggcttg ttgccttatg ctgagacgcg gaagataatt acggatgata ctagagacag
+    57301 cgtagtagcc agcttagcga ctggcaaata gctagccgcc ttagtcaagt ctggccgcaa
+    57361 cacgtccttg tatggcgccg gcccagcttc cggcttctga cctgcgttct gagggacttc
+    57421 tccggcgacc gagaggagcg ttgatgattt cctgtagtcg tagttgcatt ggaccatgcc
+    57481 gccaggacgg ggcggtttca gccgatggaa gtcagtcgaa acgcccagta tatccatggc
+    57541 ccggatccgg atccggatcc ggatccagca aggcgtaccc gcagcggcgc gcatgacgca
+    57601 ttcgatgatc gctatgccaa ctttatgatc aactacctcc caggtcaccg agcgctagtc
+    57661 cgtcacccgg gatcccagcc tgtgggtacc tgtgggtacc tgtggtggca acagcggcag
+    57721 caactgcgcc ttactgccga atagctccgc ctggacatgt tcccgggcca cggagaaaac
+    57781 agctggactc taggcagttc ggcgaacaag ccgagaccta catctggagc cgtggtggac
+    57841 gacggccgag atcccagttt ccgtcccagt tctttttaaa acaaatttcg ccgacactgc
+    57901 aggctaggag cccgtcgcct tcgtcagcgg cggctggcga cgatggcacc gcaactgcag
+    57961 cagctcccgc caggccaatc acggccgccg tccggattgc gcgcttgaag atttggccgc
+    58021 aacttccgac attttcataa tcctctttcg cctggtccag agacgcggat gactctggca
+    58081 ctacagcact taacgcacca ctcgtagcgc attgctcgaa tgtggaccga tcgtacatga
+    58141 tctgccgcca gttcggtgtc ccgcgacgct gcgcttcggg ttgctgcagg tcacggtgac
+    58201 ttcgaggtcg ccgatcgcat cgagaagctc ggggattcgg gatgaaggcc cgagagatgt
+    58261 acttgtgctt accccaacgc ctacgtacgg tcacacaaca acggattggc ggtctcggcc
+    58321 gccggcttct ggtagcacga cgtagacgcc cggttgatcc ggtcgttccg ccgaccggaa
+    58381 ccaaatttcc gccgcccgct cgggcggcca gatggtggcc caatcccacc gcgcccccgc
+    58441 aagtttcgtg ctggtgagaa cggcaccgta gaggttggcc tcacagaggt tgaccccggt
+    58501 gaggttggcg cggtcgaggt tggcctcacg gagatcggcg ctggtgaggt cgacgccggt
+    58561 gagattgact ccgcgaaggt cgatgccggc aaggttcgcg ccggcaagat ccacaccggt
+    58621 taggtcggca ccgatgagaa gcgcgccggt gagatcggcc cgcgtgaggt cggccgccgt
+    58681 caggttggca gcggtcaact cgacaccagc gaggtcgacg ccggcaaggt caacaccacg
+    58741 gaggttggcg gcggtcaggt cgacgccagc gagattggca ccggcgaggt tggcaccgat
+    58801 gagaagcgcg ccggtgaggt tgacgtcggt gaggtccgcg ccacgcaggt caacaccggc
+    58861 gaggttcgcg ccagtgaggt cgacgtcggt gaggtccgcg ccacgcaggt caacaccggc
+    58921 gaggttggca ccggtgaggt cgactccggc gaagttggcg cgggccaggt tgactccgac
+    58981 gagatcgacc tcgcgaagat ccctgttgtt gagctccgca ccagccaagt cgttcatgcg
+    59041 ggaatcgcca atgcgcgagg cgtcctgacg gagatcggcg ttgggcaggc taccgcgttg
+    59101 cgggctggcg aaggctgggg tacgtcggct caacgcagca atgaggtgtc ttaaccggcc
+    59161 aggtcgggct gctcgtggtg agtgaaaggc gggggtggaa cgaccgagcg cgagcacgag
+    59221 ttgacggcgg aaagagtcag tcgacatcgg aagaatccgc atctcctgag gccagcttct
+    59281 ggtccgttgc cagcgggggt ggcacggaac ggctgagggg taatgtcgag tggtggtgcg
+    59341 gtgtgtccac ctcggtcgat gccaggtcaa cctggcgcag aactttttcg atcagtagcg
+    59401 gtgcggtgat gccgagaagc ccggcggcta aggggctggc caggcgcccg tccgcgccga
+    59461 tgagggcggc cagtcccgcg ccggcggcga gccgaagcac gactgaggcc aggtaagcgg
+    59521 ggagccctgg ctcgtcgggg cgtttccagg gcagggtttt cgcacgtcgc aacgcagcgc
+    59581 cgagttcgag tgcttccacg atgaagctac ctagcagccc ccagagggcc gactccatag
+    59641 tggaaagggg ctcgaacggc ataggcgcac aatagccgcc cccttccttc tgccaccggt
+    59701 tggccaccgg tggaccgcca gcccgccagc agctacggga gaacgtcgaa gacggcgaaa
+    59761 tcttagaacc cggaccgagg tcgaatcaat atcagaacta tgaaggtggt aaataatcac
+    59821 accgccatgc ggtacacgat gttcacgtga acgttcgatt tgttgccatc cacccacaac
+    59881 aggccagtga gtcatcgtcg gaagcgcaaa atctgagatt ttgcctaaaa cccatcaaac
+    59941 catccagtat gggcactccc agtgttcagc accgcccgat cccgcctgtg cgcgagtcag
+    60001 ttgacggcca ggtcgcgcgg ctgacgactc acgccaccct ccggtgccga actgccgttc
+    60061 gtgctcgccg ccgcgtcggt gacagtggcg gccggaggct ggtcctggtc cccacgtcgc
+    60121 tgccgagctc gtcggggcta tcgggagcgc tcgtcacggt gccccgcctg acctcacggt
+    60181 cgggcggggc accgttgttg tggcaggcgc cggcgggacg gccccggtgg ctgcaccctt
+    60241 ggcggccacc ggggtcccgt ttcgactcag ctgcactgtg aagtcttcaa accccccggc
+    60301 aacgtttcca ggacttcaac gcggaagtta gccccagcct tcaccgtgta ggtcccggta
+    60361 ccctggaagt ccaacctttt ggtggaggag ttcagcgaga atcccgtggg aagctggccg
+    60421 ccacggtctt ccgcccgaga cagggtgtca tagatattga gcaccggcgg aagcggaccg
+    60481 ttcagactct tggccgtaaa gccgccagtg aaattggcat tcagcgccaa ctcgccagtg
+    60541 taggtggatt gcgtcagcga cgacacgacg taccgggttg tttgtgcggg caccagcaca
+    60601 cgctgagacg gcgcggtgtg cgtctccttg atcgactccg actgggtttc cgaatcttgg
+    60661 tacgacaccg tcactgactc ttcgaggccg agaccgacca ctttcgaaag ggagaaggta
+    60721 cccgaaacct tcgaggttga cgacacacca gtggtgacgg tcgtcgacac cgtgtttgtg
+    60781 aaggccttac tgaacgagtg gctccacagg gtctgatccg aacttgtgga gttcgtcaaa
+    60841 ctcgcgcacc ccaggtagaa cggggcactc gacaccacct tcgccgaacc caccggaacc
+    60901 gcatccgatt ccgtaatcag gatcggggtg gcggtaacct caaaaccaaa aggagggtag
+    60961 gcgtgactcg acatatcttc gagcagcgtg gtgatgtcgg tgatcgtcgc tgcctgtgcg
+    61021 ggcgaggcgg tcatcaacac cgccgccgcg gtgccgatcg acatcgccag gagcgctcgc
+    61081 gtcctcttta acctcatacc attcctcttc cgacttggcg gctacccggt aggcaatatc
+    61141 cagattgctg gcccgcggcg tgcttcatga cacgactagg ccacccaatc actttccctt
+    61201 ccgcacaccc ggtcgatccg accgagcgcc ggtgttgacg tagacgaatc atacacatga
+    61261 ttgggcccca agcaatcctg gcgacaccaa gcgccttacc gcaccgctag aagccagctc
+    61321 tgacctcggc ttttagcaaa aaaatacaac ttgtccgctg cttcacagat gctttatgtc
+    61381 acctactcct cttaccgatt cgttaccaag tttatgtatt cgataaacta gtaactggga
+    61441 ctcggccgaa tgcgccaccg caacagcggg caatgagatg gtcacgcaat ccgtcagcgc
+    61501 agtggggcgt gtgcggcgtc gccccgctca gccggcgaag gtggcggtgt tgacagtgga
+    61561 gcggcgctat cgcccaaggg gcgaccaccc cagctcctcc cgaccgtgcg acgccagccg
+    61621 ccggcacgcc cggtcatgcg tcgactgacc acggccgccg gccgttcgat gtcgagcacc
+    61681 agacgtcgtc caccggggac gacaccgcgc atccaccttc gctggtcatg gcgagcgatc
+    61741 gccgtcgaga ggacgtgctc cagcccgagt agccgtcgga caatagccag cccggttcgc
+    61801 cctgcggctc agggcttccg gagccatgtc ttcggatcgg tcacgaagac gcccttgccc
+    61861 tggtgacggt tgatcacctc cagcgcctcc agtcgcacgt tgacgagctg gatcgtggac
+    61921 gggcttacgt ggtaccgctc gcagagctga gcgattgagg gcagcttgtc ccccgctttg
+    61981 tatcggcccg acctgatgtc atcaatgatc tcatcggaga tccggatata gtccggtgtc
+    62041 gctggcatgt cactcctcgc gtggcacctc cgattcgatc acgagaaaga caaggacgac
+    62101 aagttcaagg tgttccttgc ctaccttggc ttccttgtat aagttgagcg gcaggtcctc
+    62161 atcgcgtggc aacgagtagg gccgatcccc cgggcggggt gggctgggca tggctcaccc
+    62221 cggcccgtcc gatccggaga ggtggttgac gtgcgtaacc cgttccgacg ctttcgtcac
+    62281 tggcgaggcc gccctgcccc gagccacccc actgctcgca ccggctcgct gatcggtgcg
+    62341 aacataggcc gccccgccgg caccgacagc gatgcggacc gccaccggtc gttcgccggc
+    62401 aacgcgggcg ggcaccaccg gtcggcgaca cgctggccgt tgacccccga tcaggtacgc
+    62461 cagcggcagt tcccacgggt ccgacgggga ctcgacgcct ccgaggtgga actcttcctc
+    62521 tatcgggtcg cagcggacct gtccgcgctg cagaccgagc tgaggagcac ccgggacgag
+    62581 aacatccgga tcaagcgggc gctgcgcgac tggcagtccc ggaccacccc cggcgtacgg
+    62641 gcatgaccgt gaccggcctc gacgagagac cacgtttcgt cgtccatttg accctgcacg
+    62701 ccgacgacct cgccggcgcg cgcctgctcg cccgctcggt ggcccgctcc ctgggcttcc
+    62761 tgcccgagct ggcccaacgt cggccacgcc cgacgcgacc agacgactgc ggcccgcaac
+    62821 cggaggtagc gggccgcagt ccgacagcgc gtggtgtcag tcgacgacga ccgggacgat
+    62881 cgcctcgttg acgccccggc tggcggtgat gacgaggtcg ccgttgccgt gccgggacag
+    62941 cgcacgcagt cgccacgtgc ccggcgccgc gaagaagcgg aactgcccgg ccgacgaggt
+    63001 gaccacctcg gcggtgaact cgtcggtgga gtcgagcaga cggacgtacg caccggtcac
+    63061 cggctcaccc gcggcgtcac ggacaacacc ggtgatgacg gtctccttct ccaggtcgag
+    63121 gctggccggc agcggggcgg cctgatccgg ggcggcgcaa ccggccgcgg tcgaagcagt
+    63181 cacgacgttc actccttccc cggctcgtcg ccgagcgcca ccggcacacc gacaagtgag
+    63241 ccgtactcgg tccaggagcc gtcgtagttc ttcacgttct ggtggccgag cagctcctgg
+    63301 agcacgaacc aggtgtgcga ggagcgctca ccgatccggc agtaggcgat cgtctcccgg
+    63361 ctgtcgtcca gcccggccgc ggcgtagatc tcgcgtagct cctggtcgga cttgaaagtg
+    63421 ccgtcctcgt tggccgcctt ggaccacggc acgctgagcg cggtgggcac gtggcccgcg
+    63481 cgctgcgcct gctcctgcgg taggtgggcg ggggcgagca ggcggcccgc gtactcgtcg
+    63541 gggctgcgga cgtcgaccag gttcttcgtg ccaatagcgg cgaccacctc gtcgcggaac
+    63601 gcccggatgg tgtggtccgg ctcctgcgcc acgtaccgag tcgccggacg ggacaccagc
+    63661 tcggtggtca gcgggcgggc gtccagctcc cacttcttgc gaccgccgtc gagcagccgg
+    63721 acctcacggt ggccgtagag cgcgaagtac cagtacgcgt acgcggcgaa ccagttgttg
+    63781 ttgccgccat agaggacgac ggtgtcgtcg ttggcgatgc cccgctcgga gagcagcgcc
+    63841 gcgaactggt ccttgttcac aaagtcccgg cggacctggt cctgaaggtc ggtcctccag
+    63901 tcgagcttga tcgcgccggg caggtggccg gtgtcgtagg ccgaggtgtc ctcgtcaacc
+    63961 tcgacgaaga cgacacccgg ggtttcgagg ttcttctcgg cccagtcggc cgagacgagt
+    64021 gcggtgtcac gactcatcag atcactcctg gtgaggatgg gatggtgagc cagcgcgcgg
+    64081 gagtcatggt gtgtcagtgg tccaccacgc gcgggaccca tggctcggat cggatcacgg
+    64141 gttcgtgcga cggcgccgct ggttggcgca ggagggggca ccagtaaggt gcgcagaccc
+    64201 tgggcgctgg gaggccgcgt caggcggccg agaacagccc cgccgtcaac tggacggggc
+    64261 aacacaggca ggtggccaca cggcacaggt cgaccgcgcg ccgcttggtg aggaacatcc
+    64321 ccatgggcag ggagactacc agcgatgtcg ccgccggcca cggctcaacc agcatccggg
+    64381 acgcgtactc gactcagctc gccgcgtgaa gcggcacctc ggccgcctcc gcggtgacct
+    64441 ggagcccttc gggtagtggc cggacctcgc tgacggtgag gtcgaacggg agcaccggca
+    64501 gtggcacgtc tacggagatg ccctcggcga agctactcag gagcgcccgg accagcgacc
+    64561 cgttcggcac cccatcgggg gtcaggtcgg tgaaccgcag cgacacctga ccctggtcga
+    64621 ccgtgatgtc ggcggtgccg ctgaccggca cccgctcccc gaggagctcc accggagcgg
+    64681 tcaccacgag ttggccgtcc cgctccccca gctgcagccc ctcccggtcg agccgggccg
+    64741 cgatgctgtc gtagctgatg gtgccggtgc cggtgacgct cccggcgatc accccgcccc
+    64801 gtccggagcg aagggtgtcc agcggggcgg tcacgtcgta ggcgtcgatg tcgagggttg
+    64861 gcagggccag cacgtcgccc tggactgatc cccggacctc gttgagcccg atggagatgc
+    64921 gctcgtagcg gccgtcgagg acctgggtga cgaaggggaa gccgccgatc tcgacctcgg
+    64981 gcggcccagc ctgaacgcct tccttggcga gttcctcgcg tacctggtcg gtcagggcgc
+    65041 gttcggccac ccccgccgcc acccggtcgg ccaccaccaa cagcccgacc aggaccagaa
+    65101 gcaggaccag gagcacgacg agtatccgcc gcccgcgctg ccgccggggg cgttcgtcct
+    65161 gctgcgggcg ctcctcggtc gtcacagctc ctcctggcac cactgttgct cctgtcgccg
+    65221 ccgtcgctgc ggcgaggtta cccgggcgat ggcgctccga ccgctcagag aaccagcttg
+    65281 cacagggcgt acgcggccgg cgcggcgagg gcgaggccgg tgagcggacc ttggatgtgc
+    65341 tggatcgccc acccggctgt cggctcgccg gccatttccc gacccgcctc cgcgaaccca
+    65401 acggcgaggt cggccaggac ggcgacgacc gccgcgacca gtcctatgat cgcggcccgg
+    65461 gtcggggtga acggggtgac gaggtagctg cccaggagcg cgctgaccat ggtgccgatc
+    65521 atggcgccgc cgaccacacc ggccgcgccc cgcggcacct ggggggccag ccggggccag
+    65581 gcggcgaacg cgtcggtgat tcgggctacg gcgagcgcga ccccggccgc ggccaggcag
+    65641 accgtgatga cctgggtgcc catcgggatc cgggtcagca cgatcatggt ggggaaggcg
+    65701 acaaccccgg cgacgatgag cacggtgccg cgcaacgatt cgaggacctg cgcccggtcg
+    65761 acccgccgga cgaactgccc cacgaccgca gcaaccaggc cgaccagcag gacctgcacc
+    65821 agcggcatca gccgggccgg atcactccgg acggcgacgg tgtcggcgac gatcgcggcg
+    65881 acggcaccca ccccggccac cgtcatcagc gccggtgggc gaaacgccat cgtccaggtc
+    65941 agcaccgaga gcgcctggac accgaagatg acagcggtga aaggtagccg gtgcccgggg
+    66001 ccgctggtct gcgccgccag caccagcccc atcccgagca gcaccgcgaa gccggcgacg
+    66061 gccagcgcga gggttcggcg cacctcgacc ggcgggacct cctccacgtc ctggtcatgg
+    66121 ccgtcgccgg ggtcacccgc gggccgacgg cctgactccc cgtcccgccg ggctcggcgt
+    66181 gggccaccgc gctccgaccg cccatcgtcg cccccggccc gcggtgcggg cggaccgctg
+    66241 gacggctgtt cgggccaggg ctcacggccg gtctcgggcc tgctggaggg aagcacccac
+    66301 cgatcgtgcc agaccgcgtg gcaccgcggg cggcatggtt tcggtgacgt taaaacctac
+    66361 cccccagtca tgggcataac agacgaaacg gatttgcgct gcaggttgac gcagggcgat
+    66421 cggttaggct caacctgttt acccgcccgt cagtgacgcc gggaccacgc agtaccccag
+    66481 cgccctcagt gcggagcgcg cgctggtcac gcgcggccac cgcgccgccg ggacggaggt
+    66541 gatcgtggag atcctgcttc tggtgacggc acgcgcaggt gaaccatccg ctgtgctgcc
+    66601 cgcgctcgac ttactacccc actcggtccg caccgcccca cgcgacgtac gtacgctggt
+    66661 cgccggcccc agcccggacg tggtcgtgat cgacgcccgt tccgagctga gcgagg
+//

--- a/tests/unit/genomics/test_antismash_loader.py
+++ b/tests/unit/genomics/test_antismash_loader.py
@@ -54,6 +54,9 @@ class TestAntismashBGCLoader:
         assert bgc_files["NZ_AZWB01000005.region001"] == str(
             data_dir / "GCF_000514515.1" / "NZ_AZWB01000005.region001.gbk"
         )
+        data_dir = DATA_DIR / "antismash_duplicated_bgc_ids"
+        with pytest.raises(ValueError, match="Duplicated BGC gbk file name"):
+            AntismashBGCLoader._parse_data_dir(str(data_dir))
 
     def test_get_bgcs(self, loader):
         bgcs = loader.get_bgcs()


### PR DESCRIPTION
Addresses the issue of duplicated BGC gbk file names causing unexpected downstream behavior, as reported in issue
https://github.com/NPLinker/nplinker/issues/332

Adds validation logic within the AntismashBGCLoader to ensure that all antismash region `.gbk` file names are unique across all subdirectories, raising an `ValueError` when duplicate file names are detected