### PR TITLE
Enhance run_bigscape for BiG-SCAPE v2 compatibility

### DIFF
--- a/bin/install-nplinker-deps
+++ b/bin/install-nplinker-deps
@@ -150,7 +150,7 @@ echo "🔥 Start installing BigScape ..."
     git config --add advice.detachedHead false
     git fetch --tags
     git checkout v2.0.2 # Feb 3, 2026
-    pip install -q click sqlalchemy "pyhmmer>=0.12.0" tqdm matplotlib requests sortedcontainers pyyaml importlib-metadata
+    pip install -q click sqlalchemy "pyhmmer>=0.12.0" tqdm matplotlib requests sortedcontainers pyyaml importlib-metadata importlib-resources
     pip install -q .
     cd ..
 

--- a/bin/install-nplinker-deps
+++ b/bin/install-nplinker-deps
@@ -142,15 +142,16 @@ echo "🔥 Start installing BigScape ..."
     chmod 664 domains_color_file.tsv
     chmod 775 Annotated_MIBiG_reference
     ln -sf $LIB_PATH/BiG-SCAPE/bigscape.py $PY_PATH/bin
+    # Patch ArrowerSVG.py for Biopython compatibility (feature.strand -> feature.location.strand)
+    sed -i.bak 's/feature\.strand/feature.location.strand/g' ArrowerSVG.py && rm -f ArrowerSVG.py.bak
     cd ..
-    # blob size limit to remove large files left in history
-    [[ -d BiG-SCAPE-v2 ]] || git clone -b dev --filter=blob:limit=10m https://github.com/medema-group/BiG-SCAPE.git BiG-SCAPE-v2
+    [[ -d BiG-SCAPE-v2 ]] || git clone https://github.com/medema-group/BiG-SCAPE.git BiG-SCAPE-v2
     cd BiG-SCAPE-v2
-    git config --ad advice.detatchedHead false
-    git checkout v2.0.0-beta.5 # feb 12, 2025
-    pip install click sqlalchemy pyhmmer tqdm matplotlib requests
-    chmod 754 bigscape.py
-    ln -sf $LIB_PATH/BiG-SCAPE-v2/bigscape.py $PY_PATH/bin/bigscape-v2.py
+    git config --add advice.detachedHead false
+    git fetch --tags
+    git checkout v2.0.2 # Feb 3, 2026
+    pip install -q click sqlalchemy "pyhmmer>=0.12.0" tqdm matplotlib requests sortedcontainers pyyaml importlib-metadata
+    pip install -q .
     cd ..
 
 

--- a/bin/install-nplinker-deps
+++ b/bin/install-nplinker-deps
@@ -150,7 +150,7 @@ echo "🔥 Start installing BigScape ..."
     git config --add advice.detachedHead false
     git fetch --tags
     git checkout v2.0.2 # Feb 3, 2026
-    pip install -q click sqlalchemy "pyhmmer>=0.12.0" tqdm matplotlib requests sortedcontainers pyyaml importlib-metadata importlib-resources
+    pip install -q click sqlalchemy "pyhmmer>=0.12.0" tqdm matplotlib requests sortedcontainers pyyaml importlib-metadata importlib-resources scikit-learn
     pip install -q .
     cd ..
 

--- a/src/nplinker/arranger.py
+++ b/src/nplinker/arranger.py
@@ -335,8 +335,7 @@ class DatasetArranger:
         elif version == "2":
             # BiG-SCAPE v2 names the DB as <output_dir_name>.db
             bigscape_db = (
-                self.bigscape_running_output_dir
-                / f"{self.bigscape_running_output_dir.name}.db"
+                self.bigscape_running_output_dir / f"{self.bigscape_running_output_dir.name}.db"
             )
             shutil.copy(bigscape_db, self.bigscape_dir / "data_sqlite.db")
         else:

--- a/src/nplinker/arranger.py
+++ b/src/nplinker/arranger.py
@@ -333,10 +333,12 @@ class DatasetArranger:
             ):
                 shutil.copy(f, self.bigscape_dir)
         elif version == "2":
-            shutil.copy(
-                self.bigscape_running_output_dir / "data_sqlite.db",
-                self.bigscape_dir,
+            # BiG-SCAPE v2 names the DB as <output_dir_name>.db
+            bigscape_db = (
+                self.bigscape_running_output_dir
+                / f"{self.bigscape_running_output_dir.name}.db"
             )
+            shutil.copy(bigscape_db, self.bigscape_dir / "data_sqlite.db")
         else:
             raise ValueError(f"Invalid BiG-SCAPE version: {version}")
 

--- a/src/nplinker/genomics/bigscape/runbigscape.py
+++ b/src/nplinker/genomics/bigscape/runbigscape.py
@@ -109,7 +109,13 @@ def run_bigscape(
 
     # append the user supplied params, if any
     if len(extra_params) > 0:
-        args.extend(extra_params.split(" "))
+        params = extra_params.split(" ")
+        # BiG-SCAPE v2 uses Click which requires hyphens in option names,
+        # while v1 used argparse which accepted both. Convert underscores
+        # to hyphens in option names for v2 compatibility.
+        if version == "2":
+            params = [p.replace("_", "-") if p.startswith("-") else p for p in params]
+        args.extend(params)
 
     logger.info(f"BiG-SCAPE command: {args}")
     result = subprocess.run(args, stdout=sys.stdout, stderr=sys.stderr)

--- a/src/nplinker/genomics/bigscape/runbigscape.py
+++ b/src/nplinker/genomics/bigscape/runbigscape.py
@@ -68,7 +68,7 @@ def run_bigscape(
     if version == "1":
         bigscape_py_path = "bigscape.py"
     elif version == "2":
-        bigscape_py_path = "bigscape-v2.py"
+        bigscape_py_path = "bigscape"
     else:
         raise ValueError("Invalid BiG-SCAPE version number. Expected: '1' or '2'.")
 

--- a/tests/unit/genomics/test_runbigscape.py
+++ b/tests/unit/genomics/test_runbigscape.py
@@ -1,6 +1,8 @@
 import os
+import subprocess
 import pytest
 from nplinker.genomics import bigscape
+from nplinker.genomics.bigscape import runbigscape
 from .. import DATA_DIR
 
 
@@ -68,3 +70,49 @@ def test_bad_parameters(tmp_path, version):
         )
 
     assert "BiG-SCAPE" in e.value.args[0]
+
+
+def test_v2_converts_underscores_to_hyphens(tmp_path, monkeypatch):
+    """Test that underscores in option names are converted to hyphens for BiG-SCAPE v2."""
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return subprocess.CompletedProcess(args, returncode=0)
+
+    monkeypatch.setattr(runbigscape.subprocess, "run", fake_run)
+
+    bigscape.run_bigscape(
+        antismash_path=tmp_path,
+        output_path=tmp_path,
+        extra_params="--mibig_version 3.1 --include_singletons --gcf_cutoffs 0.30",
+        version="2",
+    )
+
+    # Second call is the actual BiG-SCAPE run (first is the -h check)
+    actual_args = calls[1]
+    assert "--mibig-version" in actual_args
+    assert "--include-singletons" in actual_args
+    assert "--gcf-cutoffs" in actual_args
+    assert "--mibig_version" not in actual_args
+
+
+def test_v1_preserves_underscores(tmp_path, monkeypatch):
+    """Test that underscores in option names are preserved for BiG-SCAPE v1."""
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return subprocess.CompletedProcess(args, returncode=0)
+
+    monkeypatch.setattr(runbigscape.subprocess, "run", fake_run)
+
+    bigscape.run_bigscape(
+        antismash_path=tmp_path,
+        output_path=tmp_path,
+        extra_params="--mibig_version 3.1",
+        version="1",
+    )
+
+    actual_args = calls[1]
+    assert "--mibig_version" in actual_args


### PR DESCRIPTION
**BiG-SCAPE v2 compatibility improvements:**

* Updated BiG-SCAPE v2 from v2.0.0.beta5 to v2.0.2
* Updated the executable name for BiG-SCAPE v2 from `bigscape-v2.py` to `bigscape` in `run_bigscape.py` to match the new release convention.
* Added logic to convert underscores to hyphens in command-line option names for BiG-SCAPE v2, as required by its Click-based CLI, while preserving underscores for v1 (argparse-based).

**Output file handling:**

* Modified `_run_bigscape` in `arranger.py` to correctly locate and copy the BiG-SCAPE v2 output database, which is now named after the output directory, ensuring consistent downstream file usage.